### PR TITLE
Set up GitHub Pages deployment with data snapshot

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,42 @@
+name: Build and Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Generate static site
+        run: python scripts/build_site.py
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>NBA Active Franchises Snapshot</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+    body {
+      margin: 2rem auto;
+      max-width: 900px;
+      line-height: 1.6;
+      padding: 0 1rem;
+    }
+    header {
+      text-align: center;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1.5rem;
+    }
+    th, td {
+      border: 1px solid rgba(0,0,0,0.2);
+      padding: 0.5rem;
+      text-align: left;
+    }
+    th {
+      background: rgba(0,0,0,0.05);
+    }
+    caption {
+      caption-side: bottom;
+      font-size: 0.9rem;
+      color: rgba(0,0,0,0.7);
+      margin-top: 0.75rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>NBA Active Franchises Snapshot</h1>
+    <p>This lightweight page is generated automatically from <code>TeamHistories.csv</code> in this repository.</p>
+    <p><strong>70</strong> franchises are marked as active in the dataset.</p>
+    <p class="timestamp">Last generated: 2025-09-27 14:00 UTC</p>
+  </header>
+  <main>
+    <section>
+      <h2>Current franchise eras</h2>
+      <p>The table lists each active franchise along with the city, nickname, historical abbreviation, and the first season in the current era.</p>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">City</th>
+            <th scope="col">Nickname</th>
+            <th scope="col">Abbrev.</th>
+            <th scope="col">Season Founded</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Istanbul</td><td>Fenerbahce</td><td>FEN</td><td>1913</td></tr>
+          <tr><td>Rio de Janeiro</td><td>Flamengo</td><td>FLA</td><td>1919</td></tr>
+          <tr><td>Athens</td><td>Panathinaikos</td><td>PAN</td><td>1919</td></tr>
+          <tr><td>Moscow</td><td>CSKA</td><td>MOS</td><td>1923</td></tr>
+          <tr><td>Barcelona</td><td>FC Barcelona Regal</td><td>FCB</td><td>1926</td></tr>
+          <tr><td>Madrid</td><td>Baloncesto (Real Madrid)</td><td>RMD</td><td>1931</td></tr>
+          <tr><td>Athens</td><td>Olympiacos</td><td>OLP</td><td>1931</td></tr>
+          <tr><td>Madrid</td><td>Real Madrid</td><td>RMA</td><td>1931</td></tr>
+          <tr><td>Madrid</td><td>Real Madrid</td><td>RMD</td><td>1931</td></tr>
+          <tr><td>Siena</td><td>Montepaschi Siena</td><td>MPS</td><td>1934</td></tr>
+          <tr><td>Buenos Aires</td><td>San Lorenzo</td><td>SLA</td><td>1936</td></tr>
+          <tr><td>China</td><td>Team China</td><td>CHN</td><td>1936</td></tr>
+          <tr><td>Kaunas</td><td>Zalgiris</td><td>ZAK</td><td>1944</td></tr>
+          <tr><td>Belgrade</td><td>Partizan</td><td>PAR</td><td>1945</td></tr>
+          <tr><td>Lyon-Villeurbanne</td><td>Adecco ASVEL</td><td>LYV</td><td>1948</td></tr>
+          <tr><td>Boston</td><td>Celtics</td><td>BOS</td><td>1949</td></tr>
+          <tr><td>New York</td><td>Knicks</td><td>NYK</td><td>1949</td></tr>
+          <tr><td>East</td><td>NBA All-Stars</td><td>EST</td><td>1951</td></tr>
+          <tr><td>West</td><td>NBA All-Stars</td><td>WST</td><td>1951</td></tr>
+          <tr><td>Haifa</td><td>Maccabi Haifa</td><td>MAC</td><td>1953</td></tr>
+          <tr><td>Detroit</td><td>Pistons</td><td>DET</td><td>1957</td></tr>
+          <tr><td>Franca (Brazil)</td><td>SESI/Franca</td><td>FRA</td><td>1959</td></tr>
+          <tr><td>Los Angeles</td><td>Lakers</td><td>LAL</td><td>1960</td></tr>
+          <tr><td>Philadelphia</td><td>76ers</td><td>PHI</td><td>1963</td></tr>
+          <tr><td>Chicago</td><td>Bulls</td><td>CHI</td><td>1966</td></tr>
+          <tr><td>Milwaukee</td><td>Bucks</td><td>MIL</td><td>1968</td></tr>
+          <tr><td>Atlanta</td><td>Hawks</td><td>ATL</td><td>1968</td></tr>
+          <tr><td>Phoenix</td><td>Suns</td><td>PHX</td><td>1968</td></tr>
+          <tr><td>Cleveland</td><td>Cavaliers</td><td>CLE</td><td>1970</td></tr>
+          <tr><td>Portland</td><td>Trail Blazers</td><td>POR</td><td>1970</td></tr>
+          <tr><td>Houston</td><td>Rockets</td><td>HOU</td><td>1971</td></tr>
+          <tr><td>Golden State</td><td>Warriors</td><td>GSW</td><td>1971</td></tr>
+          <tr><td>Istanbul</td><td>Efes Pilsen</td><td>EPT</td><td>1976</td></tr>
+          <tr><td>Denver</td><td>Nuggets</td><td>DEN</td><td>1976</td></tr>
+          <tr><td>Indiana</td><td>Pacers</td><td>IND</td><td>1976</td></tr>
+          <tr><td>San Antonio</td><td>Spurs</td><td>SAN</td><td>1976</td></tr>
+          <tr><td>Malaga</td><td>Unicaja</td><td>MAL</td><td>1977</td></tr>
+          <tr><td>Brisbane</td><td>Bullets</td><td>BNE</td><td>1979</td></tr>
+          <tr><td>Utah</td><td>Jazz</td><td>UTA</td><td>1979</td></tr>
+          <tr><td>Raanana</td><td>Maccabi Ra anana</td><td>MRA</td><td>1980</td></tr>
+          <tr><td>Dallas</td><td>Mavericks</td><td>DAL</td><td>1980</td></tr>
+          <tr><td>Adelaide</td><td>36ers</td><td>ADL</td><td>1982</td></tr>
+          <tr><td>Perth</td><td>Wildcats</td><td>PER</td><td>1982</td></tr>
+          <tr><td>Los Angeles</td><td>Clippers</td><td>LAC</td><td>1984</td></tr>
+          <tr><td>Sacramento</td><td>Kings</td><td>SAC</td><td>1985</td></tr>
+          <tr><td>Miami</td><td>Heat</td><td>MIA</td><td>1988</td></tr>
+          <tr><td>Sydney</td><td>Kings</td><td>SYD</td><td>1988</td></tr>
+          <tr><td>Orlando</td><td>Magic</td><td>ORL</td><td>1989</td></tr>
+          <tr><td>Minnesota</td><td>Timberwolves</td><td>MIN</td><td>1989</td></tr>
+          <tr><td>Berlin</td><td>ALBA Berlin</td><td>ALB</td><td>1991</td></tr>
+          <tr><td>Beijing</td><td>Ducks</td><td>BJD</td><td>1995</td></tr>
+          <tr><td>Toronto</td><td>Raptors</td><td>TOR</td><td>1995</td></tr>
+          <tr><td>Shanghai</td><td>Shanghai Sharks</td><td>SDS</td><td>1996</td></tr>
+          <tr><td>Shanghai</td><td>Sharks</td><td>SDS</td><td>1996</td></tr>
+          <tr><td>Khimki</td><td>BC Khimki</td><td>KHI</td><td>1997</td></tr>
+          <tr><td>Vilnius</td><td>Lietuvos Rytas</td><td>LRY</td><td>1997</td></tr>
+          <tr><td>Washington</td><td>Wizards</td><td>WAS</td><td>1997</td></tr>
+          <tr><td>Cairns</td><td>Taipans</td><td>CNS</td><td>1999</td></tr>
+          <tr><td>Bilbao</td><td>Bilbao Basket</td><td>UBB</td><td>2000</td></tr>
+          <tr><td>Memphis</td><td>Grizzlies</td><td>MEM</td><td>2001</td></tr>
+          <tr><td>Auckland</td><td>Breakers</td><td>NZB</td><td>2003</td></tr>
+          <tr><td>Oklahoma City</td><td>Thunder</td><td>OKC</td><td>2008</td></tr>
+          <tr><td>Guangzhou</td><td>Long-Lions</td><td>GUA</td><td>2010</td></tr>
+          <tr><td>Brooklyn</td><td>Nets</td><td>BKN</td><td>2012</td></tr>
+          <tr><td>New Orleans</td><td>Pelicans</td><td>NOP</td><td>2013</td></tr>
+          <tr><td>Charlotte</td><td>Hornets</td><td>CHA</td><td>2014</td></tr>
+          <tr><td>Melbourne</td><td>United</td><td>MEL</td><td>2014</td></tr>
+          <tr><td>All-Star</td><td>All-Star LeBron</td><td>LBN</td><td>2018</td></tr>
+          <tr><td>All-Star</td><td>Team LeBron</td><td>LBN</td><td>2018</td></tr>
+          <tr><td>All-Star</td><td>Team Giannis</td><td>GNS</td><td>2019</td></tr>
+        </tbody>
+        <caption>Data source: <code>TeamHistories.csv</code> &mdash; generated automatically on each push.</caption>
+      </table>
+    </section>
+  </main>
+  <footer>
+    <p>View the source on <a href="https://github.com/your-username/NBA">GitHub</a>.</p>
+  </footer>
+</body>
+</html>

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -1,0 +1,130 @@
+"""Generate a minimal static site for GitHub Pages using repository data."""
+from __future__ import annotations
+
+import csv
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_FILE = ROOT / "TeamHistories.csv"
+OUTPUT_DIR = ROOT / "public"
+OUTPUT_FILE = OUTPUT_DIR / "index.html"
+
+
+def load_active_franchises(path: Path) -> list[dict[str, str]]:
+    """Return active franchise records sorted by season founded then name."""
+    teams: list[dict[str, str]] = []
+    with path.open(newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            # "2100" indicates active franchises according to the data dictionary.
+            if row.get("seasonActiveTill") == "2100":
+                teams.append(row)
+
+    def sort_key(team: dict[str, str]) -> tuple[int, str]:
+        founded = team.get("seasonFounded", "")
+        try:
+            founded_year = int(founded)
+        except ValueError:
+            founded_year = 9999
+        return founded_year, team.get("teamName", "")
+
+    teams.sort(key=sort_key)
+    return teams
+
+
+def render_html(teams: list[dict[str, str]], generated_at: datetime) -> str:
+    timestamp = generated_at.strftime("%Y-%m-%d %H:%M UTC")
+    repository = os.environ.get("GITHUB_REPOSITORY", "your-username/NBA")
+    rows = "\n          ".join(
+        f"<tr><td>{team['teamCity'].strip()}</td><td>{team['teamName'].strip()}</td>"
+        f"<td>{team['teamAbbrev'].strip()}</td><td>{team['seasonFounded'].strip()}</td></tr>"
+        for team in teams
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>NBA Active Franchises Snapshot</title>
+  <style>
+    :root {{
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }}
+    body {{
+      margin: 2rem auto;
+      max-width: 900px;
+      line-height: 1.6;
+      padding: 0 1rem;
+    }}
+    header {{
+      text-align: center;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1.5rem;
+    }}
+    th, td {{
+      border: 1px solid rgba(0,0,0,0.2);
+      padding: 0.5rem;
+      text-align: left;
+    }}
+    th {{
+      background: rgba(0,0,0,0.05);
+    }}
+    caption {{
+      caption-side: bottom;
+      font-size: 0.9rem;
+      color: rgba(0,0,0,0.7);
+      margin-top: 0.75rem;
+    }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>NBA Active Franchises Snapshot</h1>
+    <p>This lightweight page is generated automatically from <code>TeamHistories.csv</code> in this repository.</p>
+    <p><strong>{len(teams)}</strong> franchises are marked as active in the dataset.</p>
+    <p class=\"timestamp\">Last generated: {timestamp}</p>
+  </header>
+  <main>
+    <section>
+      <h2>Current franchise eras</h2>
+      <p>The table lists each active franchise along with the city, nickname, historical abbreviation, and the first season in the current era.</p>
+      <table>
+        <thead>
+          <tr>
+            <th scope=\"col\">City</th>
+            <th scope=\"col\">Nickname</th>
+            <th scope=\"col\">Abbrev.</th>
+            <th scope=\"col\">Season Founded</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows}
+        </tbody>
+        <caption>Data source: <code>TeamHistories.csv</code> &mdash; generated automatically on each push.</caption>
+      </table>
+    </section>
+  </main>
+  <footer>
+    <p>View the source on <a href=\"https://github.com/{repository}\">GitHub</a>.</p>
+  </footer>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    teams = load_active_franchises(DATA_FILE)
+    html = render_html(teams, datetime.now(tz=timezone.utc))
+    OUTPUT_FILE.write_text(html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python site generator that creates a lightweight page highlighting active franchises from `TeamHistories.csv`
- check in the generated `public/index.html` so the content can be previewed locally
- configure a GitHub Actions workflow to rebuild the page on each push and publish it via GitHub Pages

## Testing
- python scripts/build_site.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ed5377cc8327b6943a069e5d69e8