### PR TITLE
Remove non-NBA and non-ABA franchise data

### DIFF
--- a/TeamHistories.csv
+++ b/TeamHistories.csv
@@ -1,9 +1,7 @@
 teamId,teamCity,teamName,teamAbbrev,seasonFounded,seasonActiveTill,league
-1610612737,Tri-Cities,Blackhawks,TRI  ,1946,1948,BAA
 1610612737,Milwaukee,Hawks,MIL  ,1951,1954,NBA
 1610612737,St. Louis,Hawks,STL  ,1955,1967,NBA
 1610612737,Atlanta,Hawks,ATL  ,1968,2100,NBA
-1610612738,Boston,Celtics,BOS  ,1946,1948,BAA
 1610612739,Cleveland,Cavaliers,CLE  ,1970,2100,NBA
 1610612740,New Orleans,Hornets,NOH  ,2002,2004,NBA
 1610612740,Oklahoma City,Hornets,NOK  ,2005,2006,NBA
@@ -12,7 +10,6 @@ teamId,teamCity,teamName,teamAbbrev,seasonFounded,seasonActiveTill,league
 1610612741,Chicago,Bulls,CHI  ,1966,2100,NBA
 1610612742,Dallas,Mavericks,DAL  ,1980,2100,NBA
 1610612743,Denver,Nuggets,DEN  ,1976,2100,NBA
-1610612744,Philadelphia,Warriors,PHI  ,1946,1948,BAA
 1610612744,San Francisco,Warriors,SF   ,1962,1970,NBA
 1610612744,Golden State,Warriors,GSW  ,1971,2100,NBA
 1610612745,San Diego,Rockets,SD   ,1967,1970,NBA
@@ -20,7 +17,6 @@ teamId,teamCity,teamName,teamAbbrev,seasonFounded,seasonActiveTill,league
 1610612746,Buffalo,Braves,BUF  ,1970,1977,NBA
 1610612746,San Diego,Clippers,SDC  ,1978,1983,NBA
 1610612746,Los Angeles,Clippers,LAC  ,1984,2100,NBA
-1610612747,Minneapolis,Lakers,MIN  ,1948,1948,BAA
 1610612747,Los Angeles,Lakers,LAL  ,1960,2100,NBA
 1610612748,Miami,Heat,MIA  ,1988,2100,NBA
 1610612749,Milwaukee,Bucks,MIL  ,1968,2100,NBA
@@ -28,14 +24,11 @@ teamId,teamCity,teamName,teamAbbrev,seasonFounded,seasonActiveTill,league
 1610612751,New York,Nets,NYK  ,1976,1976,NBA
 1610612751,New Jersey,Nets,NJ   ,1977,2011,NBA
 1610612751,Brooklyn,Nets,BKN  ,2012,2100,NBA
-1610612752,New York,Knicks,NYK  ,1946,1948,BAA
 1610612753,Orlando,Magic,ORL  ,1989,2100,NBA
 1610612754,Indiana,Pacers,IND  ,1976,2100,NBA
-1610612755,Syracuse,Nationals,SYR  ,1949,1962,BAA
 1610612755,Philadelphia,76ers,PHI  ,1963,2100,NBA
 1610612756,Phoenix,Suns,PHX  ,1968,2100,NBA
 1610612757,Portland,Trail Blazers,POR  ,1970,2100,NBA
-1610612758,Rochester,Royals,ROC  ,1948,1948,BAA
 1610612758,Cincinnati,Royals,CIN  ,1957,1971,NBA
 1610612758,Kansas City-Omaha,Kings,KCO  ,1972,1974,NBA
 1610612758,Kansas City,Kings,KC   ,1975,1984,NBA
@@ -54,88 +47,27 @@ teamId,teamCity,teamName,teamAbbrev,seasonFounded,seasonActiveTill,league
 1610612764,Capital,Bullets,CAP  ,1973,1973,NBA
 1610612764,Washington,Bullets,WAS  ,1974,1996,NBA
 1610612764,Washington,Wizards,WAS  ,1997,2100,NBA
-1610612765,Ft. Wayne Zollner,Pistons,FWZ  ,1948,1948,BAA
 1610612765,Detroit,Pistons,DET  ,1957,2100,NBA
 1610612766,Charlotte,Hornets,CHA  ,1988,2001,NBA
 1610612766,Charlotte,Bobcats,CHA  ,2004,2013,NBA
 1610612766,Charlotte,Hornets,CHA  ,2014,2100,NBA
