### PR TITLE
Prevent schedule loader from requesting missing season data

### DIFF
--- a/public/data/schedule_manifest.json
+++ b/public/data/schedule_manifest.json
@@ -1,0 +1,8 @@
+{
+  "seasons": [
+    {
+      "path": "data/season_24_25_schedule.json",
+      "label": "2024-25"
+    }
+  ]
+}

--- a/public/franchise-explorer.html
+++ b/public/franchise-explorer.html
@@ -1935,10 +1935,36 @@
     }
 
     async function loadSchedule() {
-      const scheduleFiles = [
-        { path: 'data/season_25_26_schedule.json', label: '2025-26' },
+      const fallbackScheduleFiles = [
         { path: 'data/season_24_25_schedule.json', label: '2024-25' },
+        { path: 'data/season_25_26_schedule.json', label: '2025-26' },
       ];
+
+      let scheduleFiles = fallbackScheduleFiles;
+
+      try {
+        const manifest = await fetchJson('data/schedule_manifest.json', 'schedule manifest');
+        if (Array.isArray(manifest?.seasons)) {
+          const normalized = manifest.seasons
+            .map((season) => {
+              if (!season) return null;
+              if (typeof season === 'string') {
+                return { path: season, label: season };
+              }
+              if (typeof season === 'object' && typeof season.path === 'string' && season.path.length > 0) {
+                const label = typeof season.label === 'string' && season.label.length > 0 ? season.label : season.path;
+                return { path: season.path, label };
+              }
+              return null;
+            })
+            .filter(Boolean);
+          if (normalized.length > 0) {
+            scheduleFiles = normalized;
+          }
+        }
+      } catch (error) {
+        console.warn('Unable to load schedule manifest. Falling back to default schedule list.', error);
+      }
 
       let lastError = null;
       for (const file of scheduleFiles) {

--- a/scripts/build_schedule_snapshot.mjs
+++ b/scripts/build_schedule_snapshot.mjs
@@ -400,6 +400,17 @@ function buildScheduleSnapshot() {
   mkdirSync(outputDir, { recursive: true });
   writeFileSync(outputPath, JSON.stringify(scheduleSnapshot, null, 2));
 
+  const manifestPath = join(outputDir, 'schedule_manifest.json');
+  const manifestPayload = {
+    seasons: [
+      {
+        path: `data/${activeSeason.json}`,
+        label: activeSeason.label,
+      },
+    ],
+  };
+  writeFileSync(manifestPath, JSON.stringify(manifestPayload, null, 2));
+
   return scheduleSnapshot;
 }
 


### PR DESCRIPTION
## Summary
- load schedule data via a manifest so the app only requests available seasons
- ship a schedule manifest alongside the generated schedule snapshot for build parity
- add the manifest JSON asset used at runtime

## Testing
- curl -s http://127.0.0.1:4173/data/schedule_manifest.json

------
https://chatgpt.com/codex/tasks/task_e_68d81a42e38c832799b721e584ad929e