### PR TITLE
Build MVP experience for players tab

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -36,6 +36,48 @@
 
       <main>
         <section>
+          <h2>Player landscape snapshot</h2>
+          <p class="lead">
+            Essential league-wide profile metrics distilled from the historical roster database.
+            These quick reads anchor conversations before diving into deeper scouting flows.
+          </p>
+          <div class="summary-cards" data-summary-cards>
+            <article class="summary-card">
+              <strong>Total players tracked</strong>
+              <p>
+                <span class="stat-value" data-stat="total-players">—</span>
+                athletes have logged at least one minute since the BAA era.
+              </p>
+            </article>
+            <article class="summary-card">
+              <strong>Average build</strong>
+              <p>
+                <span class="stat-value" data-stat="average-height">—</span>
+                &nbsp;•&nbsp;
+                <span class="stat-value" data-stat="average-weight">—</span>
+              </p>
+              <p class="stat-muted">
+                Height and weight trends guide lineup archetypes and medical load projections.
+              </p>
+            </article>
+            <article class="summary-card">
+              <strong>Position mix</strong>
+              <p>
+                <span class="stat-value" data-stat="role-breakdown">—</span>
+              </p>
+              <p class="stat-muted">Share of guards, forwards, and centers in the archive.</p>
+            </article>
+            <article class="summary-card">
+              <strong>Global footprint</strong>
+              <p>
+                Players representing <span class="stat-value" data-stat="countries">—</span>
+                countries have suited up across league history.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section>
           <h2>Player archetype explorer</h2>
           <p class="lead">
             Build interactive scatter plots and radar profiles that let decision makers compare
@@ -64,6 +106,27 @@
                 categorize emerging roles. Future widgets will allow filtering by age, contract
                 status, and playoff sample size.
               </p>
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <h2>Global reach &amp; development pipelines</h2>
+          <div class="grid-two grid-two--stretch">
+            <div class="subsection">
+              <h3>Top countries of origin</h3>
+              <p class="stat-muted">
+                International scouting remains a growth lever—keep tabs on where the next wave is
+                forming.
+              </p>
+              <ol class="rank-list" data-list="countries"></ol>
+            </div>
+            <div class="subsection">
+              <h3>Most prolific college programs</h3>
+              <p class="stat-muted">
+                Track campus-to-league pipelines to align collegiate coverage and NIL partnerships.
+              </p>
+              <ol class="rank-list" data-list="colleges"></ol>
             </div>
           </div>
         </section>
@@ -102,6 +165,28 @@
               <h3>Player availability</h3>
               <p>Integrate schedule density and travel strain models to project rest nights.</p>
             </article>
+          </div>
+        </section>
+
+        <section>
+          <h2>Tallest player profiles</h2>
+          <p class="lead">
+            High-leverage size outliers redefine matchup planning. This quick table keeps coaches and
+            analysts aligned on the longest bodies in league history.
+          </p>
+          <div class="table-scroller">
+            <table class="data-table" data-table="tallest">
+              <thead>
+                <tr>
+                  <th scope="col">Player</th>
+                  <th scope="col">Height</th>
+                  <th scope="col">Weight</th>
+                  <th scope="col">Country</th>
+                  <th scope="col">Position</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
           </div>
         </section>
       </main>

--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -1,5 +1,7 @@
 import { registerCharts, helpers } from './hub-charts.js';
 