-9001,Pittsburgh,Ironmen,PIT  ,1946,1948,BAA
 1610612738,Boston,Celtics,BOS  ,1949,2100,NBA
-9003,Siena,Montepaschi Siena,MPS  ,1934,2100,LBA
-9005,Rome,Lottomatica Roma,LRO  ,1960,2020,LBA
 1610612747,Minneapolis,Lakers,LAL  ,1949,1959,NBA
-9007,Beijing,Ducks,BJD  ,1995,2100,CBA
-9009,Athens,Olympiacos,OLP  ,1931,2100,EuroLeague
 1610612758,Rochester,Royals,ROC  ,1949,1956,NBA
-9011,Istanbul,Efes Pilsen,EPT  ,1976,2100,EuroLeague
 1610612765,Ft. Wayne Zollner,Pistons,FWZ  ,1949,1956,NBA
 9013,All-Star,Team Durant,DRT  ,2021,2022,NBA
 9015,Washington,Capitols,WAS  ,1949,1949,NBA
-9015,Washington,Capitols,WAS  ,1946,1948,BAA
 9059,Chicago,Stags,CHS  ,1949,1950,NBA
-9017,Cleveland,Rebels,CLR  ,1946,1948,BAA
 9063,Sheboygan,Redskins,SHE  ,1949,1950,NBA
-9019,Shanghai,Sharks,SDS  ,1996,2100,CBA
 9012,St. Louis,Bombers,BOM  ,1949,1950,NBA
-9021,Rome,Virtus Lottomatica,ROM  ,1960,2020,LBA
 9028,Anderson,Packers,AND  ,1949,1950,NBA
-9023,Istanbul,Fenerbahce,FEN  ,1913,2100,EuroLeague
 1610612752,New York,Knicks,NYK  ,1949,2100,NBA
 9025,All-Star,Team Giannis,GNS  ,2019,2023,NBA
 1610612744,Philadelphia,Warriors,PHI  ,1949,1961,NBA
-9027,Adelaide,36ers,ADL  ,1982,2100,NBL
-9029,Auckland,Breakers,NZB  ,2003,2100,NBL
-9031,Istanbul,Fenerbahce Ulker,FBU  ,2006,2015,EuroLeague
 9033,East,NBA All-Stars,EST  ,1951,2100,NBA
-9035,Athens,Panathinaikos,PAN  ,1919,2100,EuroLeague
-9037,Cairns,Taipans,CNS  ,1999,2100,NBL
 9039,All-Star,Team LeBron,LBN  ,2018,2100,NBA
-9041,Barcelona,Regal FC Barcelona,BAR  ,2011,2013,EuroLeague
 9043,All-Star,Team Giannis,GNS  ,2019,2100,NBA
-9045,Bilbao,Bilbao Basket,UBB  ,2000,2100,EuroCup
-9047,Madrid,Real Madrid,RMA  ,1931,2100,EuroLeague
-9049,Buenos Aires,San Lorenzo,SLA  ,1936,2100,Liga Nacional
-1610612755,Syracuse,Nationals,SYR  ,1946,1948,NBL
-9051,Haifa,Maccabi Haifa,MAC  ,1953,2100,Israeli Premier League
 1610612737,Tri-Cities,Blackhawks,TRI  ,1948,1950,NBA
-9053,Madrid,Baloncesto (Real Madrid),RMD  ,1931,2100,EuroLeague
-9055,Milan,EA7 Emporio Armani Milano,EAM  ,2011,2019,EuroLeague
-9057,Shanghai,Shanghai Sharks,SDS  ,1996,2100,CBA
-9059,Chicago,Stags,CHS  ,1946,1948,BAA
-9061,Moscow,CSKA,MOS  ,1923,2100,EuroLeague
-9063,Sheboygan,Redskins,SHE  ,1938,1948,BAA
-9065,Madrid,Real Madrid,RMD  ,1931,2100,EuroLeague
 9067,West,NBA All-Stars,WST  ,1951,2100,NBA
