### PR TITLE
Add storytelling narrative walkthroughs to Insights Lab

### DIFF
--- a/public/data/storytelling_walkthroughs.json
+++ b/public/data/storytelling_walkthroughs.json
@@ -1,0 +1,118 @@
+{
+  "release": {
+    "phase": "Phase 3 — Storytelling",
+    "version": "Release 03",
+    "updated": "2024-10-05",
+    "summary": "Narrative walkthroughs that combine metrics with editorial context."
+  },
+  "stories": [
+    {
+      "id": "schedule-pulse",
+      "title": "Back-to-back gauntlet shaping rotations",
+      "lede": "A tighter cadence forces rotation planning before Thanksgiving.",
+      "metric": {
+        "label": "Back-to-back windows",
+        "value": "446",
+        "unit": "intervals",
+        "context": "16% of the 2,779 rest windows logged for 2024-25."
+      },
+      "editorial": [
+        "The 2024-25 schedule tracks 2,779 rest windows, and 446 of them arrive with zero recovery days. That keeps average downtime at 3.0 days and pushes staffs to coordinate recovery blocks weeks in advance.",
+        "One-day turnarounds (1,664 instances) dominate nearly 60% of the cadence, so even clubs with generous travel support must rehearse short-notice scouting and sports-science workflows.",
+        "Atlanta faces a league-high 17 back-to-backs, while the Clippers and Wizards both absorb seven-game road stretches—the longest gauntlets on the board."
+      ],
+      "spotlights": [
+        {
+          "label": "Average rest",
+          "value": "3.0 days",
+          "context": "The league-wide rhythm across 2,779 tracked intervals."
+        },
+        {
+          "label": "1-day turnarounds",
+          "value": "1,664",
+          "context": "59.9% of schedule gaps demand single-day prep."
+        },
+        {
+          "label": "Longest road stretch",
+          "value": "7 games",
+          "context": "Shared by the Clippers and Wizards according to schedule manifest."
+        }
+      ],
+      "sources": [
+        "season_24_25_schedule.json"
+      ]
+    },
+    {
+      "id": "efficiency-dynasties",
+      "title": "Efficiency dynasties hold the analytics high ground",
+      "lede": "Top programs pair scoring punch with stingy defense across eras.",
+      "metric": {
+        "label": "Best historical win rate",
+        "value": "59.7%",
+        "unit": "win rate",
+        "context": "Boston's mark with a +3.0 scoring margin per night."
+      },
+      "editorial": [
+        "Boston's 4,091 wins in 6,856 games deliver a 59.7% clip while outscoring opponents 106.2 to 103.2. That +3.0 differential is the anchor metric for this week's dynasty spotlight.",
+        "Los Angeles tracks just 71 wins behind at 58.5% and keeps pace with 106.7 points per game. San Antonio's 21.1 assists per night showcase ball movement as a path to sustained efficiency.",
+        "Within the top 12, Miami is the only club below 100 points per game, yet still clears a 52.6% win rate thanks to holding opponents under 99."
+      ],
+      "spotlights": [
+        {
+          "label": "Games logged",
+          "value": "6,856",
+          "context": "Boston's sample size powering the win-rate lead."
+        },
+        {
+          "label": "Assist leaders",
+          "value": "21.1 apg",
+          "context": "San Antonio's average among top-12 efficiency franchises."
+        },
+        {
+          "label": "Defensive squeeze",
+          "value": "98.9 opp ppg",
+          "context": "Miami's pressure benchmark while maintaining 52.6% wins."
+        }
+      ],
+      "sources": [
+        "team_performance.json"
+      ]
+    },
+    {
+      "id": "triple-double-era",
+      "title": "Triple-double era keeps compounding",
+      "lede": "Playmaking surges continue even as workloads normalize.",
+      "metric": {
+        "label": "Peak triple-doubles",
+        "value": "192",
+        "unit": "games",
+        "context": "Set during the 2021 season with 45,847 player-game logs."
+      },
+      "editorial": [
+        "League tracking shows triple-doubles jumping from 60 in 2015 to 96 in 2016, a 60% year-over-year surge that reset baseline expectations.",
+        "The 2021 campaign produced 192 triple-doubles across 45,847 player-game logs; even with fewer games in 2024 (37,584), the pace held at 175, signalling sustained versatility.",
+        "The current 2025 snapshot already counts 96 triple-doubles in 22,216 logged player games, keeping the narrative alive for another spike once the full season closes."
+      ],
+      "spotlights": [
+        {
+          "label": "2015 season",
+          "value": "60 triple-doubles",
+          "context": "Baseline before the era of nightly versatility."
+        },
+        {
+          "label": "2016 spike",
+          "value": "+36 YoY",
+          "context": "A 96 total that marked a 60% leap from 2015."
+        },
+        {
+          "label": "2024 tally",
+          "value": "175",
+          "context": "Delivered across 37,584 player-game logs."
+        }
+      ],
+      "sources": [
+        "player_season_insights.json"
+      ]
+    }
+  ]
+}

