### PR TITLE
Add Phase 2 chart infrastructure and prototypes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,37 +67,45 @@
         </section>
 
         <section>
-          <h2>Featured canvases in development</h2>
-          <div class="grid-two">
-            <div class="subsection">
-              <h3>Dynamic player journeys</h3>
-              <p>
-                Follow athletes from draft night to All-NBA status with interconnected timelines,
-                contract evolutions, and advanced shot maps. Future releases will pair spatial
-                visualizations with video context.
-              </p>
-              <div class="badge-list">
-                <span class="badge">Career arcs</span>
-                <span class="badge">Shot charts</span>
-                <span class="badge">Contract trends</span>
+          <h2>Visual infrastructure prototypes</h2>
+          <p class="lead">
+            Phase 2 introduces reusable chart primitives that hydrate on demand, respect
+            performance budgets, and surface the latest league data without overwhelming the
+            browser.
+          </p>
+          <div class="viz-grid">
+            <figure class="viz-card" data-chart-wrapper>
+              <header class="viz-card__title">Season workload planner</header>
+              <div class="viz-canvas">
+                <canvas data-chart="season-volume" aria-describedby="season-volume-caption"></canvas>
               </div>
-            </div>
-            <div class="chart-placeholder">Interactive trajectory view loading soon</div>
-          </div>
-          <div class="grid-two">
-            <div class="chart-placeholder">League-wide possession flow visual on deck</div>
-            <div class="subsection">
-              <h3>Systems level team insights</h3>
-              <p>
-                Compare pace, space, and defensive schemes at a glance. Upcoming modules will
-                spotlight lineup chemistry networks, in-game adjustments, and schedule density.
-              </p>
-              <div class="badge-list">
-                <span class="badge">Lineup graphs</span>
-                <span class="badge">Scheme explorer</span>
-                <span class="badge">Schedule strain</span>
+              <figcaption id="season-volume-caption" class="viz-card__caption">
+                Stack preseason, regular season, and cup/postseason games for every month of the
+                2024-25 calendar to spot schedule surges in seconds.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card" data-chart-wrapper>
+              <header class="viz-card__title">Top franchise efficiency</header>
+              <div class="viz-canvas">
+                <canvas data-chart="team-efficiency" aria-describedby="team-efficiency-caption"></canvas>
               </div>
-            </div>
+              <figcaption id="team-efficiency-caption" class="viz-card__caption">
+                Compare points scored versus allowed for the winningest franchises ever—each point
+                scales with historical win percentage.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card" data-chart-wrapper>
+              <header class="viz-card__title">Global player pipeline</header>
+              <div class="viz-canvas">
+                <canvas data-chart="global-pipeline" aria-describedby="global-pipeline-caption"></canvas>
+              </div>
+              <figcaption id="global-pipeline-caption" class="viz-card__caption">
+                Track the leading international talent sources while keeping payloads lean through
+                ranked sampling of the roster database.
+              </figcaption>
+            </figure>
           </div>
         </section>
 
@@ -151,5 +159,7 @@
 
       <footer class="page-footer">Built for the modern NBA era — expanding with every new story.</footer>
     </div>
+    <script src="vendor/chart.umd.js" defer></script>
+    <script type="module" src="scripts/index.js"></script>
   </body>
 </html>

--- a/public/players.html
+++ b/public/players.html
@@ -42,7 +42,16 @@
             players across roles, pace contexts, and matchup styles.
           </p>
           <div class="grid-two">
-            <div class="chart-placeholder">Archetype clustering scatterplot placeholder</div>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">League height distribution</header>
+              <div class="viz-canvas">
+                <canvas data-chart="player-heights" aria-describedby="player-heights-caption"></canvas>
+              </div>
+              <figcaption id="player-heights-caption" class="viz-card__caption">
+                A smoothed density curve of roster heights keeps archetype filters responsive while
+                honoring Phase 2 performance budgets.
+              </figcaption>
+            </figure>
             <div class="subsection">
               <h3>Key ingredients</h3>
               <div class="badge-list">
@@ -69,7 +78,16 @@
                 offices tools to spot breakout windows or manage workloads over 82 games.
               </p>
             </div>