-9002,Waterloo,Hawks,WAT  ,1949,1948,NBL
-9004,Barcelona,FC Barcelona Regal,FCB  ,1926,2100,EuroLeague
-9006,Belgrade,Partizan,PAR  ,1945,2100,EuroLeague
-9008,Indianapolis,Jets,JET  ,1948,1948,BAA
-9010,Khimki,BC Khimki,KHI  ,1997,2100,VTB United League
-9012,St. Louis,Bombers,BOM  ,1946,1948,BAA
-9014,Franca (Brazil),SESI/Franca,FRA  ,1959,2100,NBB
-9016,Brisbane,Bullets,BNE  ,1979,2100,NBL
-9018,Vilnius,Lietuvos Rytas,LRY  ,1997,2100,EuroCup
-9020,Detroit,Falcons,DEF  ,1946,1948,BAA
-9022,Barcelona,Winterthur FC Barcelona,BAR  ,2005,2007,EuroLeague
-9024,Vitoria-Gasteiz,Caja Laboral (Baskonia),LAB  ,2009,2013,Liga ACB
-9026,Lyon-Villeurbanne,Adecco ASVEL,LYV  ,1948,2100,EuroLeague
-9028,Anderson,Packers,AND  ,1946,1948,NBL
-9030,Milan,Armani Jeans Milano,MLN  ,2008,2011,EuroLeague
-9032,Perth,Wildcats,PER  ,1982,2100,NBL
-9034,Sydney,Kings,SYD  ,1988,2100,NBL
-9036,China,Team China,CHN  ,1936,2100,CBA
-9038,Malaga,Unicaja,MAL  ,1977,2100,EuroCup
 9040,All-Star,All-Star LeBron,LBN  ,2018,2100,NBA
-9042,Toronto,Huskies,HUS  ,1946,1948,BAA
-9044,Berlin,ALBA Berlin,ALB  ,1991,2100,EuroLeague
-9046,Madrid,MMT Estudiantes,MMT  ,2007,2011,EuroLeague
-9048,Guangzhou,Long-Lions,GUA  ,2010,2100,CBA
-9050,Melbourne,United,MEL  ,2014,2100,NBL
-9052,Tel Aviv,Maccabi Elite,MTA  ,1969,2008,EuroLeague
-9054,Tel Aviv,Maccabi Electra,MTA  ,2008,2015,EuroLeague
-9056,Providence,Steamrollers,PRO  ,1946,1948,BAA
-9058,Indianapolis,Olympians,INO  ,1949,1948,BAA
-9060,Rio de Janeiro,Flamengo,FLA  ,1919,2100,Liga Nacional
 9062,All-Star,Team Stephen,STP  ,2018,2018,NBA
-9064,Kaunas,Zalgiris,ZAK  ,1944,2100,EuroLeague
-9066,Raanana,Maccabi Ra anana,MRA  ,1980,2100,Israeli Premier League

--- a/public/data/active_franchises.json
+++ b/public/data/active_franchises.json
@@ -2,174 +2,16 @@
   "generatedAt": "2025-09-27T14:20:25.406Z",
   "currentYear": 2025,
   "totals": {
-    "all": 70,
-    "nba": 35
+    "all": 35,
+    "nba": 35,
+    "aba": 0
   },
   "leagues": [
-    "CBA",
-    "EuroCup",
-    "EuroLeague",
-    "Israeli Premier League",
-    "LBA",
-    "Liga Nacional",
-    "NBA",
-    "NBB",
-    "NBL",
-    "VTB United League"
+    "NBA"
   ],
