### PR TITLE
Transform landing page into NBA intelligence hub

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>NBA Franchise Explorer</title>
+  <title>NBA Intelligence Hub</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -71,6 +71,70 @@
       mix-blend-mode: lighten;
       pointer-events: none;
       z-index: -1;
+    }
+
+    .hub-nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      flex-wrap: wrap;
+      padding: 0.85rem 1.2rem;
+      margin-bottom: 1.5rem;
+      border-radius: var(--radius-lg);
+      background: color-mix(in srgb, rgba(255, 255, 255, 0.82) 70%, var(--surface-elevated) 30%);
+      border: 1px solid var(--card-border);
+      box-shadow: var(--shadow-soft);
+    }
+
+    .hub-nav .brand {
+      font-weight: 800;
+      font-size: 1.05rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--nba-navy);
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .hub-nav .nav-links {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .hub-nav .nav-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      text-decoration: none;
+      color: var(--text-primary);
+      background: color-mix(in srgb, var(--surface-muted) 55%, rgba(255, 255, 255, 0.8) 45%);
+      border: 1px solid color-mix(in srgb, var(--nba-royal) 18%, transparent);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+    }
+
+    .hub-nav .nav-links a:hover,
+    .hub-nav .nav-links a:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 12px 24px rgba(17, 86, 214, 0.25);
+      outline: none;
+      background: color-mix(in srgb, var(--nba-royal) 65%, white 35%);
+      color: #fff;
+    }
+
+    .lead {
+      font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+      color: var(--text-primary);
     }
 
     header {
@@ -474,6 +538,27 @@
         padding-top: 2.75rem;
       }
 
+      .hub-nav {
+        background: color-mix(in srgb, rgba(8, 12, 24, 0.92) 70%, rgba(17, 86, 214, 0.35) 30%);
+        border-color: rgba(17, 86, 214, 0.4);
+        box-shadow: 0 20px 45px rgba(2, 6, 23, 0.7);
+      }
+
+      .hub-nav .brand {
+        color: #f8fafc;
+      }
+
+      .hub-nav .nav-links a {
+        color: #f8fafc;
+        background: color-mix(in srgb, rgba(17, 86, 214, 0.35) 65%, rgba(8, 12, 24, 0.65) 35%);
+        border-color: rgba(17, 86, 214, 0.45);
+      }
+
+      .hub-nav .nav-links a:hover,
+      .hub-nav .nav-links a:focus-visible {
+        background: color-mix(in srgb, var(--nba-royal) 55%, rgba(8, 12, 24, 0.45) 45%);
+      }
+
       section {
         padding: 1.5rem 1.25rem 1.6rem;
       }
@@ -585,16 +670,27 @@
     }
   </style>
 </head>
-<body>
+<body id="top">
   <header>
+    <nav class="hub-nav" aria-label="Primary">
+      <a class="brand" href="#top">NBA Intelligence Hub</a>
+      <div class="nav-links">
+        <a href="#franchises">Franchises</a>
+        <a href="#schedule">Schedule</a>
+        <a href="#players">Players</a>
+        <a href="#games">Historic games</a>
+        <a href="#teams">Team benchmarks</a>
+        <a href="#leaders">Leaders</a>
+      </div>
+    </nav>
     <p class="eyebrow">Data sandbox</p>
-    <h1>NBA Franchise Explorer</h1>
-    <p>Filter and benchmark every active franchise era from the league's rich history.</p>
-    <p id="generated-note" aria-live="polite">Loading snapshot…</p>
+    <h1>NBA Intelligence Hub</h1>
+    <p class="lead">Explore franchises, the 2024-25 calendar, player pipelines, iconic games, team benchmarks, and all-time leaders in one place.</p>
+    <p id="generated-note" aria-live="polite">Loading active franchise snapshot…</p>
   </header>
 
   <main>
-    <section aria-labelledby="controls-heading">
+    <section id="franchises" aria-labelledby="controls-heading">
       <h2 id="controls-heading">Slice the active era data</h2>
       <div class="controls-grid" role="group" aria-labelledby="controls-heading">
         <div>
@@ -654,7 +750,7 @@
       <p class="data-note">The chart respects the filters above so you can zoom in on expansion eras and compare leagues.</p>
     </section>
 
-    <section aria-labelledby="schedule-heading">
+    <section id="schedule" aria-labelledby="schedule-heading">
       <h2 id="schedule-heading">2024-25 league calendar outlook</h2>
       <p id="schedule-note" class="data-note">Loading 2024-25 schedule insights…</p>
       <div class="summary-cards" id="schedule-summary" aria-live="polite"></div>
@@ -716,7 +812,7 @@
       </div>
     </section>
 
-    <section aria-labelledby="players-heading">
+    <section id="players" aria-labelledby="players-heading">
       <h2 id="players-heading">Global player pipeline</h2>
       <p id="players-note" class="data-note">Loading player overview…</p>
       <div class="summary-cards" id="players-summary" aria-live="polite"></div>
@@ -789,5 +885,1604 @@
         </div>
       </div>
     </section>
