### PR TITLE
Revamp landing page for NBA Intelligence Hub MVP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,26 +26,46 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Experience Hub</span>
-          <h1>Every data story behind the NBA, brought together.</h1>
+          <h1>The control room for modern NBA intelligence.</h1>
           <p>
-            Welcome to the staging ground for a modern NBA analytics experience. Explore the
-            foundations that will grow into a living atlas of player trends, team performance, and
-            historical storytelling—each page designed for future interactive visualizations.
+            Build rapid clarity around players, teams, and league history in one connected space.
+            The Intelligence Hub stitches together curated datasets, visual prototypes, and launch
+            plans so your analysts, storytellers, and decision makers always share the same view of
+            the game.
           </p>
+          <div class="cta-group" role="group" aria-label="Primary actions">
+            <a class="cta cta--primary" href="players.html">Start with player intel</a>
+            <a class="cta cta--ghost" href="#roadmap">Preview the launch roadmap</a>
+          </div>
+          <dl class="hero-metrics">
+            <div class="hero-metrics__item">
+              <dt>Realtime datasets</dt>
+              <dd>32 active feeds covering roster, schedule, and performance data.</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Historical depth</dt>
+              <dd>72 years of playoff arcs, award races, and franchise milestones.</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Experiment velocity</dt>
+              <dd>Weekly chart drops and prototype releases inside the Insights Lab.</dd>
+            </div>
+          </dl>
         </div>
       </header>
 
       <main>
         <section>
-          <h2>What you can do today</h2>
+          <h2>Launch-ready experience, already in motion</h2>
           <p class="lead">
-            Use the hub to orient yourself across the league, jump into curated player and team
-            perspectives, and discover the roadmap for upcoming visual explorations.
+            The MVP connects critical league perspectives so you can move from question to
+            visualization in minutes. Explore the live pages today and follow the plans that will
+            take the hub from internal prototype to public release.
           </p>
           <div class="summary-cards">
             <article class="summary-card">
               <strong>Player Knowledge Base</strong>
-              <p>Scout talent pipelines, biometric profiles, and situational impact.</p>
+              <p>Scout talent pipelines, biometric profiles, and situational impact with sortable dashboards.</p>
               <a href="players.html">Navigate to player dashboards →</a>
             </article>
             <article class="summary-card">
@@ -62,6 +82,54 @@
               <strong>Insights Lab</strong>
               <p>Prototype new charts and publish experiments from raw league datasets.</p>
               <a href="insights.html">Visit the Insights Lab →</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="pillars">
+          <div class="section-header">
+            <h2>What makes the hub release-ready</h2>
+            <p class="lead">
+              Every module is grounded in operational guardrails: reliable data pipelines, consistent
+              visuals, and opinionated storytelling scaffolds that keep the experience cohesive.
+            </p>
+          </div>
+          <div class="pillars-grid">
+            <article class="pillar-card">
+              <h3>Unified data contracts</h3>
+              <p>
+                Shared identifiers across player, team, and schedule feeds eliminate brittle joins
+                and unlock filters that feel instantaneous, even at league scale.
+              </p>
+              <ul class="pillar-list">
+                <li>Standardized player and franchise IDs</li>
+                <li>QA scripts for nightly refreshes</li>
+                <li>Automated anomaly detection</li>
+              </ul>
+            </article>
+            <article class="pillar-card">
+              <h3>Composable visuals</h3>
+              <p>
+                Chart primitives share motion, typography, and interaction rules so new modules can
+                be shipped in days without design drift or accessibility regressions.
+              </p>
+              <ul class="pillar-list">
+                <li>Theme-aware Chart.js presets</li>
+                <li>Server-friendly lazy hydration</li>
+                <li>Keyboard and screen reader support</li>
+              </ul>
+            </article>
+            <article class="pillar-card">
+              <h3>Editorial clarity</h3>
+              <p>
+                Templates for story ledes, callouts, and comparison blocks keep analysts focused on
+                insight quality instead of page layout chores.
+              </p>
+              <ul class="pillar-list">
+                <li>Reusable storytelling panels</li>
+                <li>Context-first copy guidelines</li>
+                <li>Publish-ready export formats</li>
+              </ul>
             </article>
           </div>
         </section>