-            <div class="chart-placeholder">Clutch impact timeline coming soon</div>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Draft pipeline cadence</header>
+              <div class="viz-canvas">
+                <canvas data-chart="draft-timeline" aria-describedby="draft-timeline-caption"></canvas>
+              </div>
+              <figcaption id="draft-timeline-caption" class="viz-card__caption">
+                Decade-level draft totals are sampled evenly to highlight momentum without shipping
+                the full historical series.
+              </figcaption>
+            </figure>
           </div>
           <div class="card-grid">
             <article class="card">
@@ -90,5 +108,7 @@
 
       <footer class="page-footer">Player insights are the heartbeat of the hub — more soon.</footer>
     </div>
+    <script src="vendor/chart.umd.js" defer></script>
+    <script type="module" src="scripts/players.js"></script>
   </body>
 </html>

--- a/public/scripts/hub-charts.js
+++ b/public/scripts/hub-charts.js
@@ -1,0 +1,179 @@
+const dataCache = new Map();
+const chartRegistry = new Map();
+const pendingDefinitions = new Map();
+let observerRef = null;
+
+function ensureChartDefaults() {
+  if (!window.Chart || ensureChartDefaults._set) return;
+  ensureChartDefaults._set = true;
+  const { Chart } = window;
+  Chart.defaults.font.family = 'Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+  Chart.defaults.font.weight = 500;
+  Chart.defaults.color = '#0b2545';
+  Chart.defaults.plugins.legend.labels.usePointStyle = true;
+  Chart.defaults.plugins.legend.labels.boxHeight = 8;
+  Chart.defaults.plugins.legend.labels.boxWidth = 8;
+  Chart.defaults.plugins.legend.align = 'end';
+  Chart.defaults.plugins.tooltip.backgroundColor = 'rgba(11, 37, 69, 0.88)';
+  Chart.defaults.plugins.tooltip.padding = 12;
+  Chart.defaults.plugins.tooltip.titleColor = '#f5f8ff';
+  Chart.defaults.plugins.tooltip.bodyColor = '#f5f8ff';
+  Chart.defaults.plugins.tooltip.displayColors = true;
+  Chart.defaults.elements.bar.borderRadius = 6;
+  Chart.defaults.elements.bar.borderSkipped = false;
+  Chart.defaults.responsive = true;
+  Chart.defaults.maintainAspectRatio = false;
+}
+
+async function loadJson(url) {
+  if (!dataCache.has(url)) {
+    dataCache.set(
+      url,
+      fetch(url)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Failed to load ${url}: ${response.status}`);
+          }
+          return response.json();
+        })
+        .then((json) => (typeof structuredClone === 'function' ? structuredClone(json) : JSON.parse(JSON.stringify(json))))
+    );
+  }
+  return dataCache.get(url);
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function evenSample(series, limit) {
+  if (!limit || series.length <= limit) {
+    return series;
+  }
+  const step = Math.ceil(series.length / limit);
+  const sampled = [];
+  for (let i = 0; i < series.length; i += step) {
+    sampled.push(series[i]);
+  }
+  return sampled;
+}
+
+function rankAndSlice(series, limit, valueAccessor = (item) => item.value ?? item.players ?? 0) {
+  if (!limit || series.length <= limit) {
+    return series;
+  }
+  return [...series]
+    .sort((a, b) => valueAccessor(b) - valueAccessor(a))
+    .slice(0, limit);
+}
+
+const helpers = {
+  formatNumber(value, maximumFractionDigits = 1) {
+    const options = { maximumFractionDigits };
+    if (maximumFractionDigits === 0) {
+      options.minimumFractionDigits = 0;
+    }
+    return new Intl.NumberFormat('en-US', options).format(value);
+  },
+  evenSample,
+  rankAndSlice,
+};
+
+function scheduleMount(callback) {
+  if ('requestIdleCallback' in window) {
+    window.requestIdleCallback(callback, { timeout: 1200 });
+  } else {
+    window.setTimeout(callback, 0);
+  }
+}
+
+function instantiateChart(canvas, definition) {
+  if (!canvas || chartRegistry.has(canvas)) {
+    return;
+  }
+
+  const run = async () => {
+    try {
+      ensureChartDefaults();
+      const sourceData = definition.source ? await loadJson(definition.source) : undefined;
+      const config = await definition.createConfig(sourceData, helpers);
+      if (!config || !canvas.isConnected) {
+        return;
+      }
+      if (prefersReducedMotion()) {
+        config.options = config.options || {};
+        config.options.animation = false;
+      }
+      const chart = new window.Chart(canvas.getContext('2d'), config);
+      chartRegistry.set(canvas, chart);
+    } catch (error) {
+      console.error('Unable to mount chart', error);
+      const container = canvas.closest('[data-chart-wrapper]');
+      if (container && !container.querySelector('.viz-error__message')) {
+        container.classList.add('viz-error');
+        const message = document.createElement('p');
+        message.className = 'viz-error__message';
+        message.textContent = 'Chart failed to load.';
+        container.appendChild(message);
+      }
+    }
+  };
+
+  scheduleMount(run);
+}
+
+function getObserver() {
+  if (!('IntersectionObserver' in window)) {
+    return null;
+  }
+  if (!observerRef) {
+    observerRef = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+          const definition = pendingDefinitions.get(entry.target);
+          if (definition) {
+            instantiateChart(entry.target, definition);
+            pendingDefinitions.delete(entry.target);
+          }
+          observerRef.unobserve(entry.target);
+        });
+      },
+      { rootMargin: '120px 0px' }
+    );
+  }
+  return observerRef;
+}
+
+export function registerCharts(configs) {
+  const observer = getObserver();
+
+  configs.forEach((config) => {
+    const canvas =
+      typeof config.element === 'string' ? document.querySelector(config.element) : config.element;
+    if (!canvas) {
+      return;
+    }
+    pendingDefinitions.set(canvas, config);
+    if (observer) {
+      observer.observe(canvas);
+    } else {
+      instantiateChart(canvas, config);
+      pendingDefinitions.delete(canvas);
+    }
+  });
+}
+
+export function destroyCharts() {
+  chartRegistry.forEach((chart) => chart.destroy());
+  chartRegistry.clear();
+  pendingDefinitions.clear();
+  if (observerRef) {
+    observerRef.disconnect();
+    observerRef = null;
+  }
+}
+
+export { helpers };

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -1,0 +1,186 @@
+import { registerCharts, helpers } from './hub-charts.js';
+
+const palette = {
+  royal: '#1156d6',
+  sky: 'rgba(31, 123, 255, 0.85)',
+  gold: '#f4b53f',
+  red: '#ef3d5b',
+  navy: '#0b2545',
+};
+
+registerCharts([
+  {
+    element: document.querySelector('[data-chart="season-volume"]'),
+    source: 'data/season_24_25_schedule.json',
+    async createConfig(data) {
+      const months = Array.isArray(data?.monthlyCounts) ? data.monthlyCounts : [];
+      if (!months.length) return null;
+      const labels = months.map((entry) => entry.label);
+      const preseason = months.map((entry) => entry.preseason || 0);
+      const regularSeason = months.map((entry) => entry.regularSeason || 0);
+      const otherPlay = months.map(
+        (entry) => Math.max(0, (entry.games || 0) - (entry.preseason || 0) - (entry.regularSeason || 0))
+      );
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Regular season',
+              data: regularSeason,
+              backgroundColor: palette.royal,
+            },
+            {
+              label: 'Preseason',
+              data: preseason,
+              backgroundColor: palette.gold,
+            },
+            {
+              label: 'Cup & postseason',
+              data: otherPlay,
+              backgroundColor: palette.red,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { top: 8, right: 12, bottom: 0, left: 0 } },
+          scales: {
+            x: {
+              stacked: true,
+              grid: { display: false },
+            },
+              y: {
+                stacked: true,
+                beginAtZero: true,
+                ticks: {
+                  callback: (value) => `${helpers.formatNumber(value, 0)}`,
+                },
+              },
+          },
+          plugins: {
+            legend: {
+              position: 'bottom',
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.dataset.label}: ${helpers.formatNumber(context.parsed.y, 0)} games`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="team-efficiency"]'),
+    source: 'data/team_performance.json',
+    async createConfig(data) {
+      const teams = helpers
+        .rankAndSlice(Array.isArray(data?.winPctLeaders) ? data.winPctLeaders : [], 12, (team) => team.winPct)
+        .map((team) => ({
+          x: Number(team.pointsPerGame.toFixed(2)),
+          y: Number(team.opponentPointsPerGame.toFixed(2)),
+          winPct: team.winPct,
+          team: team.team,
+        }))
+        .sort((a, b) => b.winPct - a.winPct);
+      if (!teams.length) return null;
+
+      return {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'Top franchises',
+              data: teams,
+              pointBackgroundColor: palette.royal,
+              pointBorderColor: palette.sky,
+              pointBorderWidth: 1.5,
+              pointRadius: (ctx) => 5 + ctx.raw.winPct * 6,
+              pointHoverRadius: (ctx) => 7 + ctx.raw.winPct * 6,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const { raw } = context;
+                  return `${raw.team}: ${helpers.formatNumber(raw.winPct * 100, 1)}% win — ${helpers.formatNumber(raw.x, 2)} pts for, ${helpers.formatNumber(raw.y, 2)} pts allowed`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              title: { display: true, text: 'Points scored per game' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+            },
+            y: {
+              title: { display: true, text: 'Points allowed per game' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="global-pipeline"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const countries = helpers.rankAndSlice(Array.isArray(data?.countries) ? data.countries : [], 12, (c) => c.players);
+      if (!countries.length) return null;
+      countries.sort((a, b) => b.players - a.players);
+      const labels = countries.map((entry) => entry.country);
+      const players = countries.map((entry) => entry.players);
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Players produced',
+              data: players,
+              backgroundColor: palette.royal,
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          layout: { padding: { right: 8, left: 8, top: 4, bottom: 4 } },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 0)}`,
+              },
+            },
+            y: {
+              grid: { display: false },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.x, 0)} players`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+]);

--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -1,0 +1,118 @@
+import { registerCharts, helpers } from './hub-charts.js';
+
+const palette = {
+  royal: '#1156d6',
+  sky: 'rgba(31, 123, 255, 0.75)',
+  gold: '#f4b53f',
+};
+
+registerCharts([
+  {
+    element: document.querySelector('[data-chart="player-heights"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const buckets = Array.isArray(data?.heightBuckets) ? data.heightBuckets : [];
+      if (!buckets.length) return null;
+      const labels = buckets.map((bucket) => bucket.label);
+      const totals = buckets.map((bucket) => bucket.players);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Players',
+              data: totals,
+              fill: true,
+              borderColor: palette.royal,
+              backgroundColor: 'rgba(17, 86, 214, 0.18)',
+              tension: 0.32,
+              pointRadius: 0,
+              pointHoverRadius: 4,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { left: 4, right: 4, top: 8, bottom: 8 } },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.y, 0)} players`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { display: false },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 0)}`,
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="draft-timeline"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const decadeCounts = Array.isArray(data?.draftSummary?.decadeCounts)
+        ? data.draftSummary.decadeCounts.filter((entry) => /\d{4}s/.test(entry.decade))
+        : [];
+      if (!decadeCounts.length) return null;
+      const trimmed = helpers.evenSample(decadeCounts, 10);
+      const labels = trimmed.map((entry) => entry.decade);
+      const drafted = trimmed.map((entry) => entry.players);
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Drafted players',
+              data: drafted,
+              backgroundColor: palette.gold,
+              borderColor: 'rgba(244, 181, 63, 0.8)',
+              borderWidth: 1,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { top: 4, right: 8, bottom: 4, left: 8 } },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.y, 0)} draft picks`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { display: false },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.1)' },
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 0)}`,
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+]);

