### PR TITLE
Revamp teams hub layout and styling

### DIFF
--- a/public/scripts/teams.js
+++ b/public/scripts/teams.js
@@ -26,13 +26,25 @@ registerCharts([
               label: 'All-time win %',
               data: pct,
               backgroundColor: palette.royal,
+              borderRadius: 10,
+              maxBarThickness: 44,
             },
           ],
         },
         options: {
+          responsive: true,
+          maintainAspectRatio: false,
           indexAxis: 'y',
           layout: { padding: { top: 6, right: 8, bottom: 6, left: 8 } },
           plugins: {
+            title: {
+              display: true,
+              text: 'Franchise win pace',
+              align: 'start',
+              color: '#0b2545',
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
             legend: { display: false },
             tooltip: {
               callbacks: {
@@ -49,10 +61,16 @@ registerCharts([
               grid: { color: 'rgba(11, 37, 69, 0.08)' },
               ticks: {
                 callback: (value) => `${helpers.formatNumber(value, 0)}%`,
+                color: '#42526c',
+                font: { size: 12 },
               },
             },
             y: {
               grid: { display: false },
+              ticks: {
+                color: '#0b2545',
+                font: { weight: 600 },
+              },
             },
           },
         },
@@ -86,12 +104,23 @@ registerCharts([
               pointBorderWidth: 1.5,
               pointRadius: (ctx) => 4 + Math.min(8, ctx.raw.totalGames / 24),
               pointHoverRadius: (ctx) => 6 + Math.min(8, ctx.raw.totalGames / 24),
+              pointHoverBorderWidth: 2,
             },
           ],
         },
         options: {
+          responsive: true,
+          maintainAspectRatio: false,
           layout: { padding: 8 },
           plugins: {
+            title: {
+              display: true,
+              text: 'Back-to-back pressure vs rest windows',
+              align: 'start',
+              color: '#0b2545',
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
             legend: { display: false },
             tooltip: {
               callbacks: {
@@ -102,12 +131,15 @@ registerCharts([
               },
             },
           },
+          interaction: { mode: 'nearest', axis: 'xy', intersect: false },
           scales: {
             x: {
               title: { display: true, text: 'Back-to-back sets' },
               grid: { color: 'rgba(11, 37, 69, 0.08)' },
               ticks: {
                 callback: (value) => `${helpers.formatNumber(value, 0)}`,
+                color: '#42526c',
+                font: { size: 12 },
               },
             },
             y: {
@@ -115,6 +147,8 @@ registerCharts([
               grid: { color: 'rgba(11, 37, 69, 0.08)' },
               ticks: {
                 callback: (value) => `${helpers.formatNumber(value, 1)}`,
+                color: '#42526c',
+                font: { size: 12 },
               },
             },
           },

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -195,6 +195,253 @@ section h2 {
   color: var(--text-subtle);
 }
 
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.section-heading__actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.section-heading__actions--ghost {
+  justify-content: flex-end;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--royal);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.15) 65%, rgba(255, 255, 255, 0.9) 35%);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+}
+
+.chip--accent {
+  color: #fff;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.85));
+  border-color: transparent;
+  box-shadow: 0 12px 24px rgba(17, 86, 214, 0.28);
+}
+
+.chip--ghost {
+  color: var(--text-strong);
+  background: color-mix(in srgb, var(--surface-alt) 70%, rgba(17, 86, 214, 0.08) 30%);
+  border-color: color-mix(in srgb, var(--border) 75%, transparent);
+}
+
+.team-overview,
+.team-analytics {
+  display: grid;
+  gap: 1.75rem;
+}
+
+.team-overview__body {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(260px, 0.95fr) minmax(320px, 1.05fr);
+  align-items: stretch;
+}
+
+.team-overview__summary {
+  display: grid;
+  gap: 1rem;
+  padding: 1.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 45%, rgba(255, 255, 255, 0.85) 55%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.team-overview__summary h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--navy);
+}
+
+.checklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.checklist li {
+  display: flex;
+  gap: 0.55rem;
+  align-items: flex-start;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.checklist li::before {
+  content: '\2713';
+  flex: 0 0 auto;
+  display: inline-flex;
+  width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(31, 123, 255, 0.85));
+  color: #fff;
+  font-size: 0.85rem;
+  margin-top: 0.1rem;
+}
+
+.team-overview__panels {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.team-kpi-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-card {
+  position: relative;
+  overflow: hidden;
+  padding: 1.2rem 1.25rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background:
+    linear-gradient(160deg, rgba(17, 86, 214, 0.18), rgba(244, 181, 63, 0.12)),
+    color-mix(in srgb, var(--surface-alt) 70%, rgba(255, 255, 255, 0.9) 30%);
+  display: grid;
+  gap: 0.55rem;
+  box-shadow: 0 14px 24px rgba(11, 37, 69, 0.14);
+}
+
+.metric-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -20% -40% 40%;
+  height: 120px;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.55), transparent 65%);
+  opacity: 0.8;
+}
+
+.metric-card__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+
+.metric-card__label {
+  color: var(--navy);
+}
+
+.metric-card__pill {
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid color-mix(in srgb, var(--royal) 30%, transparent);
+  color: var(--royal);
+}
+
+.metric-card__value {
+  margin: 0;
+  font-size: clamp(1.7rem, 4vw, 2.1rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--navy);
+}
+
+.metric-card__hint {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
+.team-overview__viz .viz-canvas {
+  min-height: 280px;
+}
+
+.team-analytics__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: minmax(300px, 1.05fr) minmax(260px, 0.95fr);
+  align-items: stretch;
+}
+
+.stacked-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem 1.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: color-mix(in srgb, rgba(244, 181, 63, 0.22) 45%, rgba(255, 255, 255, 0.85) 55%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.stacked-panel h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--navy);
+}
+
+.callout-grid {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.callout-card {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 50%, rgba(255, 255, 255, 0.85) 50%);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.callout-card__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--royal);
+}
+
+.callout-card p {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.95rem;
+}
+
+.team-initiatives {
+  display: grid;
+  gap: 1rem;
+}
+
+.team-initiatives h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--navy);
+}
+
 .summary-cards {
   display: grid;
   gap: 1.1rem;
@@ -571,6 +818,29 @@ section h2 {
 
   .story-spotlights {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 960px) {
+  .team-overview__body,
+  .team-analytics__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 540px) {
+  .section-heading__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .metric-card {
+    padding: 1.1rem 1.2rem;
   }
 }
 

--- a/public/teams.html
+++ b/public/teams.html
@@ -35,37 +35,101 @@
       </header>
 
       <main>
-        <section>
-          <h2>Team diagnostics</h2>
-          <p class="lead">
-            Design modular views that blend efficiency numbers with qualitative markers such as
-            communication grades and coaching adjustments.
-          </p>
-          <div class="grid-two">
-            <div class="subsection">
+        <section class="team-overview">
+          <div class="section-heading">
+            <div>
+              <h2>Franchise health monitor</h2>
+              <p class="lead">
+                Design modular views that blend efficiency numbers with qualitative markers so front
+                offices can assess culture, continuity, and coaching tweaks at a glance.
+              </p>
+            </div>
+            <div class="section-heading__actions">
+              <span class="chip chip--accent">MVP scope</span>
+              <span class="chip">Culture index</span>
+              <span class="chip">Roster churn</span>
+              <span class="chip">Financial runway</span>
+            </div>
+          </div>
+          <div class="team-overview__body">
+            <article class="team-overview__summary">
               <h3>Organization pulse</h3>
               <p>
                 Extend <code>TeamHistories.csv</code> with modern pace-and-space indicators to see how
-                strategies evolve. Add toggles for roster churn, draft capital, and player
-                development pathways.
+                strategies evolve. Layer on roster churn, draft capital, and development pathways to
+                reveal which franchises are building lasting systems.
               </p>
-            </div>
-            <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Historical win rate leaders</header>
-              <div class="viz-canvas">
-                <canvas data-chart="win-leaders" aria-describedby="win-leaders-caption"></canvas>
+              <ul class="checklist">
+                <li>Normalize pace arcs to compare dynasties across eras.</li>
+                <li>Overlay scouting intel with scouting grades from partner clubs.</li>
+                <li>Bookmark chemistry breakpoints before trade and free agency windows.</li>
+              </ul>
+            </article>
+            <div class="team-overview__panels">
+              <div class="team-kpi-grid">
+                <article class="metric-card">
+                  <header class="metric-card__head">
+                    <span class="metric-card__label">Dynasty tier</span>
+                    <span class="metric-card__pill">Historical</span>
+                  </header>
+                  <p class="metric-card__value">Top 10</p>
+                  <p class="metric-card__hint">Clubs living above a 60% win pace, updated nightly.</p>
+                </article>
+                <article class="metric-card">
+                  <header class="metric-card__head">
+                    <span class="metric-card__label">Continuity meter</span>
+                    <span class="metric-card__pill">Rolling 30 days</span>
+                  </header>
+                  <p class="metric-card__value">87%</p>
+                  <p class="metric-card__hint">Lineup overlap weighted by clutch possessions.</p>
+                </article>
+                <article class="metric-card">
+                  <header class="metric-card__head">
+                    <span class="metric-card__label">Travel tax</span>
+                    <span class="metric-card__pill">Season to date</span>
+                  </header>
+                  <p class="metric-card__value">1.6</p>
+                  <p class="metric-card__hint">Average rest advantage compared to opponents.</p>
+                </article>
+                <article class="metric-card">
+                  <header class="metric-card__head">
+                    <span class="metric-card__label">Playbook depth</span>
+                    <span class="metric-card__pill">Video tags</span>
+                  </header>
+                  <p class="metric-card__value">42</p>
+                  <p class="metric-card__hint">Tracked sets with confirmed counters this month.</p>
+                </article>
               </div>
-              <figcaption id="win-leaders-caption" class="viz-card__caption">
-                Horizontal bars showcase the ten most efficient franchises ever, trimmed via
-                ranked slicing to keep render times snappy.
-              </figcaption>
-            </figure>
+              <figure class="viz-card viz-card--inline team-overview__viz" data-chart-wrapper>
+                <header class="viz-card__title">Historical win rate leaders</header>
+                <div class="viz-canvas">
+                  <canvas data-chart="win-leaders" aria-describedby="win-leaders-caption"></canvas>
+                </div>
+                <figcaption id="win-leaders-caption" class="viz-card__caption">
+                  Horizontal bars spotlight the ten most efficient franchises ever, trimmed via ranked
+                  slicing to keep render times snappy.
+                </figcaption>
+              </figure>
+            </div>
           </div>
         </section>
 
-        <section>
-          <h2>Lineup chemistry lab</h2>
-          <div class="grid-two">
+        <section class="team-analytics">
+          <div class="section-heading">
+            <div>
+              <h2>Lineup chemistry lab</h2>
+              <p class="lead">
+                Translate schedule strain, spacing scores, and defensive tags into actionable lineup
+                experiments before the playoffs hit.
+              </p>
+            </div>
+            <div class="section-heading__actions section-heading__actions--ghost">
+              <span class="chip chip--ghost">Spacing scores</span>
+              <span class="chip chip--ghost">Defensive tags</span>
+              <span class="chip chip--ghost">Clutch usage</span>
+            </div>
+          </div>
+          <div class="team-analytics__grid">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Schedule strain navigator</header>
               <div class="viz-canvas">
@@ -76,32 +140,50 @@
                 back-to-back sets and average rest days for busy clubs.
               </figcaption>
             </figure>
-            <div class="subsection">
+            <div class="stacked-panel">
               <h3>Key overlays</h3>
+              <p>
+                Feed in the latest shifts from <code>TeamStatistics.zip</code> as the data warehouse is
+                unlocked. Allow coaches to stress-test lineup combinations and anticipate fatigue
+                spikes weeks in advance.
+              </p>
               <div class="badge-list">
                 <span class="badge">Spacing scores</span>
                 <span class="badge">Defensive tags</span>
                 <span class="badge">Clutch usage</span>
               </div>
-              <p>
-                Feed in the latest shifts from <code>TeamStatistics.zip</code> as the data warehouse is
-                unlocked. Allow coaches to stress test lineup combinations before the playoffs.
-              </p>
+              <div class="callout-grid">
+                <article class="callout-card">
+                  <span class="callout-card__label">Continuity lenses</span>
+                  <p>Blend substitution patterns with culture grades to flag lineup volatility.</p>
+                </article>
+                <article class="callout-card">
+                  <span class="callout-card__label">Load management</span>
+                  <p>Surface travel burdens and altitude swings before scheduling rest days.</p>
+                </article>
+                <article class="callout-card">
+                  <span class="callout-card__label">Playbook sync</span>
+                  <p>Connect scout reports with video tags so staff can demo counters instantly.</p>
+                </article>
+              </div>
             </div>
           </div>
-          <div class="card-grid">
-            <article class="card">
-              <h3>Schedule strain</h3>
-              <p>Quantify back-to-back fatigue, travel, and altitude changes in a single gauge.</p>
-            </article>
-            <article class="card">
-              <h3>Game plan repository</h3>
-              <p>Store scout reports, counter plays, and set breakdowns for each opponent.</p>
-            </article>
-            <article class="card">
-              <h3>Community signals</h3>
-              <p>Integrate fan sentiment and social listening to anticipate arena energy swings.</p>
-            </article>
+          <div class="team-initiatives">
+            <h3>Activation backlog</h3>
+            <div class="card-grid">
+              <article class="card">
+                <h3>Schedule strain</h3>
+                <p>Quantify back-to-back fatigue, travel, and altitude changes in a single gauge.</p>
+              </article>
+              <article class="card">
+                <h3>Game plan repository</h3>
+                <p>Store scout reports, counter plays, and set breakdowns for each opponent.</p>
+              </article>
+              <article class="card">
+                <h3>Community signals</h3>
+                <p>Integrate fan sentiment and social listening to anticipate arena energy swings.</p>
+              </article>
+            </div>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- Rebuilt the Teams page hero content into a franchise health dashboard with KPI cards, roadmap chips, and refreshed narrative copy
- Added new styling primitives for the redesigned layout, including chip badges, stacked panels, callout grids, and responsive tweaks to eliminate horizontal overflow
- Tuned the Chart.js configurations for the win-rate and schedule visualizations with responsive sizing, titles, and polished hover states

## Testing
- Manually verified the teams page in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d83628f45c8327895228677f026d25