@@ -109,7 +177,44 @@
           </div>
         </section>
 
-        <section>
+        <section class="insight-preview">
+          <div class="insight-preview__content">
+            <h2>From datasets to decisions in three beats</h2>
+            <p class="lead">
+              The MVP flow mirrors real basketball operations—from nightly scouting syncs to
+              long-form historical research. Reuse it as-is or extend with your own automated
+              insights.
+            </p>
+            <ol class="insight-steps">
+              <li>
+                <strong>Scan league pulse.</strong>
+                Players and teams pages surface the deltas that matter: availability, rotation shifts,
+                and efficiency swings.
+              </li>
+              <li>
+                <strong>Deep-dive context.</strong>
+                Jump into history archives or Insights Lab experiments to understand the why behind
+                trends.
+              </li>
+              <li>
+                <strong>Decide and share.</strong>
+                Export snapshots or embed charts directly into your scouting briefs and presentations.
+              </li>
+            </ol>
+            <a class="cta cta--inline" href="insights.html">See the latest experiments →</a>
+          </div>
+          <aside class="insight-preview__panel" aria-label="Platform coverage">
+            <h3>Coverage at launch</h3>
+            <ul class="coverage-list">
+              <li><span>Live roster &amp; contract tracking</span> <strong>Daily refresh</strong></li>
+              <li><span>Team offensive &amp; defensive ratings</span> <strong>Rolling 10-game windows</strong></li>
+              <li><span>Prospect journey database</span> <strong>Global leagues + NCAA</strong></li>
+              <li><span>Historical award race index</span> <strong>1951 to present</strong></li>
+            </ul>
+          </aside>
+        </section>
+
+        <section id="roadmap">
           <h2>Roadmap to launch</h2>
           <p class="lead">
             This experience hub is designed to scale. Each milestone below unlocks new sections,
@@ -154,6 +259,44 @@
               <a href="scripts/README.html">View ingestion details →</a>
             </article>
           </div>
+        </section>
+
+        <section class="faq">
+          <h2>Frequently asked questions</h2>
+          <div class="faq-grid">
+            <details>
+              <summary>How often is the data refreshed?</summary>
+              <p>
+                Core player, team, and schedule tables are ingested nightly with automated QA. Alerts
+                trigger immediate refreshes when official league feeds publish critical updates.
+              </p>
+            </details>
+            <details>
+              <summary>Can I extend the hub with proprietary metrics?</summary>
+              <p>
+                Yes. The data contracts expose merge-friendly IDs and the visualization layer reads
+                from JSON configs, making it straightforward to add custom feeds or bespoke charts.
+              </p>
+            </details>
+            <details>
+              <summary>What is required for 1.0 release?</summary>
+              <p>
+                Finalize authentication, enable user workspaces, and productionize the Insights Lab
+                publishing workflow so analysts can collaborate directly inside the platform.
+              </p>
+            </details>
+          </div>
+        </section>
+
+        <section class="callout">
+          <div class="callout__content">
+            <h2>Ready to make the jump from template to trusted tool?</h2>
+            <p>
+              Rally stakeholders around a single source of NBA truth. The Intelligence Hub is built
+              to go live—bring your branding, plug in your access controls, and launch.
+            </p>
+          </div>
+          <a class="cta cta--primary" href="mailto:product@nbahub.local">Book a rollout session</a>
         </section>
       </main>
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -170,6 +170,94 @@ a:focus {
   font-size: clamp(1.02rem, 2.4vw, 1.18rem);
 }
 