-  "earliestSeason": 1913,
-  "latestSeason": 2019,
+  "earliestSeason": 1949,
+  "latestSeason": 2100,
   "activeFranchises": [
-    {
-      "teamId": "9023",
-      "city": "Istanbul",
-      "name": "Fenerbahce",
-      "abbreviation": "FEN",
-      "league": "EuroLeague",
-      "seasonFounded": 1913,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9060",
-      "city": "Rio de Janeiro",
-      "name": "Flamengo",
-      "abbreviation": "FLA",
-      "league": "Liga Nacional",
-      "seasonFounded": 1919,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9035",
-      "city": "Athens",
-      "name": "Panathinaikos",
-      "abbreviation": "PAN",
-      "league": "EuroLeague",
-      "seasonFounded": 1919,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9061",
-      "city": "Moscow",
-      "name": "CSKA",
-      "abbreviation": "MOS",
-      "league": "EuroLeague",
-      "seasonFounded": 1923,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9004",
-      "city": "Barcelona",
-      "name": "FC Barcelona Regal",
-      "abbreviation": "FCB",
-      "league": "EuroLeague",
-      "seasonFounded": 1926,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9053",
-      "city": "Madrid",
-      "name": "Baloncesto (Real Madrid)",
-      "abbreviation": "RMD",
-      "league": "EuroLeague",
-      "seasonFounded": 1931,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9009",
-      "city": "Athens",
-      "name": "Olympiacos",
-      "abbreviation": "OLP",
-      "league": "EuroLeague",
-      "seasonFounded": 1931,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9047",
-      "city": "Madrid",
-      "name": "Real Madrid",
-      "abbreviation": "RMA",
-      "league": "EuroLeague",
-      "seasonFounded": 1931,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9065",
-      "city": "Madrid",
-      "name": "Real Madrid",
-      "abbreviation": "RMD",
-      "league": "EuroLeague",
-      "seasonFounded": 1931,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9003",
-      "city": "Siena",
-      "name": "Montepaschi Siena",
-      "abbreviation": "MPS",
-      "league": "LBA",
-      "seasonFounded": 1934,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9049",
-      "city": "Buenos Aires",
-      "name": "San Lorenzo",
-      "abbreviation": "SLA",
-      "league": "Liga Nacional",
-      "seasonFounded": 1936,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9036",
-      "city": "China",
-      "name": "Team China",
-      "abbreviation": "CHN",
-      "league": "CBA",
-      "seasonFounded": 1936,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9064",
-      "city": "Kaunas",
-      "name": "Zalgiris",
-      "abbreviation": "ZAK",
-      "league": "EuroLeague",
-      "seasonFounded": 1944,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9006",
-      "city": "Belgrade",
-      "name": "Partizan",
-      "abbreviation": "PAR",
-      "league": "EuroLeague",
-      "seasonFounded": 1945,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9026",
-      "city": "Lyon-Villeurbanne",
-      "name": "Adecco ASVEL",
-      "abbreviation": "LYV",
-      "league": "EuroLeague",
-      "seasonFounded": 1948,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
     {
       "teamId": "1610612738",
       "city": "Boston",
@@ -211,32 +53,12 @@
       "isActive": true
     },
     {
-      "teamId": "9051",
-      "city": "Haifa",
-      "name": "Maccabi Haifa",
-      "abbreviation": "MAC",
-      "league": "Israeli Premier League",
-      "seasonFounded": 1953,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612765",
       "city": "Detroit",
       "name": "Pistons",
       "abbreviation": "DET",
       "league": "NBA",
       "seasonFounded": 1957,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9014",
-      "city": "Franca (Brazil)",
-      "name": "SESI/Franca",
-      "abbreviation": "FRA",
-      "league": "NBB",
-      "seasonFounded": 1959,
       "seasonActiveTill": 2100,
       "isActive": true
     },
@@ -341,16 +163,6 @@
       "isActive": true
     },
     {
-      "teamId": "9011",
-      "city": "Istanbul",
-      "name": "Efes Pilsen",
-      "abbreviation": "EPT",
-      "league": "EuroLeague",
-      "seasonFounded": 1976,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612743",
       "city": "Denver",
       "name": "Nuggets",
@@ -381,26 +193,6 @@
       "isActive": true
     },
     {
-      "teamId": "9038",
-      "city": "Malaga",
-      "name": "Unicaja",
-      "abbreviation": "MAL",
-      "league": "EuroCup",
-      "seasonFounded": 1977,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9016",
-      "city": "Brisbane",
-      "name": "Bullets",
-      "abbreviation": "BNE",
-      "league": "NBL",
-      "seasonFounded": 1979,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612762",
       "city": "Utah",
       "name": "Jazz",
@@ -411,42 +203,12 @@
       "isActive": true
     },
     {
-      "teamId": "9066",
-      "city": "Raanana",
-      "name": "Maccabi Ra anana",
-      "abbreviation": "MRA",
-      "league": "Israeli Premier League",
-      "seasonFounded": 1980,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612742",
       "city": "Dallas",
       "name": "Mavericks",
       "abbreviation": "DAL",
       "league": "NBA",
       "seasonFounded": 1980,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9027",
-      "city": "Adelaide",
-      "name": "36ers",
-      "abbreviation": "ADL",
-      "league": "NBL",
-      "seasonFounded": 1982,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9032",
-      "city": "Perth",
-      "name": "Wildcats",
-      "abbreviation": "PER",
-      "league": "NBL",
-      "seasonFounded": 1982,
       "seasonActiveTill": 2100,
       "isActive": true
     },
@@ -481,16 +243,6 @@
       "isActive": true
     },
     {
-      "teamId": "9034",
-      "city": "Sydney",
-      "name": "Kings",
-      "abbreviation": "SYD",
-      "league": "NBL",
-      "seasonFounded": 1988,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612753",
       "city": "Orlando",
       "name": "Magic",
@@ -511,72 +263,12 @@
       "isActive": true
     },
     {
-      "teamId": "9044",
-      "city": "Berlin",
-      "name": "ALBA Berlin",
-      "abbreviation": "ALB",
-      "league": "EuroLeague",
-      "seasonFounded": 1991,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9007",
-      "city": "Beijing",
-      "name": "Ducks",
-      "abbreviation": "BJD",
-      "league": "CBA",
-      "seasonFounded": 1995,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612761",
       "city": "Toronto",
       "name": "Raptors",
       "abbreviation": "TOR",
       "league": "NBA",
       "seasonFounded": 1995,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9057",
-      "city": "Shanghai",
-      "name": "Shanghai Sharks",
-      "abbreviation": "SDS",
-      "league": "CBA",
-      "seasonFounded": 1996,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9019",
-      "city": "Shanghai",
-      "name": "Sharks",
-      "abbreviation": "SDS",
-      "league": "CBA",
-      "seasonFounded": 1996,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9010",
-      "city": "Khimki",
-      "name": "BC Khimki",
-      "abbreviation": "KHI",
-      "league": "VTB United League",
-      "seasonFounded": 1997,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9018",
-      "city": "Vilnius",
-      "name": "Lietuvos Rytas",
-      "abbreviation": "LRY",
-      "league": "EuroCup",
-      "seasonFounded": 1997,
       "seasonActiveTill": 2100,
       "isActive": true
     },