--- a/public/insights.html
+++ b/public/insights.html
@@ -58,6 +58,34 @@
         </section>
 
         <section>
+          <h2>Phase 3 — Storytelling release</h2>
+          <p class="lead">
+            Follow guided walkthroughs that pair headline metrics with the editorial context needed to
+            brief stakeholders on what changed and why it matters.
+          </p>
+          <div class="story-walkthrough" data-storyboard>
+            <aside class="story-walkthrough__sidebar">
+              <div class="story-meta" data-story-meta>
+                <p class="story-meta__placeholder">Loading release details…</p>
+              </div>
+              <nav
+                class="story-steps"
+                data-story-nav
+                role="tablist"
+                aria-label="Narrative walkthroughs"
+              ></nav>
+            </aside>
+            <article
+              class="story-panel"
+              data-story-content
+              aria-live="polite"
+            >
+              <p class="story-panel__placeholder">Loading narrative walkthroughs…</p>
+            </article>
+          </div>
+        </section>
+
+        <section>
           <h2>Experiment backlog</h2>
           <div class="card-grid">
             <article class="card">
@@ -102,5 +130,6 @@
 
       <footer class="page-footer">Ideas incubated here will power the next wave of NBA experiences.</footer>
     </div>
+    <script type="module" src="scripts/insights.js"></script>
   </body>
 </html>