+
+  <section id="games" aria-labelledby="games-heading">
+      <h2 id="games-heading">Historic game spotlights</h2>
+      <p id="games-note" class="data-note">Loading historical game insights…</p>
+      <div class="summary-cards" id="games-summary" aria-live="polite"></div>
+
+      <div class="section-grid">
+        <div class="panel">
+          <h3>Highest scoring games</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Matchup</th>
+                  <th scope="col">Total</th>
+                </tr>
+              </thead>
+              <tbody id="games-highest-body">
+                <tr><td colspan="3">Loading scoring highlights…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Largest margins</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Result</th>
+                  <th scope="col">Margin</th>
+                </tr>
+              </thead>
+              <tbody id="games-margins-body">
+                <tr><td colspan="3">Loading margin data…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Attendance leaders</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Date</th>
+                  <th scope="col">Matchup</th>
+                  <th scope="col">Attendance</th>
+                </tr>
+              </thead>
+              <tbody id="games-attendance-body">
+                <tr><td colspan="3">Loading attendance highlights…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel panel-wide">
+          <h3>Games by decade</h3>
+          <canvas id="games-decade-chart" role="img" aria-label="Line chart showing recorded NBA games by decade"></canvas>
+        </div>
+      </div>
+    </section>
+
+  
+
+  <section id="teams" aria-labelledby="team-heading">
+      <h2 id="team-heading">Team performance benchmarks</h2>
+      <p id="team-note" class="data-note">Loading team performance snapshot…</p>
+      <div class="summary-cards" id="team-summary" aria-live="polite"></div>
+
+      <div class="section-grid">
+        <div class="panel">
+          <h3>Win percentage leaders (≥ 500 games)</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Team</th>
+                  <th scope="col">Win %</th>
+                  <th scope="col">Games</th>
+                </tr>
+              </thead>
+              <tbody id="team-win-body">
+                <tr><td colspan="3">Loading team win percentages…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Single-game scoring highs</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Team</th>
+                  <th scope="col">Opponent</th>
+                  <th scope="col">Points</th>
+                </tr>
+              </thead>
+              <tbody id="team-scoring-body">
+                <tr><td colspan="3">Loading team scoring highs…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Single-game assist highs</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Team</th>
+                  <th scope="col">Opponent</th>
+                  <th scope="col">Assists</th>
+                </tr>
+              </thead>
+              <tbody id="team-assists-body">
+                <tr><td colspan="3">Loading assist highlights…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  
+
+  <section id="leaders" aria-labelledby="leaders-heading">
+      <h2 id="leaders-heading">All-time player leaders</h2>
+      <p id="leaders-note" class="data-note">Loading player leaderboards…</p>
+      <div class="summary-cards" id="leaders-summary" aria-live="polite"></div>
+
+      <div class="section-grid">
+        <div class="panel">
+          <h3>Career points leaders</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">PTS</th>
+                  <th scope="col">G</th>
+                </tr>
+              </thead>
+              <tbody id="leaders-career-points">
+                <tr><td colspan="3">Loading career points…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Career assist leaders</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">AST</th>
+                  <th scope="col">G</th>
+                </tr>
+              </thead>
+              <tbody id="leaders-career-assists">
+                <tr><td colspan="3">Loading career assists…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Career rebound leaders</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">REB</th>
+                  <th scope="col">G</th>
+                </tr>
+              </thead>
+              <tbody id="leaders-career-rebounds">
+                <tr><td colspan="3">Loading career rebounds…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="section-grid">
+        <div class="panel">
+          <h3>Single-game scoring highs</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">PTS</th>
+                  <th scope="col">Date</th>
+                </tr>
+              </thead>
+              <tbody id="leaders-game-points">
+                <tr><td colspan="3">Loading single-game points…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Single-game assist highs</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">AST</th>
+                  <th scope="col">Date</th>
+                </tr>
+              </thead>
+              <tbody id="leaders-game-assists">
+                <tr><td colspan="3">Loading single-game assists…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div class="panel">
+          <h3>Single-game rebound highs</h3>
+          <div class="table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">REB</th>
+                  <th scope="col">Date</th>
+                </tr>
+              </thead>
+              <tbody id="leaders-game-rebounds">
+                <tr><td colspan="3">Loading single-game rebounds…</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  
+
+  <section id="about" aria-labelledby="meta-heading">
+      <h2 id="meta-heading">About this hub</h2>
+      <p>The NBA Intelligence Hub combines franchise, schedule, player, game, team, and leaderboard snapshots built from the CSV sources in this repository.</p>
+      <p>Use the scripts in the <code>scripts/</code> directory (<code>build_snapshot.mjs</code>, <code>build_schedule_snapshot.mjs</code>, and <code>build_insights.py</code>) to regenerate the snapshots and refresh every panel with the latest data.</p>
+    </section>
+  </main>
+
+  <script src="vendor/chart.umd.js"></script>
+  <script>
+    const state = {
+      raw: [],
+      filtered: [],
+      snapshot: null,
+      schedule: null,
+      playersOverview: null,
+      historicGames: null,
+      teamPerformance: null,
+      playerLeaders: null,
+    };
+
+    const dom = {
+      generatedNote: document.getElementById('generated-note'),
+      league: document.getElementById('league'),
+      search: document.getElementById('search'),
+      seasonStart: document.getElementById('season-start'),
+      seasonEnd: document.getElementById('season-end'),
+      reset: document.getElementById('reset-filters'),
+      teamsBody: document.getElementById('teams-body'),
+      summaryCards: document.getElementById('summary-cards'),
+      scheduleNote: document.getElementById('schedule-note'),
+      scheduleSummary: document.getElementById('schedule-summary'),
+      scheduleTeamsBody: document.getElementById('schedule-teams-body'),
+      scheduleSpecialList: document.getElementById('schedule-special-list'),
+      scheduleMonthlyCanvas: document.getElementById('schedule-monthly-chart'),
+      scheduleRestCanvas: document.getElementById('schedule-rest-chart'),
+      scheduleRestNote: document.getElementById('schedule-rest-note'),
+      scheduleBackToBackBody: document.getElementById('schedule-backtoback-body'),
+      playersNote: document.getElementById('players-note'),
+      playersSummary: document.getElementById('players-summary'),
+      playersCountriesBody: document.getElementById('players-countries-body'),
+      playersHeightCanvas: document.getElementById('players-height-chart'),
+      playersHeightNote: document.getElementById('players-height-note'),
+      playersTallestList: document.getElementById('players-tallest-list'),
+      playersCollegesBody: document.getElementById('players-colleges-body'),
+      playersDraftCanvas: document.getElementById('players-draft-chart'),
+      playersDraftNote: document.getElementById('players-draft-note'),
+      playersDraftDecadesBody: document.getElementById('players-draft-decades-body'),
+      gamesNote: document.getElementById('games-note'),
+      gamesSummary: document.getElementById('games-summary'),
+      gamesHighestBody: document.getElementById('games-highest-body'),
+      gamesMarginsBody: document.getElementById('games-margins-body'),
+      gamesAttendanceBody: document.getElementById('games-attendance-body'),
+      gamesDecadeCanvas: document.getElementById('games-decade-chart'),
+      teamNote: document.getElementById('team-note'),
+      teamSummary: document.getElementById('team-summary'),
+      teamWinBody: document.getElementById('team-win-body'),
+      teamScoringBody: document.getElementById('team-scoring-body'),
+      teamAssistsBody: document.getElementById('team-assists-body'),
+      leadersNote: document.getElementById('leaders-note'),
+      leadersSummary: document.getElementById('leaders-summary'),
+      leadersCareerPoints: document.getElementById('leaders-career-points'),
+      leadersCareerAssists: document.getElementById('leaders-career-assists'),
+      leadersCareerRebounds: document.getElementById('leaders-career-rebounds'),
+      leadersGamePoints: document.getElementById('leaders-game-points'),
+      leadersGameAssists: document.getElementById('leaders-game-assists'),
+      leadersGameRebounds: document.getElementById('leaders-game-rebounds'),
+    };
+
+    function chartAvailable() {
+      return typeof window !== 'undefined' && typeof window.Chart !== 'undefined';
+    }
+
+    async function fetchJson(path, friendlyName) {
+      const url = new URL(path, document.baseURI);
+      const response = await fetch(url.toString(), { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to load ${friendlyName ?? path} (${response.status}) from ${url}`);
+      }
+      return response.json();
+    }
+
+    let decadeChart;
+    let scheduleChart;
+    let scheduleRestChart;
+    let playersHeightChart;
+    let playersDraftChart;
+    let gamesDecadeChart;
+
+    function formatNumber(value) {
+      return new Intl.NumberFormat().format(value);
+    }
+
+    function formatDecimal(value, digits = 1) {
+      if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+      return new Intl.NumberFormat('en', {
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(Number(value));
+    }
+
+    function formatPercent(value, digits = 1) {
+      if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+      return new Intl.NumberFormat('en', {
+        style: 'percent',
+        minimumFractionDigits: digits,
+        maximumFractionDigits: digits,
+      }).format(Number(value));
+    }
+
+    function formatFeetAndInches(value) {
+      if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+      const total = Number(value);
+      const feet = Math.floor(total / 12);
+      const remainder = Math.round((total - feet * 12) * 10) / 10;
+      const rounded = Math.round(remainder);
+      const inches = Math.abs(remainder - rounded) < 0.05 ? String(rounded) : remainder.toFixed(1);
+      return `${feet}\u2032${inches}\u2033`;
+    }
+
+    function formatWeight(value) {
+      if (value === null || value === undefined || Number.isNaN(Number(value))) return '—';
+      return `${Math.round(Number(value))} lbs`;
+    }
+
+    const fullDateFormatter = new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric', year: 'numeric' });
+    const shortDateFormatter = new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' });
+
+    function formatDate(isoString, formatter = fullDateFormatter) {
+      if (!isoString) return '—';
+      const parsed = new Date(isoString);
+      if (!Number.isNaN(parsed.getTime())) {
+        return formatter.format(parsed);
+      }
+      const fallback = new Date(String(isoString).replace(' ', 'T'));
+      if (!Number.isNaN(fallback.getTime())) {
+        return formatter.format(fallback);
+      }
+      return '—';
+    }
+
+    function formatMatchup(home, away) {
+      const awayLabel = [away?.city, away?.name].filter(Boolean).join(' ') || 'Away team';
+      const homeLabel = [home?.city, home?.name].filter(Boolean).join(' ') || 'Home team';
+      return `<span class="team-name">${awayLabel}</span> @ <span class="team-name">${homeLabel}</span>`;
+    }
+
+    function formatResult(game) {
+      const homeScore = typeof game?.home?.score === 'number' ? game.home.score : Number(game?.home?.score) || 0;
+      const awayScore = typeof game?.away?.score === 'number' ? game.away.score : Number(game?.away?.score) || 0;
+      const homeName = [game?.home?.city, game?.home?.name].filter(Boolean).join(' ') || 'Home team';
+      const awayName = [game?.away?.city, game?.away?.name].filter(Boolean).join(' ') || 'Away team';
+      if (homeScore >= awayScore) {
+        return `<span class="team-name">${homeName}</span> ${formatNumber(homeScore)} – <span class="team-name">${awayName}</span> ${formatNumber(awayScore)}`;
+      }
+      return `<span class="team-name">${awayName}</span> ${formatNumber(awayScore)} – <span class="team-name">${homeName}</span> ${formatNumber(homeScore)}`;
+    }
+
+    function formatDateRange(startIso, endIso) {
+      if (!startIso || !endIso) return '—';
+      return `${formatDate(startIso)} → ${formatDate(endIso)}`;
+    }
+
+    function buildSummary(franchises) {
+      const totals = state.snapshot?.totals ?? { all: 0, nba: 0 };
+      const cards = [
+        {
+          label: 'Filtered franchises',
+          value: franchises.length,
+        },
+        {
+          label: 'Active NBA franchises',
+          value: totals.nba,
+        },
+      ];
+
+      if (state.snapshot?.earliestSeason) {
+        cards.push({
+          label: 'Earliest era start',
+          value: state.snapshot.earliestSeason,
+        });
+      }
+      if (state.snapshot?.latestSeason) {
+        cards.push({
+          label: 'Latest era start',
+          value: state.snapshot.latestSeason,
+        });
+      }
+
+      dom.summaryCards.innerHTML = cards
+        .map(
+          (card) => `
+            <div class="summary-card">
+              <h3>${card.label}</h3>
+              <p>${formatNumber(card.value)}</p>
+            </div>
+          `,
+        )
+        .join('');
+    }
+
+    function renderTable(franchises) {
+      if (franchises.length === 0) {
+        dom.teamsBody.innerHTML = '<tr><td colspan="6">No franchises match your filters yet. Try expanding the range or clearing the search.</td></tr>';
+        return;
+      }
+
+      const rows = franchises
+        .map((team) => {
+          const seasons = team.seasonFounded ? (state.snapshot.currentYear - team.seasonFounded + 1) : null;
+          const spanLabel = seasons && seasons > 0 ? `${formatNumber(seasons)} seasons` : '—';
+          const eraStart = team.seasonFounded ?? '—';
+          const leagueBadge = `<span class="badge">${team.league}</span>`;
+
+          return `
+            <tr>
+              <td>${team.city}</td>
+              <td><span class="team-name">${team.name}</span></td>
+              <td>${leagueBadge}</td>
+              <td>${eraStart}</td>
+              <td>${spanLabel}</td>
+              <td>${team.abbreviation || '—'}</td>
+            </tr>
+          `;
+        })
+        .join('');
+
+      dom.teamsBody.innerHTML = rows;
+    }
+
+    function renderChart(franchises) {
+      if (!state.snapshot) return;
+
+      const decadeCounts = new Map();
+      for (const team of franchises) {
+        if (typeof team.seasonFounded === 'number') {
+          const decade = Math.floor(team.seasonFounded / 10) * 10;
+          decadeCounts.set(decade, (decadeCounts.get(decade) ?? 0) + 1);
+        }
+      }
+      const labels = Array.from(decadeCounts.keys()).sort((a, b) => a - b);
+      const values = labels.map((label) => decadeCounts.get(label));
+
+      const dataset = {
+        label: 'Active franchises',
+        data: values,
+        backgroundColor: 'rgba(23, 105, 170, 0.45)',
+        borderRadius: 6,
+      };
+
+      if (!chartAvailable()) {
+        return;
+      }
+
+      if (!decadeChart) {
+        const ctx = document.getElementById('decade-chart');
+        decadeChart = new Chart(ctx, {
+          type: 'bar',
+          data: {
+            labels: labels.map((decade) => `${decade}s`),
+            datasets: [dataset],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              y: {
+                beginAtZero: true,
+                ticks: {
+                  precision: 0,
+                },
+              },
+            },
+          },
+        });
+      } else {
+        decadeChart.data.labels = labels.map((decade) => `${decade}s`);
+        decadeChart.data.datasets[0].data = values;
+        decadeChart.update();
+      }
+    }
+
+    function renderScheduleSummary() {
+      if (!state.schedule) return;
+
+        const { totals, generatedAt, dateRange, restSummary } = state.schedule;
+        const cards = [
+          {
+            label: 'Total scheduled games',
+            value: totals.games,
+          },
+          {
+            label: 'Teams with games',
+            value: totals.teams,
+          },
+          {
+            label: 'Regular-season games',
+            value: totals.regularSeason,
+          },
+          {
+            label: 'Preseason games',
+            value: totals.preseason,
+          },
+        ];
+
+      if (totals.other > 0) {
+        cards.push({
+          label: 'Cup & playoff games',
+          value: totals.other,
+        });
+      }
+
+        if (restSummary?.averageRestDays) {
+          cards.push({
+            label: 'Avg. rest days',
+            value: restSummary.averageRestDays,
+            formatter: (value) => formatDecimal(value, 2),
+          });
+        }
+        if (restSummary?.backToBackIntervals) {
+          cards.push({
+            label: 'Back-to-back sets',
+            value: restSummary.backToBackIntervals,
+          });
+        }
+
+        dom.scheduleSummary.innerHTML = cards
+          .map(
+            (card) => `
+              <div class="summary-card">
+                <h3>${card.label}</h3>
+                <p>${card.formatter ? card.formatter(card.value) : formatNumber(card.value)}</p>
+              </div>
+            `,
+          )
+          .join('');
+
+      const generatedText = generatedAt ? new Date(generatedAt).toLocaleString() : '—';
+      const coverage = dateRange ? formatDateRange(dateRange.start, dateRange.end) : '—';
+      const restParts = [];
+      if (restSummary?.averageRestDays && restSummary?.totalIntervals) {
+        restParts.push(`Average rest ${formatDecimal(restSummary.averageRestDays, 2)} days across ${formatNumber(restSummary.totalIntervals)} schedule gaps`);
+      }
+      if (restSummary?.backToBackIntervals) {
+        restParts.push(`${formatNumber(restSummary.backToBackIntervals)} zero-day turnarounds`);
+      }
+      const restSentence = restParts.length > 0 ? ` Rest outlook: ${restParts.join(', ')}.` : '';
+      const seasonInfo = state.schedule?.season ?? {};
+      const seasonLabel = seasonInfo.label ? ` (${seasonInfo.label})` : '';
+      const sourceCsv = seasonInfo.sourceCsv ?? 'LeagueSchedule24_25.csv';
+      dom.scheduleNote.textContent = `Schedule snapshot${seasonLabel} generated ${generatedText}. Coverage: ${coverage}. Totals include preseason, Emirates NBA Cup, play-in, and playoff rounds from ${sourceCsv}.${restSentence}`;
+    }
+
+    function renderScheduleChart() {
+      if (!state.schedule || !dom.scheduleMonthlyCanvas) return;
+      const months = state.schedule.monthlyCounts ?? [];
+      if (months.length === 0) {
+        if (scheduleChart) {
+          scheduleChart.destroy();
+          scheduleChart = null;
+        }
+        return;
+      }
+
+      const labels = months.map((month) => month.label);
+      const preseasonData = months.map((month) => month.preseason ?? 0);
+      const regularData = months.map((month) => month.regularSeason ?? 0);
+      const otherData = months.map((month) => Math.max(0, (month.games ?? 0) - (month.preseason ?? 0) - (month.regularSeason ?? 0)));
+
+      const datasets = [
+        {
+          label: 'Preseason',
+          data: preseasonData,
+          backgroundColor: 'rgba(23, 105, 170, 0.35)',
+          stack: 'schedule',
+          borderRadius: 6,
+        },
+        {
+          label: 'Regular season',
+          data: regularData,
+          backgroundColor: 'rgba(23, 105, 170, 0.7)',
+          stack: 'schedule',
+          borderRadius: 6,
+        },
+        {
+          label: 'Cup & playoffs',
+          data: otherData,
+          backgroundColor: 'rgba(249, 115, 22, 0.65)',
+          stack: 'schedule',
+          borderRadius: 6,
+        },
+      ];
+
+      if (!chartAvailable()) {
+        if (!dom.scheduleNote.textContent.includes('Chart.js')) {
+          dom.scheduleNote.textContent += ' Chart visualizations unavailable—Chart.js did not load.';
+        }
+        return;
+      }
+
+      if (!scheduleChart) {
+        scheduleChart = new Chart(dom.scheduleMonthlyCanvas, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets,
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { stacked: true },
+              y: {
+                stacked: true,
+                beginAtZero: true,
+                ticks: { precision: 0 },
+              },
+            },
+            plugins: {
+              legend: {
+                position: 'bottom',
+              },
+            },
+          },
+        });
+      } else {
+        scheduleChart.data.labels = labels;
+        scheduleChart.data.datasets[0].data = preseasonData;
+        scheduleChart.data.datasets[1].data = regularData;
+        scheduleChart.data.datasets[2].data = otherData;
+        scheduleChart.update();
+      }
+    }
+
+    function renderScheduleTeams() {
+      if (!state.schedule) return;
+      const teams = state.schedule.teams ?? [];
+      if (teams.length === 0) {
+        dom.scheduleTeamsBody.innerHTML = '<tr><td colspan="5">No team workload data is available yet.</td></tr>';
+        return;
+      }
+
+      const rows = [...teams]
+        .sort((a, b) => {
+          if (b.otherGames === a.otherGames) {
+            if (b.totalGames === a.totalGames) {
+              return a.name.localeCompare(b.name);
+            }
+            return b.totalGames - a.totalGames;
+          }
+          return b.otherGames - a.otherGames;
+        })
+        .slice(0, 8)
+        .map((team) => {
+          const badge = team.abbreviation ? ` <span class="badge">${team.abbreviation}</span>` : '';
+          return `
+            <tr>
+              <td><span class="team-name">${team.name}</span>${badge}</td>
+              <td>${formatNumber(team.regularSeasonGames)}</td>
+              <td>${formatNumber(team.otherGames)}</td>
+              <td>${formatNumber(team.preseasonGames)}</td>
+              <td>${formatNumber(team.totalGames)}</td>
+            </tr>
+          `;
+        })
+        .join('');
+
+      dom.scheduleTeamsBody.innerHTML = rows;
+    }
+
+    function renderScheduleRest() {
+      if (!dom.scheduleRestNote) return;
+      const restBuckets = state.schedule?.restBuckets ?? [];
+      const restSummary = state.schedule?.restSummary ?? {};
+
+      const summaryParts = [];
+      if (restSummary?.totalIntervals && restSummary?.averageRestDays) {
+        summaryParts.push(`Average rest ${formatDecimal(restSummary.averageRestDays, 2)} days across ${formatNumber(restSummary.totalIntervals)} gaps`);
+      }
+      if (restSummary?.backToBackIntervals) {
+        summaryParts.push(`${formatNumber(restSummary.backToBackIntervals)} involve zero-day turnarounds`);
+      }
+      dom.scheduleRestNote.textContent = summaryParts.length > 0
+        ? `${summaryParts.join('. ')}.`
+        : 'Rest distribution summarizes the time between games for each franchise in the snapshot.';
+
+      if (!dom.scheduleRestCanvas) return;
+      if (restBuckets.length === 0) {
+        if (scheduleRestChart) {
+          scheduleRestChart.destroy();
+          scheduleRestChart = null;
+        }
+        return;
+      }
+
+      const labels = restBuckets.map((bucket) => bucket.label ?? 'Unknown');
+      const values = restBuckets.map((bucket) => bucket.intervals ?? 0);
+
+      if (!chartAvailable()) {
+        if (!dom.scheduleRestNote.textContent.includes('Chart.js')) {
+          dom.scheduleRestNote.textContent += ' Chart visualization unavailable—Chart.js did not load.';
+        }
+        return;
+      }
+
+      if (!scheduleRestChart) {
+        scheduleRestChart = new Chart(dom.scheduleRestCanvas, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [
+              {
+                label: 'Rest intervals',
+                data: values,
+                backgroundColor: 'rgba(23, 105, 170, 0.6)',
+                borderRadius: 6,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            indexAxis: 'y',
+            scales: {
+              x: {
+                beginAtZero: true,
+                ticks: { precision: 0 },
+              },
+            },
+            plugins: {
+              legend: { display: false },
+            },
+          },
+        });
+      } else {
+        scheduleRestChart.data.labels = labels;
+        scheduleRestChart.data.datasets[0].data = values;
+        scheduleRestChart.update();
+      }
+    }
+
+    function renderScheduleBackToBack() {
+      if (!dom.scheduleBackToBackBody) return;
+      const leaders = state.schedule?.backToBackLeaders ?? [];
+      if (!leaders || leaders.length === 0) {
+        dom.scheduleBackToBackBody.innerHTML = '<tr><td colspan="4">No back-to-back insights available.</td></tr>';
+        return;
+      }
+
+      dom.scheduleBackToBackBody.innerHTML = leaders
+        .map((team) => {
+          const badge = team.abbreviation ? ` <span class="badge">${team.abbreviation}</span>` : '';
+          const avgRest = typeof team.averageRestDays === 'number'
+            ? `${formatDecimal(team.averageRestDays, 2)} d`
+            : '—';
+          const longestRoad = team.longestRoadTrip ? `${formatNumber(team.longestRoadTrip)} games` : '—';
+          return `
+            <tr>
+              <td><span class="team-name">${team.name}</span>${badge}</td>
+              <td>${formatNumber(team.backToBacks ?? 0)}</td>
+              <td>${avgRest}</td>
+              <td>${longestRoad}</td>
+            </tr>
+          `;
+        })
+        .join('');
+    }
+
+    function renderScheduleSpecials() {
+      if (!state.schedule) return;
+      const specials = state.schedule.specialGames ?? [];
+      if (specials.length === 0) {
+        dom.scheduleSpecialList.innerHTML = '<li>No special events were tagged in this schedule snapshot.</li>';
+        return;
+      }
+
+      const teamLookup = new Map((state.schedule.teams ?? []).map((team) => [team.teamId, team]));
+      const items = specials
+        .slice(0, 10)
+        .map((game) => {
+          const dateLabel = game.date ? formatDate(game.date, shortDateFormatter) : 'TBD';
+          const descriptors = [game.label];
+          if (game.subLabel && !descriptors.includes(game.subLabel)) descriptors.push(game.subLabel);
+          if (game.subtype && !descriptors.includes(game.subtype)) descriptors.push(game.subtype);
+          if (game.seriesText && !descriptors.includes(game.seriesText)) descriptors.push(game.seriesText);
+          const descriptorText = descriptors.filter((value) => value && value.length > 0).join(' · ');
+          const home = teamLookup.get(game.hometeamId)?.name ?? game.hometeamId ?? '';
+          const away = teamLookup.get(game.awayteamId)?.name ?? game.awayteamId ?? '';
+          const matchup = home && away ? `${away} @ ${home}` : home || away || 'Matchup TBA';
+          const locationParts = [game.arena, game.city, game.state].filter((value) => value && value.length > 0);
+          const locationText = locationParts.join(', ');
+          const dateAttr = game.date ? ` datetime="${game.date}"` : '';
+          return `
+            <li>
+              <div><time${dateAttr}>${dateLabel}</time>${descriptorText ? ` ${descriptorText}` : ''}</div>
+              <span class="special-meta">${matchup}${locationText ? ` • ${locationText}` : ''}</span>
+            </li>
+          `;
+        })
+        .join('');
+
+      dom.scheduleSpecialList.innerHTML = items;
+    }
+
+    function renderPlayersOverview() {
+      const snapshot = state.playersOverview;
+      if (!snapshot) return;
+
+      const totals = snapshot.totals ?? {};
+      const totalPlayers = totals.players ?? 0;
+      const draftSummary = snapshot.draftSummary ?? null;
+      const draftedPlayers = draftSummary?.draftedPlayers ?? 0;
+      const undraftedPlayers = draftSummary?.undraftedPlayers ?? 0;
+      const cards = [
+        { label: 'Players on record', value: formatNumber(totalPlayers) },
+        { label: 'Average height (in)', value: formatDecimal(totals.averageHeightInches ?? 0, 2) },
+        { label: 'Average weight (lb)', value: formatDecimal(totals.averageWeightPounds ?? 0, 1) },
+        { label: 'Countries represented', value: formatNumber(totals.countriesRepresented ?? 0) },
+      ];
+      if (draftSummary) {
+        const draftedShare = totalPlayers > 0 ? draftedPlayers / totalPlayers : null;
+        const draftedLabel = draftedShare !== null
+          ? `${formatNumber(draftedPlayers)} (${formatPercent(draftedShare, 1)})`
+          : formatNumber(draftedPlayers);
+        cards.push({ label: 'Drafted players', value: draftedLabel });
+      }
+      dom.playersSummary.innerHTML = cards
+        .map((card) => `
+          <div class="summary-card">
+            <h3>${card.label}</h3>
+            <p>${card.value}</p>
+          </div>
+        `)
+        .join('');
+
+      const generatedText = snapshot.generatedAt ? new Date(snapshot.generatedAt).toLocaleString() : '—';
+      const draftLedger = draftSummary
+        ? ` Draft ledger — Drafted: ${formatNumber(draftedPlayers)}, Undrafted: ${formatNumber(undraftedPlayers)}.`
+        : '';
+      dom.playersNote.textContent = `Snapshot generated ${generatedText}. Position flags — G: ${formatNumber(totals.guards ?? 0)}, F: ${formatNumber(totals.forwards ?? 0)}, C: ${formatNumber(totals.centers ?? 0)}.${draftLedger}`;
+
+      const countries = snapshot.countries ?? [];
+      dom.playersCountriesBody.innerHTML = countries.length > 0
+        ? countries
+            .map((country) => `
+              <tr>
+                <td>${country.country}</td>
+                <td>${formatNumber(country.players ?? 0)}</td>
+              </tr>
+            `)
+            .join('')
+        : '<tr><td colspan="2">No country data available.</td></tr>';
+
+      const colleges = snapshot.colleges ?? [];
+      dom.playersCollegesBody.innerHTML = colleges.length > 0
+        ? colleges
+            .map((college) => `
+              <tr>
+                <td>${college.program}</td>
+                <td>${formatNumber(college.players ?? 0)}</td>
+              </tr>
+            `)
+            .join('')
+        : '<tr><td colspan="2">No college data available.</td></tr>';
+
+      const decades = draftSummary?.decadeCounts ?? [];
+      if (draftSummary) {
+        dom.playersDraftDecadesBody.innerHTML = decades.length > 0
+          ? decades
+              .map((entry) => `
+                <tr>
+                  <td>${entry.decade}</td>
+                  <td>${formatNumber(entry.players ?? 0)}</td>
+                </tr>
+              `)
+              .join('')
+          : '<tr><td colspan="2">No draft year breakdown available.</td></tr>';
+
+        const draftNoteParts = [];
+        if (draftSummary.earliestDraftYear && draftSummary.latestDraftYear) {
+          draftNoteParts.push(`Draft years span ${draftSummary.earliestDraftYear}–${draftSummary.latestDraftYear}`);
+        }
+        draftNoteParts.push(`${formatNumber(draftedPlayers)} drafted, ${formatNumber(undraftedPlayers)} undrafted`);
+        dom.playersDraftNote.textContent = `${draftNoteParts.join('. ')}.`;
+
+        if (dom.playersDraftCanvas) {
+          const values = [draftedPlayers, undraftedPlayers];
+          const labels = ['Drafted', 'Undrafted'];
+          if (!chartAvailable()) {
+            if (!dom.playersDraftNote.textContent.includes('Chart.js')) {
+              dom.playersDraftNote.textContent += ' Chart visualization unavailable—Chart.js did not load.';
+            }
+          } else if (!playersDraftChart) {
+            playersDraftChart = new Chart(dom.playersDraftCanvas, {
+              type: 'doughnut',
+              data: {
+                labels,
+                datasets: [
+                  {
+                    data: values,
+                    backgroundColor: [
+                      'rgba(23, 105, 170, 0.75)',
+                      'rgba(148, 163, 184, 0.6)',
+                    ],
+                    borderWidth: 0,
+                  },
+                ],
+              },
+              options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                  legend: {
+                    position: 'bottom',
+                  },
+                },
+              },
+            });
+          } else {
+            playersDraftChart.data.labels = labels;
+            playersDraftChart.data.datasets[0].data = values;
+            playersDraftChart.update();
+          }
+        }
+      } else {
+        dom.playersDraftDecadesBody.innerHTML = '<tr><td colspan="2">No draft data available.</td></tr>';
+        dom.playersDraftNote.textContent = 'Draft snapshot unavailable.';
+        if (playersDraftChart) {
+          playersDraftChart.destroy();
+          playersDraftChart = null;
+        }
+      }
+
+      const tallest = snapshot.tallestPlayers ?? [];
+      dom.playersTallestList.innerHTML = tallest.length > 0
+        ? tallest
+            .map((player, index) => {
+              const positions = (player.positions ?? []).join(' • ');
+              const metaParts = [];
+              if (player.weightPounds) metaParts.push(formatWeight(player.weightPounds));
+              if (player.country) metaParts.push(player.country);
+              return `
+                <li>
+                  <strong>${index + 1}. ${player.name}</strong> — ${formatFeetAndInches(player.heightInches)}${positions ? ` · ${positions}` : ''}
+                  <span class="tallest-meta">${metaParts.join(' • ')}</span>
+                </li>
+              `;
+            })
+            .join('')
+        : '<li>No height data available.</li>';
+
+      const heightBuckets = snapshot.heightBuckets ?? [];
+      if (heightBuckets.length === 0) {
+        if (playersHeightChart) {
+          playersHeightChart.destroy();
+          playersHeightChart = null;
+        }
+        dom.playersHeightNote.textContent = 'Height data unavailable.';
+      } else {
+        const labels = heightBuckets.map((bucket) => String(bucket.label || '').replace('"', '\u2033'));
+        const values = heightBuckets.map((bucket) => bucket.players ?? 0);
+        const totalPlayers = values.reduce((sum, value) => sum + value, 0);
+        const minHeight = snapshot.heightSummary?.minHeightInches;
+        const maxHeight = snapshot.heightSummary?.maxHeightInches;
+        dom.playersHeightNote.textContent = `Covers ${formatNumber(totalPlayers)} players with listed heights from ${formatFeetAndInches(minHeight)} to ${formatFeetAndInches(maxHeight)}.`;
+
+        if (!chartAvailable()) {
+          if (!dom.playersHeightNote.textContent.includes('Chart.js')) {
+            dom.playersHeightNote.textContent += ' Chart visualization unavailable—Chart.js did not load.';
+          }
+          return;
+        }
+
+        if (!playersHeightChart) {
+          playersHeightChart = new Chart(dom.playersHeightCanvas, {
+            type: 'bar',
+            data: {
+              labels,
+              datasets: [
+                {
+                  label: 'Players',
+                  data: values,
+                  backgroundColor: 'rgba(23, 105, 170, 0.65)',
+                  borderRadius: 6,
+                },
+              ],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              scales: {
+                x: { stacked: false },
+                y: {
+                  beginAtZero: true,
+                  ticks: { precision: 0 },
+                },
+              },
+              plugins: {
+                legend: { display: false },
+              },
+            },
+          });
+        } else {
+          playersHeightChart.data.labels = labels;
+          playersHeightChart.data.datasets[0].data = values;
+          playersHeightChart.update();
+        }
+      }
+    }
+
+    function renderHistoricGames() {
+      const snapshot = state.historicGames;
+      if (!snapshot) return;
+
+      const totals = snapshot.totals ?? {};
+      const cards = [];
+      if (totals.games) {
+        cards.push({ label: 'Games captured', value: formatNumber(totals.games) });
+      }
+      (totals.byType ?? []).slice(0, 3).forEach((entry) => {
+        cards.push({ label: `${entry.gameType} games`, value: formatNumber(entry.games ?? 0) });
+      });
+      if (totals.firstGame && totals.latestGame) {
+        cards.push({ label: 'Coverage', value: formatDateRange(totals.firstGame, totals.latestGame) });
+      }
+      dom.gamesSummary.innerHTML = cards
+        .map((card) => `
+          <div class="summary-card">
+            <h3>${card.label}</h3>
+            <p>${card.value}</p>
+          </div>
+        `)
+        .join('');
+
+      const generatedText = snapshot.generatedAt ? new Date(snapshot.generatedAt).toLocaleString() : '—';
+      dom.gamesNote.textContent = `Snapshot generated ${generatedText}.`;
+
+      const highest = snapshot.highestScoringGames ?? [];
+      dom.gamesHighestBody.innerHTML = highest.length > 0
+        ? highest
+            .slice(0, 10)
+            .map((game) => {
+              const meta = game.gameType ? `<span class="tallest-meta">${game.gameType}</span>` : '';
+              return `
+                <tr>
+                  <td>${formatDate(game.date)}</td>
+                  <td>${formatMatchup(game.home, game.away)}${meta}</td>
+                  <td>${formatNumber(game.totalPoints ?? 0)}</td>
+                </tr>
+              `;
+            })
+            .join('')
+        : '<tr><td colspan="3">No scoring highlights available.</td></tr>';
+
+      const margins = snapshot.largestMargins ?? [];
+      dom.gamesMarginsBody.innerHTML = margins.length > 0
+        ? margins
+            .slice(0, 10)
+            .map((game) => {
+              const extra = [formatMatchup(game.home, game.away)];
+              if (game.gameType) extra.push(game.gameType);
+              return `
+                <tr>
+                  <td>${formatDate(game.date)}</td>
+                  <td>${formatResult(game)}<span class="tallest-meta">${extra.join(' • ')}</span></td>
+                  <td>${formatNumber(game.margin ?? 0)}</td>
+                </tr>
+              `;
+            })
+            .join('')
+        : '<tr><td colspan="3">No margin data available.</td></tr>';
+
+      const attendance = snapshot.attendanceLeaders ?? [];
+      dom.gamesAttendanceBody.innerHTML = attendance.length > 0
+        ? attendance
+            .slice(0, 10)
+            .map((game) => {
+              const extra = [];
+              if (game.gameType) extra.push(game.gameType);
+              return `
+                <tr>
+                  <td>${formatDate(game.date)}</td>
+                  <td>${formatMatchup(game.home, game.away)}${extra.length ? ` <span class="tallest-meta">${extra.join(' • ')}</span>` : ''}</td>
+                  <td>${formatNumber(game.attendance ?? 0)}</td>
+                </tr>
+              `;
+            })
+            .join('')
+        : '<tr><td colspan="3">No attendance data available.</td></tr>';
+
+      const gamesByDecade = snapshot.gamesByDecade ?? [];
+      if (gamesByDecade.length === 0) {
+        if (gamesDecadeChart) {
+          gamesDecadeChart.destroy();
+          gamesDecadeChart = null;
+        }
+      } else {
+        const labels = gamesByDecade.map((entry) => entry.decade);
+        const values = gamesByDecade.map((entry) => entry.games ?? 0);
+        if (!chartAvailable()) {
+          if (!dom.gamesNote.textContent.includes('Chart.js')) {
+            dom.gamesNote.textContent += ' Chart visualization unavailable—Chart.js did not load.';
+          }
+          return;
+        }
+        if (!gamesDecadeChart) {
+          gamesDecadeChart = new Chart(dom.gamesDecadeCanvas, {
+            type: 'line',
+            data: {
+              labels,
+              datasets: [
+                {
+                  label: 'Games',
+                  data: values,
+                  fill: true,
+                  backgroundColor: 'rgba(23, 105, 170, 0.2)',
+                  borderColor: 'rgba(23, 105, 170, 0.7)',
+                  tension: 0.25,
+                },
+              ],
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { display: false },
+              },
+              scales: {
+                y: {
+                  beginAtZero: true,
+                  ticks: { precision: 0 },
+                },
+              },
+            },
+          });
+        } else {
+          gamesDecadeChart.data.labels = labels;
+          gamesDecadeChart.data.datasets[0].data = values;
+          gamesDecadeChart.update();
+        }
+      }
+    }
+
+    function renderTeamPerformance() {
+      const snapshot = state.teamPerformance;
+      if (!snapshot) return;
+
+      const generatedText = snapshot.generatedAt ? new Date(snapshot.generatedAt).toLocaleString() : '—';
+      dom.teamNote.textContent = `Snapshot generated ${generatedText}. Single-game highs use the team perspective from TeamStatistics.csv.`;
+
+      const leaders = snapshot.winPctLeaders ?? [];
+      const cards = [];
+      if (leaders.length > 0) {
+        cards.push({ label: 'Qualified franchises', value: formatNumber(leaders.length) });
+        const top = leaders[0];
+        cards.push({ label: 'Top win %', value: `${top.team} · ${formatPercent(top.winPct ?? 0, 1)}` });
+      }
+      const scoringTop = snapshot.singleGameHighs?.scoring?.[0];
+      if (scoringTop) {
+        cards.push({ label: 'Highest single-game score', value: `${scoringTop.team} · ${formatNumber(scoringTop.points ?? 0)}` });
+      }
+      dom.teamSummary.innerHTML = cards
+        .map((card) => `
+          <div class="summary-card">
+            <h3>${card.label}</h3>
+            <p>${card.value}</p>
+          </div>
+        `)
+        .join('');
+
+      dom.teamWinBody.innerHTML = leaders.length > 0
+        ? leaders
+            .slice(0, 12)
+            .map((team) => {
+              const meta = `PPG ${formatDecimal(team.pointsPerGame ?? 0, 1)} · OPP ${formatDecimal(team.opponentPointsPerGame ?? 0, 1)}`;
+              return `
+                <tr>
+                  <td><span class="team-name">${team.team}</span><span class="tallest-meta">${meta}</span></td>
+                  <td>${formatPercent(team.winPct ?? 0, 1)}</td>
+                  <td>${formatNumber(team.games ?? 0)}</td>
+                </tr>
+              `;
+            })
+            .join('')
+        : '<tr><td colspan="3">No qualifying teams found.</td></tr>';
+
+      const scoringHighs = snapshot.singleGameHighs?.scoring ?? [];
+      dom.teamScoringBody.innerHTML = scoringHighs.length > 0
+        ? scoringHighs
+            .slice(0, 10)
+            .map((game) => {
+              const metaParts = [formatDate(game.date)];
+              if (game.gameType) metaParts.push(game.gameType);
+              return `
+                <tr>
+                  <td><span class="team-name">${game.team}</span><span class="tallest-meta">${metaParts.join(' • ')}</span></td>
+                  <td>${game.opponent ? `<span class="team-name">${game.opponent}</span>` : '—'}</td>
+                  <td>${formatNumber(game.points ?? 0)}</td>
+                </tr>
+              `;
+            })
+            .join('')
+        : '<tr><td colspan="3">No scoring highs available.</td></tr>';
+
+      const assistHighs = snapshot.singleGameHighs?.assists ?? [];
+      dom.teamAssistsBody.innerHTML = assistHighs.length > 0
+        ? assistHighs
+            .slice(0, 10)
+            .map((game) => {
+              const metaParts = [formatDate(game.date)];
+              if (game.gameType) metaParts.push(game.gameType);
+              return `
+                <tr>
+                  <td><span class="team-name">${game.team}</span><span class="tallest-meta">${metaParts.join(' • ')}</span></td>
+                  <td>${game.opponent ? `<span class="team-name">${game.opponent}</span>` : '—'}</td>
+                  <td>${formatNumber(game.assists ?? 0)}</td>
+                </tr>
+              `;
+            })
+            .join('')
+        : '<tr><td colspan="3">No assist highs available.</td></tr>';
+    }
+
+    function renderPlayerLeaders() {
+      const snapshot = state.playerLeaders;
+      if (!snapshot) return;
+
+      const totals = snapshot.totals ?? {};
+      const cards = [
+        { label: 'Player stat lines', value: formatNumber(totals.playerGameRows ?? 0) },
+        { label: 'Players with tracked games', value: formatNumber(totals.playersWithStats ?? 0) },
+      ];
+      const coverage = totals.seasonCoverage ?? {};
+      if (coverage.start && coverage.end) {
+        cards.push({ label: 'Season coverage', value: `${coverage.start} – ${coverage.end}` });
+      }
+      dom.leadersSummary.innerHTML = cards
+        .map((card) => `
+          <div class="summary-card">
+            <h3>${card.label}</h3>
+            <p>${card.value}</p>
+          </div>
+        `)
+        .join('');
+
+      const generatedText = snapshot.generatedAt ? new Date(snapshot.generatedAt).toLocaleString() : '—';
+      dom.leadersNote.textContent = `Snapshot generated ${generatedText}. Career totals include every entry in PlayerStatistics.csv.`;
+
+      const careerPoints = snapshot.careerLeaders?.points ?? [];
+      const careerAssists = snapshot.careerLeaders?.assists ?? [];
+      const careerRebounds = snapshot.careerLeaders?.rebounds ?? [];
+      const singleGamePoints = snapshot.singleGameHighs?.points ?? [];
+      const singleGameAssists = snapshot.singleGameHighs?.assists ?? [];
+      const singleGameRebounds = snapshot.singleGameHighs?.rebounds ?? [];
+
+      const avgKeyMap = {
+        points: 'pointsPerGame',
+        assists: 'assistsPerGame',
+        rebounds: 'reboundsPerGame',
+      };
+
+      function renderCareerTable(body, players, statKey) {
+        const avgKey = avgKeyMap[statKey];
+        if (!body) return;
+        if (!players || players.length === 0) {
+          body.innerHTML = '<tr><td colspan="3">No leaderboard data available.</td></tr>';
+          return;
+        }
+        body.innerHTML = players
+          .slice(0, 12)
+          .map((player) => {
+            const metaParts = [];
+            if (player[avgKey]) metaParts.push(`${statKey.toUpperCase()} PG ${formatDecimal(player[avgKey], 1)}`);
+            if (player.firstSeason && player.lastSeason) metaParts.push(`${player.firstSeason}–${player.lastSeason}`);
+            if (player.teams && player.teams.length > 0) metaParts.push(player.teams.join(' • '));
+            return `
+              <tr>
+                <td><span class="team-name">${player.name}</span><span class="tallest-meta">${metaParts.join(' • ')}</span></td>
+                <td>${formatNumber(Math.round(player[statKey] ?? 0))}</td>
+                <td>${formatNumber(player.games ?? 0)}</td>
+              </tr>
+            `;
+          })
+          .join('');
+      }
+
+      function renderSingleGameTable(body, games, statKey) {
+        if (!body) return;
+        if (!games || games.length === 0) {
+          body.innerHTML = '<tr><td colspan="3">No single-game records available.</td></tr>';
+          return;
+        }
+        body.innerHTML = games
+          .slice(0, 12)
+          .map((game) => {
+            const metaParts = [];
+            if (game.team) metaParts.push(game.team);
+            if (game.opponent) metaParts.push(`vs ${game.opponent}`);
+            if (game.gameType) metaParts.push(game.gameType);
+            if (game.minutes) metaParts.push(`${formatDecimal(game.minutes, 1)} min`);
+            return `
+              <tr>
+                <td><span class="team-name">${game.name}</span><span class="tallest-meta">${metaParts.join(' • ')}</span></td>
+                <td>${formatNumber(Math.round(game[statKey] ?? 0))}</td>
+                <td>${formatDate(game.gameDate)}</td>
+              </tr>
+            `;
+          })
+          .join('');
+      }
+
+      renderCareerTable(dom.leadersCareerPoints, careerPoints, 'points');
+      renderCareerTable(dom.leadersCareerAssists, careerAssists, 'assists');
+      renderCareerTable(dom.leadersCareerRebounds, careerRebounds, 'rebounds');
+      renderSingleGameTable(dom.leadersGamePoints, singleGamePoints, 'points');
+      renderSingleGameTable(dom.leadersGameAssists, singleGameAssists, 'assists');
+      renderSingleGameTable(dom.leadersGameRebounds, singleGameRebounds, 'rebounds');
+    }
+
+    function applyFilters() {
+      const searchTerm = dom.search.value.trim().toLowerCase();
+      const selectedLeague = dom.league.value;
+      const minSeason = Number.parseInt(dom.seasonStart.value, 10);
+      const maxSeason = Number.parseInt(dom.seasonEnd.value, 10);
+
+      state.filtered = state.raw.filter((team) => {
+        const matchesLeague = !selectedLeague || team.league === selectedLeague;
+        if (!matchesLeague) return false;
+
+        if (Number.isInteger(minSeason) && typeof team.seasonFounded === 'number') {
+          if (team.seasonFounded < minSeason) return false;
+        }
+        if (Number.isInteger(maxSeason) && typeof team.seasonFounded === 'number') {
+          if (team.seasonFounded > maxSeason) return false;
+        }
+
+        if (searchTerm.length > 0) {
+          const haystack = `${team.city} ${team.name} ${team.abbreviation}`.toLowerCase();
+          if (!haystack.includes(searchTerm)) return false;
+        }
+        return true;
+      });
+
+      renderTable(state.filtered);
+      buildSummary(state.filtered);
+      renderChart(state.filtered);
+    }
+
+    function resetFilters() {
+      if (!state.snapshot) return;
+      dom.search.value = '';
+      dom.league.value = '';
+      dom.seasonStart.value = state.snapshot.earliestSeason ?? '';
+      dom.seasonEnd.value = state.snapshot.currentYear ?? '';
+      applyFilters();
+    }
+
+    function hydrateControls(snapshot) {
+      dom.seasonStart.min = snapshot.earliestSeason ?? '';
+      dom.seasonStart.max = snapshot.currentYear ?? '';
+      dom.seasonEnd.min = snapshot.earliestSeason ?? '';
+      dom.seasonEnd.max = snapshot.currentYear ?? '';
+      dom.seasonStart.value = snapshot.earliestSeason ?? '';
+      dom.seasonEnd.value = snapshot.currentYear ?? '';
+
+      dom.league.innerHTML = '<option value="">All leagues</option>' + snapshot.leagues
+        .map((league) => `<option value="${league}">${league}</option>`)
+        .join('');
+
+      dom.league.value = '';
+    }
+
+    async function loadData() {
+      try {
+        const snapshot = await fetchJson('data/active_franchises.json', 'franchise snapshot');
+        state.snapshot = snapshot;
+        state.raw = snapshot.activeFranchises;
+        const totalFranchises = formatNumber(snapshot.totals?.all ?? state.raw.length);
+        const totalNbaFranchises = snapshot.totals?.nba ? ` (${formatNumber(snapshot.totals.nba)} NBA)` : '';
+        dom.generatedNote.textContent = `Snapshot generated ${new Date(snapshot.generatedAt).toLocaleString()} · ${totalFranchises} franchises active today${totalNbaFranchises}.`;
+        hydrateControls(snapshot);
+        applyFilters();
+      } catch (error) {
+        console.error(error);
+        dom.generatedNote.textContent = 'Unable to load franchise snapshot. Please refresh to try again.';
+      }
+    }
+
+    async function loadSchedule() {
+      const fallbackScheduleFiles = [
+        { path: 'data/season_24_25_schedule.json', label: '2024-25' },
+        { path: 'data/season_25_26_schedule.json', label: '2025-26' },
+      ];
+
+      let scheduleFiles = fallbackScheduleFiles;
+
+      try {
+        const manifest = await fetchJson('data/schedule_manifest.json', 'schedule manifest');
+        if (Array.isArray(manifest?.seasons)) {
+          const normalized = manifest.seasons
+            .map((season) => {
+              if (!season) return null;
+              if (typeof season === 'string') {
+                return { path: season, label: season };
+              }
+              if (typeof season === 'object' && typeof season.path === 'string' && season.path.length > 0) {
+                const label = typeof season.label === 'string' && season.label.length > 0 ? season.label : season.path;
+                return { path: season.path, label };
+              }
+              return null;
+            })
+            .filter(Boolean);
+          if (normalized.length > 0) {
+            scheduleFiles = normalized;
+          }
+        }
+      } catch (error) {
+        console.warn('Unable to load schedule manifest. Falling back to default schedule list.', error);
+      }
+
+      let lastError = null;
+      for (const file of scheduleFiles) {
+        try {
+          const schedule = await fetchJson(file.path, `${file.label} schedule snapshot`);
+          state.schedule = schedule;
+          renderScheduleSummary();
+          renderScheduleChart();
+          renderScheduleTeams();
+          renderScheduleRest();
+          renderScheduleBackToBack();
+          renderScheduleSpecials();
+          return;
+        } catch (error) {
+          console.warn(`Unable to load schedule from ${file.path}`, error);
+          lastError = error;
+        }
+      }
+
+      console.error(lastError);
+      dom.scheduleNote.textContent = 'Unable to load the latest schedule snapshot. Please refresh to try again.';
+      dom.scheduleSummary.innerHTML = '';
+      dom.scheduleTeamsBody.innerHTML = '<tr><td colspan="5">Schedule data unavailable.</td></tr>';
+      dom.scheduleSpecialList.innerHTML = '<li>Schedule data unavailable.</li>';
+      dom.scheduleRestNote.textContent = 'Rest distribution unavailable.';
+      dom.scheduleBackToBackBody.innerHTML = '<tr><td colspan="4">Schedule data unavailable.</td></tr>';
+      if (scheduleChart) {
+        scheduleChart.destroy();
+        scheduleChart = null;
+      }
+      if (scheduleRestChart) {
+        scheduleRestChart.destroy();
+        scheduleRestChart = null;
+      }
+    }
+
+    async function loadPlayersOverview() {
+      try {
+        state.playersOverview = await fetchJson('data/players_overview.json', 'players overview snapshot');
+        renderPlayersOverview();
+      } catch (error) {
+        console.error(error);
+        state.playersOverview = null;
+        dom.playersNote.textContent = 'Unable to load player overview snapshot. Please refresh to try again.';
+        dom.playersSummary.innerHTML = '';
+        dom.playersCountriesBody.innerHTML = '<tr><td colspan="2">Player snapshot unavailable.</td></tr>';
+        dom.playersCollegesBody.innerHTML = '<tr><td colspan="2">Player snapshot unavailable.</td></tr>';
+        dom.playersTallestList.innerHTML = '<li>Player snapshot unavailable.</li>';
+        dom.playersHeightNote.textContent = 'Height data unavailable.';
+        dom.playersDraftNote.textContent = 'Draft snapshot unavailable.';
+        dom.playersDraftDecadesBody.innerHTML = '<tr><td colspan="2">Player snapshot unavailable.</td></tr>';
+        if (playersHeightChart) {
+          playersHeightChart.destroy();
+          playersHeightChart = null;
+        }
+        if (playersDraftChart) {
+          playersDraftChart.destroy();
+          playersDraftChart = null;
+        }
+      }
+    }
+
+    async function loadHistoricGames() {
+      try {
+        state.historicGames = await fetchJson('data/historic_games.json', 'historical game snapshot');
+        renderHistoricGames();
+      } catch (error) {
+        console.error(error);
+        state.historicGames = null;
+        dom.gamesNote.textContent = 'Unable to load historical game insights. Please refresh to try again.';
+        dom.gamesSummary.innerHTML = '';
+        dom.gamesHighestBody.innerHTML = '<tr><td colspan="3">Historical game snapshot unavailable.</td></tr>';
+        dom.gamesMarginsBody.innerHTML = '<tr><td colspan="3">Historical game snapshot unavailable.</td></tr>';
+        dom.gamesAttendanceBody.innerHTML = '<tr><td colspan="3">Historical game snapshot unavailable.</td></tr>';
+        if (gamesDecadeChart) {
+          gamesDecadeChart.destroy();
+          gamesDecadeChart = null;
+        }
+      }
+    }
+
+    async function loadTeamPerformance() {
+      try {
+        state.teamPerformance = await fetchJson('data/team_performance.json', 'team performance snapshot');
+        renderTeamPerformance();
+      } catch (error) {
+        console.error(error);
+        state.teamPerformance = null;
+        dom.teamNote.textContent = 'Unable to load team performance snapshot. Please refresh to try again.';
+        dom.teamSummary.innerHTML = '';
+        dom.teamWinBody.innerHTML = '<tr><td colspan="3">Team snapshot unavailable.</td></tr>';
+        dom.teamScoringBody.innerHTML = '<tr><td colspan="3">Team snapshot unavailable.</td></tr>';
+        dom.teamAssistsBody.innerHTML = '<tr><td colspan="3">Team snapshot unavailable.</td></tr>';
+      }
+    }
+
+    async function loadPlayerLeaders() {
+      try {
+        state.playerLeaders = await fetchJson('data/player_leaders.json', 'player leaders snapshot');
+        renderPlayerLeaders();
+      } catch (error) {
+        console.error(error);
+        state.playerLeaders = null;
+        dom.leadersNote.textContent = 'Unable to load player leaderboards. Please refresh to try again.';
+        dom.leadersSummary.innerHTML = '';
+        dom.leadersCareerPoints.innerHTML = '<tr><td colspan="3">Player leaderboard unavailable.</td></tr>';
+        dom.leadersCareerAssists.innerHTML = '<tr><td colspan="3">Player leaderboard unavailable.</td></tr>';
+        dom.leadersCareerRebounds.innerHTML = '<tr><td colspan="3">Player leaderboard unavailable.</td></tr>';
+        dom.leadersGamePoints.innerHTML = '<tr><td colspan="3">Player leaderboard unavailable.</td></tr>';
+        dom.leadersGameAssists.innerHTML = '<tr><td colspan="3">Player leaderboard unavailable.</td></tr>';
+        dom.leadersGameRebounds.innerHTML = '<tr><td colspan="3">Player leaderboard unavailable.</td></tr>';
+      }
+    }
+
+    dom.search.addEventListener('input', () => applyFilters());
+    dom.league.addEventListener('change', () => applyFilters());
+    dom.seasonStart.addEventListener('change', () => applyFilters());
+    dom.seasonEnd.addEventListener('change', () => applyFilters());
+    dom.reset.addEventListener('click', () => resetFilters());
+
+    loadData();
+    loadSchedule();
+    loadPlayersOverview();
+    loadHistoricGames();
+    loadTeamPerformance();
+    loadPlayerLeaders();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Refresh the landing page header with a primary navigation bar and updated hero copy for the NBA Intelligence Hub.
- Bring the schedule, player, historic game, team benchmark, and leaderboard dashboards from the explorer into `index.html` so the hub covers the full data surface.
- Load the existing snapshot JSON feeds and Chart.js visualizations on the landing page to keep all sections interactive.

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d821f3aeec83279857282b56ab20d7