### PR TITLE
Add Basketball-Reference schedule fetcher and season-aware snapshot fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
 - **How to regenerate:** Run `node scripts/build_snapshot.mjs` from the repository root. The script parses `TeamHistories.csv`, filters for active franchise eras, and writes `public/data/active_franchises.json`.
 - **Why it matters:** Keeps the browser payload small while guaranteeing the visualization reflects the latest CSV sources.
 
-### 2024-25 schedule snapshot
+### Schedule snapshot (upcoming season)
 - **Description:** Aggregated JSON powering the league calendar insights section in `public/franchise-explorer.html`, summarizing monthly volume, team workloads, and tagged special events.
-- **How to regenerate:** Run `node scripts/build_schedule_snapshot.mjs` from the repository root. The script reads `LeagueSchedule24_25.csv` and joins against `TeamHistories.csv` to provide friendly team names.
+- **How to regenerate:**
+  1. Download the latest schedule CSV (for example `LeagueSchedule25_26.csv`) by running `python scripts/fetch_schedule_from_bref.py`. The helper reads [Basketball-Reference](https://www.basketball-reference.com/leagues/NBA_2026_games.html#schedule) and reshapes the data into the repository schema.
+  2. Run `node scripts/build_schedule_snapshot.mjs` from the repository root. The script prefers `LeagueSchedule25_26.csv` when present and falls back to `LeagueSchedule24_25.csv`, joining against `TeamHistories.csv` to provide friendly team names.
 - **Why it matters:** Allows the MVP to surface upcoming season context without shipping the full 1,400-row CSV to the browser.
 
 ### Insight snapshots (players, games, teams)
@@ -96,8 +98,10 @@
 
 ### LeagueSchedule24_25.csv
 - **Description:** 2024-25 preseason and regular-season master schedule snapshot.
-- **Row count:** 1,408 scheduled games. 
+- **Row count:** 1,408 scheduled games.
 - **Provenance:** TBD.
+
+> **Note:** Use `python scripts/fetch_schedule_from_bref.py` to generate the upcoming season schedule (e.g., `LeagueSchedule25_26.csv`) before rebuilding the snapshot.
 
 | Column | Type | Description |
 | --- | --- | --- |

--- a/public/data/season_24_25_schedule.json
+++ b/public/data/season_24_25_schedule.json
@@ -1,5 +1,11 @@
 {
-  "generatedAt": "2025-09-27T15:53:07.542Z",
+  "generatedAt": "2025-09-27T17:02:12.803Z",
+  "season": {
+    "key": "24_25",
+    "label": "2024-25",
+    "sourceCsv": "LeagueSchedule24_25.csv",
+    "outputJson": "season_24_25_schedule.json"
+  },
   "totals": {
     "games": 1408,
     "preseason": 86,

--- a/public/franchise-explorer.html
+++ b/public/franchise-explorer.html
@@ -1093,7 +1093,10 @@
         restParts.push(`${formatNumber(restSummary.backToBackIntervals)} zero-day turnarounds`);
       }
       const restSentence = restParts.length > 0 ? ` Rest outlook: ${restParts.join(', ')}.` : '';
-      dom.scheduleNote.textContent = `Schedule snapshot generated ${generatedText}. Coverage: ${coverage}. Totals include preseason, Emirates NBA Cup, play-in, and playoff rounds from LeagueSchedule24_25.csv.${restSentence}`;
+      const seasonInfo = state.schedule?.season ?? {};
+      const seasonLabel = seasonInfo.label ? ` (${seasonInfo.label})` : '';
+      const sourceCsv = seasonInfo.sourceCsv ?? 'LeagueSchedule24_25.csv';
+      dom.scheduleNote.textContent = `Schedule snapshot${seasonLabel} generated ${generatedText}. Coverage: ${coverage}. Totals include preseason, Emirates NBA Cup, play-in, and playoff rounds from ${sourceCsv}.${restSentence}`;
     }
 
     function renderScheduleChart() {
@@ -1932,31 +1935,43 @@
     }
 
     async function loadSchedule() {
-      try {
-        const schedule = await fetchJson('data/season_24_25_schedule.json', 'schedule snapshot');
-        state.schedule = schedule;
-        renderScheduleSummary();
-        renderScheduleChart();
-        renderScheduleTeams();
-        renderScheduleRest();
-        renderScheduleBackToBack();
-        renderScheduleSpecials();
-      } catch (error) {
-        console.error(error);
-        dom.scheduleNote.textContent = 'Unable to load the 2024-25 schedule snapshot. Please refresh to try again.';
-        dom.scheduleSummary.innerHTML = '';
-        dom.scheduleTeamsBody.innerHTML = '<tr><td colspan="5">Schedule data unavailable.</td></tr>';
-        dom.scheduleSpecialList.innerHTML = '<li>Schedule data unavailable.</li>';
-        dom.scheduleRestNote.textContent = 'Rest distribution unavailable.';
-        dom.scheduleBackToBackBody.innerHTML = '<tr><td colspan="4">Schedule data unavailable.</td></tr>';
-        if (scheduleChart) {
-          scheduleChart.destroy();
-          scheduleChart = null;
+      const scheduleFiles = [
+        { path: 'data/season_25_26_schedule.json', label: '2025-26' },
+        { path: 'data/season_24_25_schedule.json', label: '2024-25' },
+      ];
+
+      let lastError = null;
+      for (const file of scheduleFiles) {
+        try {
+          const schedule = await fetchJson(file.path, `${file.label} schedule snapshot`);
+          state.schedule = schedule;
+          renderScheduleSummary();
+          renderScheduleChart();
+          renderScheduleTeams();
+          renderScheduleRest();
+          renderScheduleBackToBack();
+          renderScheduleSpecials();
+          return;
+        } catch (error) {
+          console.warn(`Unable to load schedule from ${file.path}`, error);
+          lastError = error;
         }
-        if (scheduleRestChart) {
-          scheduleRestChart.destroy();
-          scheduleRestChart = null;
-        }
+      }
+
+      console.error(lastError);
+      dom.scheduleNote.textContent = 'Unable to load the latest schedule snapshot. Please refresh to try again.';
+      dom.scheduleSummary.innerHTML = '';
+      dom.scheduleTeamsBody.innerHTML = '<tr><td colspan="5">Schedule data unavailable.</td></tr>';
+      dom.scheduleSpecialList.innerHTML = '<li>Schedule data unavailable.</li>';
+      dom.scheduleRestNote.textContent = 'Rest distribution unavailable.';
+      dom.scheduleBackToBackBody.innerHTML = '<tr><td colspan="4">Schedule data unavailable.</td></tr>';
+      if (scheduleChart) {
+        scheduleChart.destroy();
+        scheduleChart = null;
+      }
+      if (scheduleRestChart) {
+        scheduleRestChart.destroy();
+        scheduleRestChart = null;
       }
     }
 

--- a/scripts/fetch_schedule_from_bref.py
+++ b/scripts/fetch_schedule_from_bref.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Download and convert the Basketball-Reference schedule into the repo CSV format."""
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+import requests
+from bs4 import BeautifulSoup, Comment
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover
+    from backports.zoneinfo import ZoneInfo  # type: ignore
+
+BREF_TEAM_TO_STATS_ID = {
+    "ATL": "1610612737",
+    "BOS": "1610612738",
+    "BRK": "1610612751",
+    "CHI": "1610612741",
+    "CHO": "1610612766",
+    "CHA": "1610612766",
+    "CLE": "1610612739",
+    "DAL": "1610612742",
+    "DEN": "1610612743",
+    "DET": "1610612765",
+    "GSW": "1610612744",
+    "HOU": "1610612745",
+    "IND": "1610612754",
+    "LAC": "1610612746",
+    "LAL": "1610612747",
+    "MEM": "1610612763",
+    "MIA": "1610612748",
+    "MIL": "1610612749",
+    "MIN": "1610612750",
+    "NOP": "1610612740",
+    "NYK": "1610612752",
+    "OKC": "1610612760",
+    "ORL": "1610612753",
+    "PHI": "1610612755",
+    "PHO": "1610612756",
+    "PHX": "1610612756",
+    "POR": "1610612757",
+    "SAC": "1610612758",
+    "SAS": "1610612759",
+    "TOR": "1610612761",
+    "UTA": "1610612762",
+    "WAS": "1610612764",
+}
+
+CSV_HEADERS = [
+    "gameId",
+    "gameDateTimeEst",
+    "gameDay",
+    "arenaCity",
+    "arenaState",
+    "arenaName",
+    "gameLabel",
+    "gameSubLabel",
+    "gameSubtype",
+    "gameSequence",
+    "seriesGameNumber",
+    "seriesText",
+    "weekNumber",
+    "hometeamId",
+    "awayteamId",
+]
+
+@dataclass
+class ScheduleRow:
+    game_id: str
+    tipoff_utc: str
+    game_day: str
+    arena_name: str
+    label: str
+    sublabel: str
+    subtype: str
+    sequence: int
+    home_id: str
+    away_id: str
+
+    def to_csv_row(self) -> list[str]:
+        return [
+            self.game_id,
+            self.tipoff_utc,
+            self.game_day,
+            "",
+            "",
+            self.arena_name,
+            self.label,
+            self.sublabel,
+            self.subtype,
+            str(self.sequence),
+            "",
+            "",
+            "",
+            self.home_id,
+            self.away_id,
+        ]
+
+
+def parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--season",
+        default="2025-26",
+        help="Season label in YYYY-YY format (default: 2025-26)",
+    )
+    parser.add_argument(
+        "--html-path",
+        type=Path,
+        help="Optional path to a local Basketball-Reference HTML schedule. When provided, the script skips network fetches.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output CSV path. Defaults to LeagueScheduleXX_YY.csv under the repo root.",
+    )
+    parser.add_argument(
+        "--url",
+        help="Override the Basketball-Reference schedule URL.",
+    )
+    return parser.parse_args(argv)
+
+
+def season_to_end_year(season_label: str) -> int:
+    parts = season_label.split("-")
+    if len(parts) != 2:
+        raise ValueError(f"Unexpected season format: {season_label}")
+    start = int(parts[0])
+    end_suffix = int(parts[1])
+    if end_suffix < 100:
+        end = (start // 100) * 100 + end_suffix
+        if end < start:
+            end += 100
+    else:
+        end = end_suffix
+    return end
+
+
+def fetch_html(url: str) -> str:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.text
+
+
+def extract_schedule_table(html: str) -> BeautifulSoup:
+    soup = BeautifulSoup(html, "html.parser")
+    for comment in soup.find_all(string=lambda text: isinstance(text, Comment)):
+        if "<table" in comment and "id=\"schedule\"" in comment:
+            return BeautifulSoup(comment, "html.parser")
+    table = soup.find("table", id="schedule")
+    if table:
+        return table
+    raise RuntimeError("Unable to locate schedule table in source HTML")
+
+
+def parse_time(date: dt.date, time_text: str) -> dt.datetime:
+    if not time_text or time_text.strip().lower() in {"tbd", "na", ""}:
+        naive = dt.datetime.combine(date, dt.time(0, 0))
+        eastern = naive.replace(tzinfo=ZoneInfo("America/New_York"))
+        return eastern.astimezone(ZoneInfo("UTC"))
+
+    time_text = time_text.strip().lower().replace(" ", "")
+    if time_text.endswith("a"):
+        time_text = f"{time_text[:-1]}am"
+    elif time_text.endswith("p"):
+        time_text = f"{time_text[:-1]}pm"
+    try:
+        tip_local = dt.datetime.strptime(time_text, "%I:%M%p")
+    except ValueError:
+        try:
+            tip_local = dt.datetime.strptime(time_text, "%I%p")
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Unable to parse tip-off time '{time_text}'") from exc
+    tip_datetime = dt.datetime.combine(date, tip_local.time())
+    eastern = tip_datetime.replace(tzinfo=ZoneInfo("America/New_York"))
+    return eastern.astimezone(ZoneInfo("UTC"))
+
+
+def infer_label(game_type: str, notes: str, date_value: dt.date) -> str:
+    normalized_type = (game_type or "").strip().lower()
+    normalized_notes = (notes or "").strip().lower()
+    if normalized_type:
+        if "preseason" in normalized_type:
+            return "Preseason"
+        if "cup" in normalized_type:
+            return "In-Season Tournament"
+        if "play-in" in normalized_type:
+            return "Play-In"
+        if "playoff" in normalized_type or "final" in normalized_type:
+            return "Playoffs"
+        if "regular" in normalized_type:
+            return "Regular Season"
+    if "preseason" in normalized_notes:
+        return "Preseason"
+    if date_value.month < 10:
+        return "Preseason"
+    return "Regular Season"
+
+
+def parse_schedule_rows(table: BeautifulSoup) -> list[ScheduleRow]:
+    body = table.find("tbody") or table
+    rows: list[ScheduleRow] = []
+    sequence_tracker: defaultdict[dt.date, int] = defaultdict(int)
+
+    for tr in body.find_all("tr"):
+        if "class" in tr.attrs and "thead" in tr.get("class", []):
+            continue
+        date_cell = tr.find("th", {"data-stat": "date_game"})
+        if not date_cell:
+            continue
+        csk = date_cell.get("csk")
+        if not csk:
+            continue
+        date_value = dt.datetime.strptime(csk, "%Y%m%d").date()
+        time_cell = tr.find("td", {"data-stat": "start_time"})
+        start_time = time_cell.get_text(strip=True) if time_cell else ""
+        tipoff_utc = parse_time(date_value, start_time)
+
+        visitor_cell = tr.find("td", {"data-stat": "visitor_team_name"})
+        home_cell = tr.find("td", {"data-stat": "home_team_name"})
+        if not visitor_cell or not home_cell:
+            continue
+        visitor_link = visitor_cell.find("a")
+        home_link = home_cell.find("a")
+        visitor_abbr = visitor_link["href"].split("/")[2] if visitor_link and "href" in visitor_link.attrs else visitor_cell.get_text(strip=True)[:3].upper()
+        home_abbr = home_link["href"].split("/")[2] if home_link and "href" in home_link.attrs else home_cell.get_text(strip=True)[:3].upper()
+        visitor_id = BREF_TEAM_TO_STATS_ID.get(visitor_abbr, "")
+        home_id = BREF_TEAM_TO_STATS_ID.get(home_abbr, "")
+
+        arena_cell = tr.find("td", {"data-stat": "arena_name"})
+        arena_name = arena_cell.get_text(strip=True) if arena_cell else ""
+
+        type_cell = tr.find("td", {"data-stat": "game_type"})
+        notes_cell = tr.find("td", {"data-stat": "notes"})
+        game_type = type_cell.get_text(strip=True) if type_cell else ""
+        notes = notes_cell.get_text(strip=True) if notes_cell else ""
+
+        label = infer_label(game_type, notes, date_value)
+        subtype = ""
+        if "cup" in (game_type or "").lower() or "cup" in (notes or "").lower():
+            subtype = "In-Season Tournament"
+        elif "play-in" in (game_type or "").lower() or "play-in" in (notes or "").lower():
+            subtype = "Play-In"
+        elif "playoff" in (game_type or "").lower() or "final" in (notes or "").lower():
+            subtype = "Playoffs"
+
+        box_cell = tr.find("td", {"data-stat": "box_score_text"})
+        game_id = ""
+        if box_cell:
+            link = box_cell.find("a")
+            if link and "href" in link.attrs:
+                slug = link["href"].split("/")[-1]
+                game_id = slug.replace(".html", "")
+        if not game_id:
+            game_id = f"sched-{date_value:%Y%m%d}-{visitor_abbr}-{home_abbr}"
+
+        sequence_tracker[date_value] += 1
+        sequence = sequence_tracker[date_value]
+
+        rows.append(
+            ScheduleRow(
+                game_id=game_id,
+                tipoff_utc=tipoff_utc.strftime("%Y-%m-%d %H:%M:%S+00:00"),
+                game_day=date_value.strftime("%a"),
+                arena_name=arena_name,
+                label=label,
+                sublabel=notes,
+                subtype=subtype,
+                sequence=sequence,
+                home_id=home_id,
+                away_id=visitor_id,
+            )
+        )
+
+    return rows
+
+
+def write_csv(rows: list[ScheduleRow], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(CSV_HEADERS)
+        for row in rows:
+            writer.writerow(row.to_csv_row())
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_args(argv)
+    season_end_year = season_to_end_year(args.season)
+    season_slug = args.season.replace("-", "_")
+
+    if args.output:
+        output_path = args.output
+    else:
+        output_path = Path(__file__).resolve().parent.parent / f"LeagueSchedule{season_slug}.csv"
+
+    url = args.url or f"https://www.basketball-reference.com/leagues/NBA_{season_end_year}_games.html"
+
+    if args.html_path:
+        html = args.html_path.read_text(encoding="utf-8")
+    else:
+        print(f"Fetching schedule from {url}...", file=sys.stderr)
+        html = fetch_html(url)
+
+    table = extract_schedule_table(html)
+    rows = parse_schedule_rows(table)
+    if not rows:
+        raise RuntimeError("No schedule rows parsed from Basketball-Reference HTML")
+    write_csv(rows, output_path)
+    print(f"Wrote {len(rows)} games to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/testdata/bref_schedule_sample.html
+++ b/scripts/testdata/bref_schedule_sample.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="utf-8"><title>Sample Schedule</title></head>
+  <body>
+    <!--
+    <table id="schedule" class="sortable stats_table">
+      <tbody>
+        <tr data-row="0">
+          <th scope="row" class="left " data-stat="date_game" csk="20251004">Sat, Oct 4, 2025</th>
+          <td class="right " data-stat="start_time">12:00p</td>
+          <td class="left " data-stat="visitor_team_name"><a href="/teams/BOS/2026.html">Boston Celtics</a></td>
+          <td class="right " data-stat="visitor_pts"></td>
+          <td class="left " data-stat="home_team_name"><a href="/teams/NYK/2026.html">New York Knicks</a></td>
+          <td class="right " data-stat="home_pts"></td>
+          <td class="right " data-stat="overtime"></td>
+          <td class="right " data-stat="attendance"></td>
+          <td class="left " data-stat="arena_name">Madison Square Garden</td>
+          <td class="left " data-stat="game_type">Preseason</td>
+          <td class="left " data-stat="notes"></td>
+          <td class="left " data-stat="box_score_text"><a href="/boxscores/202510040NYK.html">Preview</a></td>
+        </tr>
+        <tr data-row="1">
+          <th scope="row" class="left " data-stat="date_game" csk="20251022">Wed, Oct 22, 2025</th>
+          <td class="right " data-stat="start_time">7:30p</td>
+          <td class="left " data-stat="visitor_team_name"><a href="/teams/LAL/2026.html">Los Angeles Lakers</a></td>
+          <td class="right " data-stat="visitor_pts"></td>
+          <td class="left " data-stat="home_team_name"><a href="/teams/GSW/2026.html">Golden State Warriors</a></td>
+          <td class="right " data-stat="home_pts"></td>
+          <td class="right " data-stat="overtime"></td>
+          <td class="right " data-stat="attendance"></td>
+          <td class="left " data-stat="arena_name">Chase Center</td>
+          <td class="left " data-stat="game_type">Regular Season</td>
+          <td class="left " data-stat="notes">Opening Night</td>
+          <td class="left " data-stat="box_score_text"><a href="/boxscores/202510220GSW.html">Preview</a></td>
+        </tr>
+      </tbody>
+    </table>
+    -->
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Python helper that reshapes the Basketball-Reference schedule into the repo CSV format so the upcoming season can be refreshed quickly
- teach the schedule snapshot builder to pick the newest league schedule file, embed season metadata, and expose it to the UI
- update the franchise explorer to load whichever schedule JSON is available (2025-26 first, then 2024-25) and document the new workflow in the README

## Testing
- python scripts/fetch_schedule_from_bref.py --season 2025-26 --html-path scripts/testdata/bref_schedule_sample.html --output /tmp/sample_schedule.csv
- node scripts/build_schedule_snapshot.mjs


------
https://chatgpt.com/codex/tasks/task_e_68d80e42a1b88327901f4cfdd202c3b8