--- a/public/scripts/teams.js
+++ b/public/scripts/teams.js
@@ -1,0 +1,125 @@
+import { registerCharts, helpers } from './hub-charts.js';
+
+const palette = {
+  royal: '#1156d6',
+  red: '#ef3d5b',
+  teal: 'rgba(17, 86, 214, 0.2)',
+};
+
+registerCharts([
+  {
+    element: document.querySelector('[data-chart="win-leaders"]'),
+    source: 'data/team_performance.json',
+    async createConfig(data) {
+      const leaders = helpers.rankAndSlice(Array.isArray(data?.winPctLeaders) ? data.winPctLeaders : [], 10, (team) => team.winPct);
+      if (!leaders.length) return null;
+      leaders.sort((a, b) => b.winPct - a.winPct);
+      const labels = leaders.map((team) => team.team);
+      const pct = leaders.map((team) => Number((team.winPct * 100).toFixed(1)));
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'All-time win %',
+              data: pct,
+              backgroundColor: palette.royal,
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          layout: { padding: { top: 6, right: 8, bottom: 6, left: 8 } },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.x, 1)}% win rate`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              suggestedMax: 70,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 0)}%`,
+              },
+            },
+            y: {
+              grid: { display: false },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="schedule-strain"]'),
+    source: 'data/season_24_25_schedule.json',
+    async createConfig(data) {
+      const teams = helpers
+        .rankAndSlice(Array.isArray(data?.teams) ? data.teams : [], 12, (team) => team.backToBacks)
+        .map((team) => ({
+          x: team.backToBacks,
+          y: Number(team.averageRestDays?.toFixed(2) ?? 0),
+          team: team.name,
+          abbreviation: team.abbreviation,
+          totalGames: team.totalGames,
+        }));
+      if (!teams.length) return null;
+
+      return {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'Teams',
+              data: teams,
+              pointBackgroundColor: palette.red,
+              pointBorderColor: palette.teal,
+              pointBorderWidth: 1.5,
+              pointRadius: (ctx) => 4 + Math.min(8, ctx.raw.totalGames / 24),
+              pointHoverRadius: (ctx) => 6 + Math.min(8, ctx.raw.totalGames / 24),
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const { raw } = context;
+                  return `${raw.team}: ${helpers.formatNumber(raw.x, 0)} back-to-back sets • ${helpers.formatNumber(raw.y, 2)} avg rest days`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              title: { display: true, text: 'Back-to-back sets' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 0)}`,
+              },
+            },
+            y: {
+              title: { display: true, text: 'Average rest days' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 1)}`,
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+]);

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -299,6 +299,65 @@ section h2 {
   font-size: 0.95rem;
 }
 
