### PR TITLE
Fix illegal return in player insights rendering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2099,7 +2099,6 @@
       });
       renderSeasonTripleLeaders(snapshot.tripleDoubleLeaders ?? []);
       renderSeasonTrendsChart(snapshot.seasonTrends ?? []);
-    }
 
       const tallest = snapshot.tallestPlayers ?? [];
       dom.playersTallestList.innerHTML = tallest.length > 0


### PR DESCRIPTION
## Summary
- keep the player season insight rendering logic inside its function so top-level `return` statements no longer throw a syntax error

## Testing
- manual: loaded http://127.0.0.1:8000/index.html


------
https://chatgpt.com/codex/tasks/task_e_68d80cc322d483278f846c4e821cd798