--- a/public/scripts/insights.js
+++ b/public/scripts/insights.js
@@ -1,0 +1,239 @@
+import { helpers } from './hub-charts.js';
+
+const DATA_URL = 'data/storytelling_walkthroughs.json';
+const PANEL_ID = 'story-panel';
+
+function formatDate(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(date);
+}
+
+function formatMetric(entry) {
+  if (!entry) return null;
+  const { value, unit } = entry;
+  if (typeof value === 'number') {
+    const digits = Number.isInteger(value) ? 0 : 1;
+    const formatted = helpers.formatNumber(value, digits);
+    return unit ? `${formatted} ${unit}` : formatted;
+  }
+  if (typeof value === 'string') {
+    return unit ? `${value} ${unit}` : value;
+  }
+  return unit || '';
+}
+
+function clearChildren(node) {
+  if (!node) return;
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function createElement(tag, className, textContent) {
+  const element = document.createElement(tag);
+  if (className) {
+    element.className = className;
+  }
+  if (typeof textContent === 'string') {
+    element.textContent = textContent;
+  }
+  return element;
+}
+
+function renderMeta(target, release) {
+  if (!target) return;
+  clearChildren(target);
+
+  if (!release) {
+    target.appendChild(createElement('p', 'story-meta__placeholder', 'Release details unavailable.'));
+    return;
+  }
+
+  const badgeLabel = release.version || release.phase || 'Release';
+  const badge = createElement('span', 'story-meta__badge', badgeLabel);
+
+  const phase = release.phase ? createElement('p', 'story-meta__phase', release.phase) : null;
+  const updated = formatDate(release.updated);
+  const metaList = createElement('div', 'story-meta__details');
+
+  if (phase) {
+    metaList.appendChild(phase);
+  }
+  if (updated) {
+    metaList.appendChild(createElement('p', 'story-meta__updated', `Updated ${updated}`));
+  }
+  if (release.summary) {
+    metaList.appendChild(createElement('p', 'story-meta__summary', release.summary));
+  }
+
+  target.appendChild(badge);
+  target.appendChild(metaList);
+}
+
+function renderStoryPanel(container, story, index) {
+  if (!container || !story) return;
+  clearChildren(container);
+
+  container.id = PANEL_ID;
+  container.setAttribute('role', 'tabpanel');
+  container.setAttribute('tabindex', '0');
+
+  const header = createElement('header', 'story-step__header');
+  header.appendChild(createElement('p', 'story-step__lede', story.lede || ''));
+  header.appendChild(createElement('h3', 'story-step__title', story.title || `Story ${index + 1}`));
+
+  const metricSection = createElement('section', 'story-step__metrics');
+  const primaryMetric = createElement('div', 'story-metric story-metric--primary');
+  primaryMetric.appendChild(createElement('span', 'story-metric__label', story.metric?.label || 'Headline metric'));
+  primaryMetric.appendChild(createElement('strong', 'story-metric__value', formatMetric(story.metric) || ''));
+  if (story.metric?.context) {
+    primaryMetric.appendChild(createElement('span', 'story-metric__context', story.metric.context));
+  }
+  metricSection.appendChild(primaryMetric);
+
+  const spotlights = Array.isArray(story.spotlights) ? story.spotlights : [];
+  if (spotlights.length) {
+    const list = createElement('ul', 'story-spotlights');
+    spotlights.forEach((spotlight) => {
+      const item = createElement('li', 'story-spotlight');
+      item.appendChild(createElement('span', 'story-spotlight__label', spotlight.label || ''));
+      item.appendChild(createElement('span', 'story-spotlight__value', formatMetric(spotlight) || ''));
+      if (spotlight.context) {
+        item.appendChild(createElement('span', 'story-spotlight__context', spotlight.context));
+      }
+      list.appendChild(item);
+    });
+    metricSection.appendChild(list);
+  }
+
+  const editorial = Array.isArray(story.editorial) ? story.editorial : [];
+  const copy = createElement('div', 'story-step__body');
+  if (editorial.length) {
+    editorial.forEach((paragraph) => {
+      copy.appendChild(createElement('p', null, paragraph));
+    });
+  }
+
+  if (Array.isArray(story.sources) && story.sources.length) {
+    const sources = createElement('div', 'story-sources');
+    sources.appendChild(createElement('span', 'story-sources__label', 'Data sources:'));
+    story.sources.forEach((source) => {
+      sources.appendChild(createElement('code', 'story-sources__tag', source));
+    });
+    copy.appendChild(sources);
+  }
+
+  container.appendChild(header);
+  container.appendChild(metricSection);
+  container.appendChild(copy);
+}
+
+function setupStorytelling(board, data) {
+  const nav = board.querySelector('[data-story-nav]');
+  const content = board.querySelector('[data-story-content]');
+  const meta = board.querySelector('[data-story-meta]');
+  renderMeta(meta, data?.release);
+
+  const stories = Array.isArray(data?.stories) ? data.stories.filter(Boolean) : [];
+  if (!stories.length) {
+    clearChildren(content);
+    content.appendChild(createElement('p', 'story-panel__placeholder', 'Narrative walkthroughs are on the way.'));
+    return;
+  }
+
+  const buttons = [];
+  clearChildren(nav);
+  stories.forEach((story, index) => {
+    const button = createElement('button', 'story-step__trigger');
+    button.type = 'button';
+    const tabId = `story-tab-${story.id || index}`;
+    const panelId = PANEL_ID;
+    button.id = tabId;
+    button.setAttribute('role', 'tab');
+    button.setAttribute('aria-controls', panelId);
+    button.setAttribute('tabindex', index === 0 ? '0' : '-1');
+    button.innerHTML = `
+      <span class="story-step__index">${String(index + 1).padStart(2, '0')}</span>
+      <span class="story-step__summary">
+        <strong>${story.title || `Story ${index + 1}`}</strong>
+        <span>${story.metric?.label || story.lede || ''}</span>
+      </span>
+    `;
+    button.addEventListener('click', () => activate(index));
+    nav.appendChild(button);
+    buttons.push(button);
+  });
+
+  nav.addEventListener('keydown', (event) => {
+    if (!['ArrowRight', 'ArrowLeft'].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    const current = buttons.findIndex((button) => button.classList.contains('is-active'));
+    const startingIndex = current === -1 ? 0 : current;
+    const direction = event.key === 'ArrowRight' ? 1 : -1;
+    const nextIndex = (startingIndex + direction + stories.length) % stories.length;
+    buttons[nextIndex].focus();
+    activate(nextIndex);
+  });
+
+  function activate(index) {
+    const story = stories[index];
+    if (!story) {
+      return;
+    }
+    buttons.forEach((button, buttonIndex) => {
+      const isActive = buttonIndex === index;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.setAttribute('tabindex', isActive ? '0' : '-1');
+    });
+    renderStoryPanel(content, story, index);
+    const activeButton = buttons[index];
+    if (activeButton) {
+      content.setAttribute('aria-labelledby', activeButton.id);
+    }
+  }
+
+  activate(0);
+}
+
+async function initStorytelling() {
+  const board = document.querySelector('[data-storyboard]');
+  if (!board) {
+    return;
+  }
+  try {
+    const response = await fetch(DATA_URL);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch storytelling data: ${response.status}`);
+    }
+    const data = await response.json();
+    setupStorytelling(board, data);
+  } catch (error) {
+    console.error('Storytelling release failed to load', error);
+    const meta = board.querySelector('[data-story-meta]');
+    const content = board.querySelector('[data-story-content]');
+    renderMeta(meta, null);
+    if (content) {
+      clearChildren(content);
+      content.appendChild(
+        createElement(
+          'p',
+          'story-panel__placeholder',
+          'We could not load the narrative walkthroughs. Refresh to try again.'
+        )
+      );
+    }
+  }
+}
+
+initStorytelling();

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -278,6 +278,302 @@ section h2 {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.story-walkthrough {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+  grid-template-columns: minmax(220px, 0.85fr) 1.4fr;
+  align-items: stretch;
+}
+
+.story-walkthrough__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.story-meta {
+  background: color-mix(in srgb, var(--surface-alt) 60%, #ffffff 40%);
+  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
+  border-radius: var(--radius-md);
+  padding: 1.1rem 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.story-meta__badge {
+  justify-self: start;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(239, 61, 91, 0.85));
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.story-meta__details {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.story-meta__phase {
+  margin: 0;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.story-meta__updated,
+.story-meta__summary,
+.story-meta__placeholder {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.9rem;
+}
+
+.story-steps {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.story-step__trigger {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.9rem;
+  align-items: center;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 10%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 40%, rgba(255, 255, 255, 0.92) 60%);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.story-step__trigger:hover,
+.story-step__trigger:focus-visible {
+  outline: none;
+  border-color: rgba(17, 86, 214, 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(17, 86, 214, 0.18);
+}
+
+.story-step__trigger.is-active {
+  border-color: transparent;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.85));
+  color: #fff;
+  box-shadow: 0 16px 28px rgba(17, 86, 214, 0.35);
+}
+
+.story-step__trigger.is-active .story-step__summary span {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.story-step__index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 12px;
+  background: rgba(17, 86, 214, 0.12);
+  color: var(--royal);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.story-step__trigger.is-active .story-step__index {
+  background: rgba(255, 255, 255, 0.16);
+  color: #fff;
+}
+
+.story-step__summary {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.story-step__summary strong {
+  font-size: 0.95rem;
+  line-height: 1.3;
+}
+
+.story-step__summary span {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.story-panel {
+  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.2rem, 3vw, 1.8rem);
+  background: radial-gradient(circle at top right, rgba(17, 86, 214, 0.12), transparent 55%),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 60%, rgba(242, 246, 255, 0.8) 40%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  display: grid;
+  gap: 1.4rem;
+}
+
+.story-panel__placeholder {
+  margin: 0;
+  color: var(--text-subtle);
+  font-style: italic;
+}
+
+.story-step__header {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.story-step__lede {
+  margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(17, 86, 214, 0.8);
+  font-weight: 700;
+}
+
+.story-step__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+}
+
+.story-step__metrics {
+  display: grid;
+  gap: 1rem;
+}
+
+.story-metric {
+  background: rgba(17, 86, 214, 0.08);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.story-metric--primary {
+  border-left: 4px solid var(--royal);
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.12), rgba(17, 86, 214, 0.04));
+}
+
+.story-metric__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.story-metric__value {
+  font-size: clamp(1.6rem, 4vw, 2.1rem);
+  line-height: 1.15;
+}
+
+.story-metric__context {
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+.story-spotlights {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.story-spotlight {
+  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.95rem;
+  background: rgba(255, 255, 255, 0.78);
+  display: grid;
+  gap: 0.3rem;
+}
+
+.story-spotlight__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-subtle);
+}
+
+.story-spotlight__value {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.story-spotlight__context {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.story-step__body {
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.98rem;
+}
+
+.story-step__body p {
+  margin: 0;
+}
+
+.story-sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 0.5rem;
+}
+
+.story-sources__label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.story-sources__tag {
+  background: rgba(17, 86, 214, 0.08);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--royal);
+}
+
+@media (max-width: 960px) {
+  .story-walkthrough {
+    grid-template-columns: 1fr;
+  }
+
+  .story-step__trigger {
+    grid-template-columns: auto 1fr;
+  }
+
+  .story-panel {
+    order: 2;
+  }
+}
+
+@media (max-width: 620px) {
+  .story-step__trigger {
+    grid-template-columns: 1fr;
+  }
+
+  .story-step__index {
+    width: auto;
+    justify-content: flex-start;
+    height: auto;
+    padding: 0.2rem 0.5rem;
+  }
+
+  .story-spotlights {
+    grid-template-columns: 1fr;
+  }
+}
+
 .card {
   padding: 1.4rem 1.3rem;
   border-radius: var(--radius-md);


### PR DESCRIPTION
## Summary
- add a Phase 3 storytelling release section to the Insights Lab overview
- load narrative walkthrough data from a new JSON feed and render it with a dedicated client script
- style the storytelling navigation, metric highlights, and content panels for the release walkthrough

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d8338396a48327af32b48613de900e