+const DATA_SOURCE = 'data/players_overview.json';
+
 const palette = {
   royal: '#1156d6',
   sky: 'rgba(31, 123, 255, 0.75)',
@@ -9,7 +11,7 @@ const palette = {
 registerCharts([
   {
     element: document.querySelector('[data-chart="player-heights"]'),
-    source: 'data/players_overview.json',
+    source: DATA_SOURCE,
     async createConfig(data) {
       const buckets = Array.isArray(data?.heightBuckets) ? data.heightBuckets : [];
       if (!buckets.length) return null;
@@ -63,7 +65,7 @@ registerCharts([
   },
   {
     element: document.querySelector('[data-chart="draft-timeline"]'),
-    source: 'data/players_overview.json',
+    source: DATA_SOURCE,
     async createConfig(data) {
       const decadeCounts = Array.isArray(data?.draftSummary?.decadeCounts)
         ? data.draftSummary.decadeCounts.filter((entry) => /\d{4}s/.test(entry.decade))
@@ -116,3 +118,136 @@ registerCharts([
     },
   },
 ]);
+
+function formatHeight(inches, { maximumFractionDigits = 0 } = {}) {
+  if (!Number.isFinite(inches)) return '—';
+  const feet = Math.floor(inches / 12);
+  const remaining = inches - feet * 12;
+  const inchString = remaining.toFixed(Math.max(0, maximumFractionDigits));
+  const trimmed = maximumFractionDigits === 0 ? inchString.replace(/\.0+$/, '') : inchString;
+  return `${feet}'${trimmed}\"`;
+}
+
+function formatWeight(pounds) {
+  if (!Number.isFinite(pounds)) return '—';
+  return `${helpers.formatNumber(pounds, 0)} lbs`;
+}
+
+function renderSummary(data) {
+  const totalPlayers = document.querySelector('[data-stat="total-players"]');
+  const avgHeight = document.querySelector('[data-stat="average-height"]');
+  const avgWeight = document.querySelector('[data-stat="average-weight"]');
+  const roleBreakdown = document.querySelector('[data-stat="role-breakdown"]');
+  const countries = document.querySelector('[data-stat="countries"]');
+
+  if (!data?.totals) return;
+
+  const { players, averageHeightInches, averageWeightPounds, guards, forwards, centers, countriesRepresented } =
+    data.totals;
+
+  if (totalPlayers) {
+    totalPlayers.textContent = helpers.formatNumber(players, 0);
+  }
+
+  if (avgHeight) {
+    avgHeight.textContent = formatHeight(averageHeightInches, { maximumFractionDigits: 1 });
+  }
+
+  if (avgWeight) {
+    avgWeight.textContent = formatWeight(averageWeightPounds);
+  }
+
+  if (roleBreakdown) {
+    const totalRolePlayers = guards + forwards + centers || players || 0;
+    if (totalRolePlayers) {
+      const segments = [
+        ['G', guards],
+        ['F', forwards],
+        ['C', centers],
+      ].map(([label, value]) => {
+        const percent = (value / totalRolePlayers) * 100;
+        return `${label} ${helpers.formatNumber(percent, 0)}%`;
+      });
+      roleBreakdown.textContent = segments.join(' • ');
+    }
+  }
+
+  if (countries) {
+    countries.textContent = helpers.formatNumber(countriesRepresented, 0);
+  }
+}
+
+function renderRankedList(root, list, labelKey, valueKey) {
+  if (!root || !Array.isArray(list) || !list.length) return;
+  const fragment = document.createDocumentFragment();
+  list.forEach((entry) => {
+    const item = document.createElement('li');
+    item.textContent = entry?.[labelKey] ?? 'Unknown';
+    const detail = document.createElement('span');
+    const value = entry?.[valueKey];
+    detail.textContent = Number.isFinite(value)
+      ? `${helpers.formatNumber(value, 0)} players`
+      : '—';
+    item.appendChild(detail);
+    fragment.appendChild(item);
+  });
+  root.innerHTML = '';
+  root.appendChild(fragment);
+}
+
+function renderTallestTable(root, tallest) {
+  if (!root || !Array.isArray(tallest) || !tallest.length) return;
+  const tbody = root.querySelector('tbody');
+  if (!tbody) return;
+
+  const rows = tallest.slice(0, 10).map((player) => {
+    const row = document.createElement('tr');
+
+    const nameCell = document.createElement('th');
+    nameCell.scope = 'row';
+    nameCell.textContent = player?.name ?? 'Unknown';
+    row.appendChild(nameCell);
+
+    const heightCell = document.createElement('td');
+    heightCell.textContent = formatHeight(player?.heightInches, { maximumFractionDigits: 0 });
+    row.appendChild(heightCell);
+
+    const weightCell = document.createElement('td');
+    weightCell.textContent = formatWeight(player?.weightPounds);
+    row.appendChild(weightCell);
+
+    const countryCell = document.createElement('td');
+    countryCell.textContent = player?.country ?? '—';
+    row.appendChild(countryCell);
+
+    const positionCell = document.createElement('td');
+    positionCell.textContent = Array.isArray(player?.positions) && player.positions.length
+      ? player.positions.join(' / ')
+      : '—';
+    row.appendChild(positionCell);
+
+    return row;
+  });
+
+  tbody.innerHTML = '';
+  rows.forEach((row) => tbody.appendChild(row));
+}
+
+async function hydratePlayersPage() {
+  try {
+    const response = await fetch(DATA_SOURCE);
+    if (!response.ok) {
+      throw new Error(`Failed to load player overview: ${response.status}`);
+    }
+    const data = await response.json();
+
+    renderSummary(data);
+    renderRankedList(document.querySelector('[data-list="countries"]'), data?.countries?.slice(0, 6), 'country', 'players');
+    renderRankedList(document.querySelector('[data-list="colleges"]'), data?.colleges?.slice(0, 6), 'program', 'players');
+    renderTallestTable(document.querySelector('[data-table="tallest"]'), data?.tallestPlayers);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+hydratePlayersPage();

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -235,10 +235,26 @@ section h2 {
   color: var(--red);
 }
 
+.stat-value {
+  font-size: clamp(1.35rem, 3vw, 1.85rem);
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.stat-muted {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.9rem;
+}
+
 .grid-two {
   display: grid;
   gap: 2rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.grid-two--stretch {
+  align-items: stretch;
 }
 
 .subsection {
@@ -276,6 +292,90 @@ section h2 {
   display: grid;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.rank-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.5rem;
+  counter-reset: list;
+}
+
+.rank-list li {
+  position: relative;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.07) 60%, rgba(255, 255, 255, 0.92) 40%);
+  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
+  border-radius: var(--radius-md);
+  padding: 0.65rem 0.9rem 0.65rem 2.3rem;
+  font-weight: 600;
+  color: var(--navy);
+}
+
+.rank-list li::before {
+  counter-increment: list;
+  content: counter(list);
+  position: absolute;
+  left: 0.7rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.45rem;
+  height: 1.45rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.95), rgba(239, 61, 91, 0.85));
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rank-list li span {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-subtle);
+}
+
+.table-scroller {
+  margin-top: 1.5rem;
+  overflow-x: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  font-size: 0.9rem;
+}
+
+.data-table thead th {
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 40%, rgba(255, 255, 255, 0.9) 60%);
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-subtle);
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table tbody tr:hover {
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.06) 50%, rgba(255, 255, 255, 0.9) 50%);
 }
 
 .story-walkthrough {


### PR DESCRIPTION
## Summary
- add an above-the-fold player landscape snapshot with automated metrics from the roster dataset
- surface top countries, college pipelines, and tallest player profiles for quick scouting reference
- extend shared styles and client script to hydrate the new sections from players_overview.json

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d83602dc9c83279725816c5c74cc65