### PR TITLE
Add inline favicon to prevent missing resource error

### DIFF
--- a/public/franchise-explorer.html
+++ b/public/franchise-explorer.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231156d6'/%3E%3Ctext x='50%25' y='52%25' font-family='Inter,Arial,sans-serif' font-size='28' font-weight='700' fill='white' text-anchor='middle'%3ENBA%3C/text%3E%3C/svg%3E"
+  />
   <title>NBA Franchise Explorer</title>
   <style>
     :root {

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link
+    rel="icon"
+    type="image/svg+xml"
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231156d6'/%3E%3Ctext x='50%25' y='52%25' font-family='Inter,Arial,sans-serif' font-size='28' font-weight='700' fill='white' text-anchor='middle'%3ENBA%3C/text%3E%3C/svg%3E"
+  />
   <title>NBA Intelligence Hub</title>
   <style>
     :root {


### PR DESCRIPTION
## Summary
- add an inline SVG favicon to the NBA Intelligence Hub homepage
- reuse the same favicon on the franchise explorer page to stop 404 errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d827c7b820832789a389447c553bdf