+.cta-group {
+  margin-top: 1.8rem;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.cta--primary {
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.88));
+  color: #fff;
+  box-shadow: 0 16px 28px rgba(17, 86, 214, 0.32);
+}
+
+.cta--primary:hover,
+.cta--primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 32px rgba(17, 86, 214, 0.36);
+  color: #fff;
+}
+
+.cta--ghost {
+  border: 2px solid color-mix(in srgb, var(--royal) 45%, transparent);
+  color: var(--royal);
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.cta--ghost:hover,
+.cta--ghost:focus-visible {
+  border-color: var(--royal);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(17, 86, 214, 0.22);
+}
+
+.cta--inline {
+  margin-top: 1.5rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin: 2.2rem auto 0;
+  padding: 1.2rem;
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 60%, rgba(242, 246, 255, 0.84) 40%);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  max-width: 840px;
+}
+
+.hero-metrics__item {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.hero-metrics dt {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(17, 86, 214, 0.85);
+  font-weight: 700;
+}
+
+.hero-metrics dd {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
 main {
   display: grid;
   gap: 2.25rem;
@@ -235,6 +323,111 @@ section h2 {
   color: var(--red);
 }
 
+.pillars {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.section-header {
+  display: grid;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.pillars-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.1rem;
+}
+
+.pillar-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.35rem 1.4rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 50%, rgba(255, 255, 255, 0.92) 50%);
+  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.pillar-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--navy);
+}
+
+.pillar-card p {
+  margin: 0;
+  font-size: 0.96rem;
+  color: var(--text-subtle);
+}
+
+.pillar-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--text-strong);
+  font-size: 0.9rem;
+}
+
+.insight-preview {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: minmax(260px, 1fr) minmax(220px, 0.9fr);
+  align-items: start;
+}
+
+.insight-preview__content {
+  display: grid;
+  gap: 1rem;
+}
+
+.insight-steps {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.65rem;
+  color: var(--text-strong);
+}
+
+.insight-steps strong {
+  display: block;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.insight-preview__panel {
+  padding: 1.4rem 1.5rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 40%, rgba(244, 181, 63, 0.1) 60%);
+  border: 1px solid color-mix(in srgb, var(--royal) 10%, transparent);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.coverage-list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+  list-style: none;
+}
+
+.coverage-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
+.coverage-list strong {
+  font-size: 0.9rem;
+  color: var(--navy);
+}
+
 .grid-two {
   display: grid;
   gap: 2rem;
@@ -276,6 +469,88 @@ section h2 {
   display: grid;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.faq {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.faq-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.faq details {
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.8) 30%);
+  padding: 1rem 1.1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.faq summary {
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+
+.faq summary::marker,
+.faq summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq details[open] summary {
+  color: var(--royal);
+}
+
+.faq p {
+  margin: 0.75rem 0 0;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
+.callout {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.2rem;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(31, 123, 255, 0.8));
+  color: #fff;
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 4vw, 2.4rem);
+  box-shadow: 0 20px 36px rgba(17, 86, 214, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.callout__content {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 520px;
+}
+
+.callout__content h2 {
+  margin: 0;
+  color: inherit;
+}
+
+.callout__content p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.callout .cta--primary {
+  background: #fff;
+  color: var(--royal);
+  box-shadow: none;
+}
+
+.callout .cta--primary:hover,
+.callout .cta--primary:focus-visible {
+  color: var(--navy);
+  box-shadow: 0 16px 30px rgba(11, 37, 69, 0.26);
 }
 
 .story-walkthrough {
@@ -709,6 +984,23 @@ section h2 {
 
   .nav-links {
     justify-content: center;
+  }
+
+  .hero-metrics {
+    padding: 1rem;
+  }
+
+  .insight-preview {
+    grid-template-columns: 1fr;
+  }
+
+  .callout {
+    text-align: center;
+    justify-content: center;
+  }
+
+  .callout__content {
+    max-width: none;
   }
 
   .viz-canvas {


### PR DESCRIPTION
## Summary
- refresh the landing page hero with clear positioning, CTAs, and supporting metrics
- add release readiness pillars, workflow overview, coverage summary, FAQs, and closing call-to-action sections
- extend hub styles to support new layouts, buttons, and responsive refinements for the MVP narrative

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d83564f8d483279fd6077406f1a641