@@ -591,26 +283,6 @@
       "isActive": true
     },
     {
-      "teamId": "9037",
-      "city": "Cairns",
-      "name": "Taipans",
-      "abbreviation": "CNS",
-      "league": "NBL",
-      "seasonFounded": 1999,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9045",
-      "city": "Bilbao",
-      "name": "Bilbao Basket",
-      "abbreviation": "UBB",
-      "league": "EuroCup",
-      "seasonFounded": 2000,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612763",
       "city": "Memphis",
       "name": "Grizzlies",
@@ -621,32 +293,12 @@
       "isActive": true
     },
     {
-      "teamId": "9029",
-      "city": "Auckland",
-      "name": "Breakers",
-      "abbreviation": "NZB",
-      "league": "NBL",
-      "seasonFounded": 2003,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
       "teamId": "1610612760",
       "city": "Oklahoma City",
       "name": "Thunder",
       "abbreviation": "OKC",
       "league": "NBA",
       "seasonFounded": 2008,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9048",
-      "city": "Guangzhou",
-      "name": "Long-Lions",
-      "abbreviation": "GUA",
-      "league": "CBA",
-      "seasonFounded": 2010,
       "seasonActiveTill": 2100,
       "isActive": true
     },
@@ -676,16 +328,6 @@
       "name": "Hornets",
       "abbreviation": "CHA",
       "league": "NBA",
-      "seasonFounded": 2014,
-      "seasonActiveTill": 2100,
-      "isActive": true
-    },
-    {
-      "teamId": "9050",
-      "city": "Melbourne",
-      "name": "United",
-      "abbreviation": "MEL",
-      "league": "NBL",
       "seasonFounded": 2014,
       "seasonActiveTill": 2100,
       "isActive": true
@@ -723,24 +365,12 @@
   ],
   "decades": [
     {
-      "decade": 1910,
-      "total": 3
-    },
-    {
-      "decade": 1920,
+      "decade": 1940,
       "total": 2
     },
     {
-      "decade": 1930,
-      "total": 7
-    },
-    {
-      "decade": 1940,
-      "total": 5
-    },
-    {
       "decade": 1950,
-      "total": 5
+      "total": 3
     },
     {
       "decade": 1960,
@@ -748,23 +378,23 @@
     },
     {
       "decade": 1970,
-      "total": 11
+      "total": 8
     },
     {
       "decade": 1980,
-      "total": 10
+      "total": 6
     },
     {
       "decade": 1990,
-      "total": 9
+      "total": 2
     },
     {
       "decade": 2000,
-      "total": 4
+      "total": 2
     },
     {
       "decade": 2010,
-      "total": 8
+      "total": 6
     }
   ]
 }


### PR DESCRIPTION
## Summary
- filter the active franchise dataset down to NBA/ABA teams only and recompute supporting metadata
- strip non-NBA/ABA league entries from the historical team data export

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d82b08096c83278d426cde46bf1ccd