+.viz-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.viz-card {
+  position: relative;
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.2rem 1.3rem 1.4rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: linear-gradient(160deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.1));
+  box-shadow: var(--shadow-soft);
+}
+
+.viz-card--inline {
+  height: 100%;
+  grid-template-rows: auto 1fr auto;
+}
+
+.viz-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.viz-card__caption {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
+.viz-canvas {
+  position: relative;
+  min-height: 240px;
+}
+
+.viz-card canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.viz-error {
+  border-color: rgba(239, 61, 91, 0.4);
+}
+
+.viz-error__message {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(239, 61, 91, 0.1);
+  color: var(--red);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
 .chart-placeholder {
   border: 2px dashed color-mix(in srgb, var(--royal) 35%, transparent);
   border-radius: var(--radius-md);
@@ -354,5 +413,9 @@ section h2 {
 
   .nav-links {
     justify-content: center;
+  }
+
+  .viz-canvas {
+    min-height: 200px;
   }
 }

--- a/public/teams.html
+++ b/public/teams.html
@@ -50,14 +50,32 @@
                 development pathways.
               </p>
             </div>
-            <div class="chart-placeholder">Momentum radar visualization in progress</div>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Historical win rate leaders</header>
+              <div class="viz-canvas">
+                <canvas data-chart="win-leaders" aria-describedby="win-leaders-caption"></canvas>
+              </div>
+              <figcaption id="win-leaders-caption" class="viz-card__caption">
+                Horizontal bars showcase the ten most efficient franchises ever, trimmed via
+                ranked slicing to keep render times snappy.
+              </figcaption>
+            </figure>
           </div>
         </section>
 
         <section>
           <h2>Lineup chemistry lab</h2>
           <div class="grid-two">
-            <div class="chart-placeholder">Five-man network analysis placeholder</div>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Schedule strain navigator</header>
+              <div class="viz-canvas">
+                <canvas data-chart="schedule-strain" aria-describedby="schedule-strain-caption"></canvas>
+              </div>
+              <figcaption id="schedule-strain-caption" class="viz-card__caption">
+                Bubble size scales with total games while the axes reveal the balance between
+                back-to-back sets and average rest days for busy clubs.
+              </figcaption>
+            </figure>
             <div class="subsection">
               <h3>Key overlays</h3>
               <div class="badge-list">
@@ -90,5 +108,7 @@
 
       <footer class="page-footer">Team stories will anchor the hub's competitive scouting tools.</footer>
     </div>
+    <script src="vendor/chart.umd.js" defer></script>
+    <script type="module" src="scripts/teams.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace overview, player, and team placeholders with live visual prototype cards powered by hub data
- introduce shared Chart.js wrapper with lazy hydration, cached fetches, and formatting helpers for lightweight rendering
- style new visualization components and ship dedicated page entry modules for schedule, player, and team insights

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d830dec8b083279fc0a02b97f4500d