### PR TITLE
Build interactive history dashboard

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -28,8 +28,8 @@
           <span class="eyebrow">League Archive</span>
           <h1>Chronicle the eras that shaped today's game.</h1>
           <p>
-            Build immersive history exhibits that tie archival data to iconic moments, playoff runs,
-            and franchise legacies.
+            Plug into curated timelines, record books, and attendance milestones to turn archival datasets
+            into rich interactive retrospectives.
           </p>
         </div>
       </header>
@@ -38,50 +38,123 @@
         <section>
           <h2>Era explorer</h2>
           <p class="lead">
-            Visualize pace changes, three-point revolutions, and defensive rules across decades using
-            the league schedule and team history datasets.
+            Trace the league's growth decade by decade and see how expansion bursts, archival coverage, and
+            postseason logs stack up across the NBA timeline.
           </p>
-          <div class="grid-two">
-            <div class="chart-placeholder">Decade comparison ribbon chart placeholder</div>
-            <div class="subsection">
-              <h3>Story threads</h3>
-              <div class="badge-list">
-                <span class="badge">Dynasty trackers</span>
-                <span class="badge">Rule shifts</span>
-                <span class="badge">Underdog runs</span>
-              </div>
+
+          <div class="summary-cards summary-cards--compact">
+            <article class="summary-card">
+              <strong>Archive breadth</strong>
               <p>
-                Stitch together statistical swing points with quotes, photos, and video cues to build
-                narrative arcs. Embed contextual annotations right beside the data.
+                <span data-history="total-games">--</span> games logged from
+                <span data-history="first-game">--</span> through <span data-history="latest-game">--</span>.
               </p>
+            </article>
+            <article class="summary-card">
+              <strong>Postseason catalog</strong>
+              <p>
+                <span data-history="playoff-games">--</span> playoff contests, representing
+                <span data-history="playoff-share">--</span> of the archive.
+              </p>
+            </article>
+            <article class="summary-card">
+              <strong>Attendance record</strong>
+              <p data-history="attendance-record">--</p>
+            </article>
+          </div>
+
+          <div class="grid-two">
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Games logged by decade</header>
+              <div class="viz-canvas">
+                <canvas data-chart="games-by-decade" aria-describedby="games-by-decade-caption"></canvas>
+              </div>
+              <figcaption id="games-by-decade-caption" class="viz-card__caption">
+                A filled line plot surfaces how the volume of tracked matchups accelerated from the early BAA
+                seasons through the modern 2020s slate.
+              </figcaption>
+            </figure>
+            <div class="subsection">
+              <h3>Expansion timeline</h3>
+              <p>
+                The franchise ledger now counts <span data-history="franchise-count">--</span> active NBA clubs. The
+                busiest era was the <span data-history="peak-expansion-decade">--</span>, which added
+                <span data-history="peak-expansion-total">--</span> teams.
+              </p>
+              <ol class="timeline" data-history="expansion-timeline"></ol>
             </div>
           </div>
         </section>
 
         <section>
           <h2>Playoff retrospectives</h2>
+          <p class="lead">
+            Compare the split between regular-season grinds and postseason epics, then dive into the biggest
+            blowouts and packed houses ever captured in the game logs.
+          </p>
+
           <div class="grid-two">
-            <div class="subsection">
-              <h3>Bracket replays</h3>
-              <p>
-                Recreate historic playoff brackets, highlight upset probabilities, and surface the
-                tactical adjustments that swung each series.
-              </p>
-            </div>
-            <div class="chart-placeholder">Historic bracket explorer coming soon</div>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Game type distribution</header>
+              <div class="viz-canvas">
+                <canvas data-chart="game-type-share" aria-describedby="game-type-share-caption"></canvas>
+              </div>
+              <figcaption id="game-type-share-caption" class="viz-card__caption">
+                Doughnut segments show how regular season, playoffs, play-in tournaments, and showcase games
+                populate the historical record.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Largest victory margins</header>
+              <div class="viz-canvas">
+                <canvas data-chart="largest-margins" aria-describedby="largest-margins-caption"></canvas>
+              </div>
+              <figcaption id="largest-margins-caption" class="viz-card__caption">
+                Horizontal bars spotlight the most lopsided scorelines on file, giving historians quick access
+                to blowout context.
+              </figcaption>
+            </figure>
           </div>
+
           <div class="card-grid">
             <article class="card">
-              <h3>Legends index</h3>
-              <p>Cross-reference milestones and accolades across every era in one interactive table.</p>
+              <h3>Scoreboard fireworks</h3>
+              <p>Highest combined point totals across the archive deliver instant storytelling starters.</p>
+              <ul class="list-grid list-grid--dense" data-history="record-games"></ul>
             </article>
             <article class="card">
-              <h3>Broadcast moments</h3>
-              <p>Attach archival clips and commentary transcripts to game-level data points.</p>
+              <h3>Mega crowds</h3>
+              <p>Attendance giants that redefined what a sold-out arena looks like.</p>
+              <div class="table-scroll">
+                <table class="history-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Date</th>
+                      <th scope="col">Matchup</th>
+                      <th scope="col" class="history-table__numeric">Attendance</th>
+                    </tr>
+                  </thead>
+                  <tbody data-history="attendance-body"></tbody>
+                </table>
+              </div>
             </article>
             <article class="card">
-              <h3>Timeline builder</h3>
-              <p>Empower fans to craft personal timelines of the plays that defined their fandom.</p>
+              <h3>Archive cadence</h3>
+              <p>Monitor refresh cycles and coverage windows for the historical ingest.</p>
+              <dl class="history-facts">
+                <div class="history-facts__row">
+                  <dt>Last refresh</dt>
+                  <dd data-history="archive-updated">--</dd>
+                </div>
+                <div class="history-facts__row">
+                  <dt>Seasons tracked</dt>
+                  <dd><span data-history="season-range">--</span> (<span data-history="season-count">--</span>)</dd>
+                </div>
+                <div class="history-facts__row">
+                  <dt>Coverage span</dt>
+                  <dd><span data-history="first-game">--</span> – <span data-history="latest-game">--</span></dd>
+                </div>
+              </dl>
             </article>
           </div>
         </section>
@@ -89,5 +162,7 @@
 
       <footer class="page-footer">Preserving history to inform the next generation of NBA data stories.</footer>
     </div>
+    <script src="vendor/chart.umd.js" defer></script>
+    <script type="module" src="scripts/history.js"></script>
   </body>
 </html>

--- a/public/scripts/history.js
+++ b/public/scripts/history.js
@@ -1,0 +1,410 @@
+import { registerCharts, helpers } from './hub-charts.js';
+
+const palette = {
+  navy: '#0b2545',
+  royal: '#1156d6',
+  sky: '#1f7bff',
+  gold: '#f4b53f',
+  crimson: '#ef3d5b',
+  teal: 'rgba(17, 86, 214, 0.16)',
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+const percentFormatter = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+const summaryEls = {
+  totalGames: document.querySelector('[data-history="total-games"]'),
+  firstGame: document.querySelectorAll('[data-history="first-game"]'),
+  latestGame: document.querySelectorAll('[data-history="latest-game"]'),
+  playoffGames: document.querySelector('[data-history="playoff-games"]'),
+  playoffShare: document.querySelector('[data-history="playoff-share"]'),
+  attendanceRecord: document.querySelector('[data-history="attendance-record"]'),
+  franchiseCount: document.querySelector('[data-history="franchise-count"]'),
+  peakExpansionDecade: document.querySelector('[data-history="peak-expansion-decade"]'),
+  peakExpansionTotal: document.querySelector('[data-history="peak-expansion-total"]'),
+  expansionTimeline: document.querySelector('[data-history="expansion-timeline"]'),
+  recordGames: document.querySelector('[data-history="record-games"]'),
+  attendanceBody: document.querySelector('[data-history="attendance-body"]'),
+  archiveUpdated: document.querySelector('[data-history="archive-updated"]'),
+  seasonRange: document.querySelector('[data-history="season-range"]'),
+  seasonCount: document.querySelector('[data-history="season-count"]'),
+};
+
+function parseDate(value) {
+  if (!value) return null;
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+  const date = new Date(`${normalized}Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDate(value) {
+  const date = value instanceof Date ? value : parseDate(value);
+  if (!date) return '—';
+  return dateFormatter.format(date);
+}
+
+function setText(target, text) {
+  if (!target) return;
+  if (NodeList.prototype.isPrototypeOf(target) || Array.isArray(target)) {
+    target.forEach((node) => {
+      if (node) {
+        node.textContent = text;
+      }
+    });
+    return;
+  }
+  target.textContent = text;
+}
+
+function formatTeamName(team) {
+  if (!team) return '';
+  const parts = [team.city, team.name].filter(Boolean);
+  return parts.join(' ');
+}
+
+function formatMatchup(game) {
+  if (!game) return '';
+  const away = formatTeamName(game.away);
+  const home = formatTeamName(game.home);
+  return `${away} at ${home}`;
+}
+
+function updateEraSummary(history) {
+  if (!history?.totals) return;
+  const { totals } = history;
+  const totalGames = totals.games ?? 0;
+  setText(summaryEls.totalGames, helpers.formatNumber(totalGames, 0));
+  const first = formatDate(totals.firstGame);
+  const latest = formatDate(totals.latestGame);
+  setText(summaryEls.firstGame, first);
+  setText(summaryEls.latestGame, latest);
+
+  const playoffEntry = Array.isArray(totals.byType)
+    ? totals.byType.find((item) => item.gameType === 'Playoffs')
+    : null;
+  const playoffGames = playoffEntry?.games ?? 0;
+  setText(summaryEls.playoffGames, helpers.formatNumber(playoffGames, 0));
+  const share = totalGames ? playoffGames / totalGames : 0;
+  setText(summaryEls.playoffShare, percentFormatter.format(share));
+
+  const topAttendance = Array.isArray(history.attendanceLeaders)
+    ? [...history.attendanceLeaders].sort((a, b) => b.attendance - a.attendance)[0]
+    : null;
+  if (topAttendance && summaryEls.attendanceRecord) {
+    const opponent = formatMatchup(topAttendance);
+    const recordDate = formatDate(topAttendance.date);
+    summaryEls.attendanceRecord.textContent = `${helpers.formatNumber(topAttendance.attendance, 0)} fans watched ${opponent} on ${recordDate}.`;
+  }
+}
+
+function populateExpansionTimeline(franchises) {
+  if (!summaryEls.expansionTimeline) return;
+  summaryEls.expansionTimeline.innerHTML = '';
+  const decadeEntries = Array.isArray(franchises?.decades) ? franchises.decades : [];
+  const teams = Array.isArray(franchises?.activeFranchises) ? franchises.activeFranchises : [];
+
+  const activeTeams = teams.filter((team) => team && team.isActive && String(team.teamId).length === 10);
+  if (summaryEls.franchiseCount) {
+    setText(summaryEls.franchiseCount, helpers.formatNumber(activeTeams.length, 0));
+  }
+
+  let peakDecade = null;
+  let peakTotal = 0;
+
+  decadeEntries
+    .slice()
+    .sort((a, b) => a.decade - b.decade)
+    .forEach((entry) => {
+      const additions = activeTeams
+        .filter((team) => Math.floor(team.seasonFounded / 10) * 10 === entry.decade)
+        .sort((a, b) => a.seasonFounded - b.seasonFounded);
+      const sampleNames = additions.slice(0, 3).map((team) => team.name);
+      const item = document.createElement('li');
+      item.className = 'timeline__item';
+
+      const header = document.createElement('div');
+      header.className = 'timeline__header';
+      const year = document.createElement('span');
+      year.className = 'timeline__year';
+      year.textContent = `${entry.decade}s`;
+      const count = document.createElement('span');
+      count.className = 'timeline__count';
+      count.textContent = `${entry.total} additions`;
+      header.append(year, count);
+
+      const detail = document.createElement('p');
+      detail.className = 'timeline__detail';
+      detail.textContent = sampleNames.length
+        ? `Key arrivals: ${sampleNames.join(', ')}${additions.length > sampleNames.length ? '…' : ''}`
+        : 'Active rosters stabilized this decade.';
+
+      item.append(header, detail);
+      summaryEls.expansionTimeline.append(item);
+
+      if (entry.total > peakTotal) {
+        peakTotal = entry.total;
+        peakDecade = `${entry.decade}s`;
+      }
+    });
+
+  if (peakDecade && summaryEls.peakExpansionDecade) {
+    setText(summaryEls.peakExpansionDecade, peakDecade);
+  }
+  if (summaryEls.peakExpansionTotal) {
+    setText(summaryEls.peakExpansionTotal, helpers.formatNumber(peakTotal, 0));
+  }
+}
+
+function populateRecordGames(history) {
+  if (!summaryEls.recordGames) return;
+  summaryEls.recordGames.innerHTML = '';
+  const records = Array.isArray(history?.highestScoringGames) ? history.highestScoringGames : [];
+  records
+    .slice()
+    .sort((a, b) => b.totalPoints - a.totalPoints)
+    .slice(0, 4)
+    .forEach((game) => {
+      const item = document.createElement('li');
+      item.className = 'record-item';
+      const title = document.createElement('strong');
+      title.className = 'record-item__title';
+      const awayName = formatTeamName(game.away);
+      const homeName = formatTeamName(game.home);
+      title.textContent = `${awayName} ${game.away?.score ?? ''} @ ${homeName} ${game.home?.score ?? ''}`.trim();
+      const meta = document.createElement('span');
+      meta.className = 'record-item__meta';
+      meta.textContent = `${game.gameType} • ${formatDate(game.date)} • ${helpers.formatNumber(game.totalPoints, 0)} total points`;
+      item.append(title, meta);
+      summaryEls.recordGames.append(item);
+    });
+}
+
+function populateAttendanceTable(history) {
+  if (!summaryEls.attendanceBody) return;
+  summaryEls.attendanceBody.innerHTML = '';
+  const rows = Array.isArray(history?.attendanceLeaders) ? history.attendanceLeaders : [];
+  rows
+    .slice()
+    .sort((a, b) => b.attendance - a.attendance)
+    .slice(0, 5)
+    .forEach((game) => {
+      const tr = document.createElement('tr');
+      const dateCell = document.createElement('td');
+      dateCell.textContent = formatDate(game.date);
+      const matchupCell = document.createElement('td');
+      matchupCell.textContent = formatMatchup(game);
+      const attendanceCell = document.createElement('td');
+      attendanceCell.className = 'history-table__numeric';
+      attendanceCell.textContent = numberFormatter.format(game.attendance);
+      tr.append(dateCell, matchupCell, attendanceCell);
+      summaryEls.attendanceBody.append(tr);
+    });
+}
+
+function updateArchiveFacts(history, audit) {
+  if (summaryEls.archiveUpdated) {
+    setText(summaryEls.archiveUpdated, formatDate(history?.generatedAt));
+  }
+  const seasons = Array.isArray(audit?.games?.seasonBreakdown) ? audit.games.seasonBreakdown : [];
+  if (seasons.length && summaryEls.seasonRange) {
+    const firstSeason = seasons[0][0];
+    const lastSeason = seasons[seasons.length - 1][0];
+    setText(summaryEls.seasonRange, `${firstSeason} – ${lastSeason}`);
+    if (summaryEls.seasonCount) {
+      setText(summaryEls.seasonCount, helpers.formatNumber(seasons.length, 0));
+    }
+  }
+}
+
+async function bootstrap() {
+  try {
+    const [history, franchises, audit] = await Promise.all([
+      fetch('data/historic_games.json').then((response) => (response.ok ? response.json() : null)),
+      fetch('data/active_franchises.json').then((response) => (response.ok ? response.json() : null)),
+      fetch('data/historical_audit.json').then((response) => (response.ok ? response.json() : null)),
+    ]);
+
+    if (history) {
+      updateEraSummary(history);
+      populateRecordGames(history);
+      populateAttendanceTable(history);
+    }
+
+    if (franchises) {
+      populateExpansionTimeline(franchises);
+    }
+
+    if (history && audit) {
+      updateArchiveFacts(history, audit);
+    }
+  } catch (error) {
+    console.error('Failed to initialise history page', error);
+  }
+}
+
+registerCharts([
+  {
+    element: document.querySelector('[data-chart="games-by-decade"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data) {
+      const series = Array.isArray(data?.gamesByDecade) ? data.gamesByDecade : [];
+      if (!series.length) return null;
+      const labels = series.map((item) => item.decade);
+      const values = series.map((item) => item.games);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Games logged',
+              data: values,
+              borderColor: palette.royal,
+              backgroundColor: palette.teal,
+              borderWidth: 2,
+              fill: true,
+              tension: 0.3,
+              pointRadius: 3,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.parsed.y.toLocaleString()} games`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => numberFormatter.format(value),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="game-type-share"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data) {
+      const breakdown = Array.isArray(data?.totals?.byType) ? data.totals.byType.filter((entry) => entry.games > 0) : [];
+      if (!breakdown.length) return null;
+      const labels = breakdown.map((item) => item.gameType);
+      const values = breakdown.map((item) => item.games);
+      const colors = [palette.royal, palette.crimson, palette.gold, palette.sky, '#6f8bc5', '#4fb9c4'];
+      const total = values.reduce((acc, value) => acc + value, 0);
+
+      return {
+        type: 'doughnut',
+        data: {
+          labels,
+          datasets: [
+            {
+              data: values,
+              backgroundColor: colors.slice(0, values.length),
+              borderWidth: 0,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          plugins: {
+            legend: { position: 'bottom' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const value = context.parsed;
+                  const share = total ? value / total : 0;
+                  return `${context.label}: ${numberFormatter.format(value)} games (${percentFormatter.format(share)})`;
+                },
+              },
+            },
+          },
+          cutout: '60%',
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="largest-margins"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data) {
+      const rows = Array.isArray(data?.largestMargins) ? data.largestMargins : [];
+      if (!rows.length) return null;
+      const topRows = helpers.rankAndSlice(rows, 6, (item) => item.margin).sort((a, b) => b.margin - a.margin);
+      const labels = topRows.map((game) => {
+        const date = formatDate(game.date);
+        return `${formatTeamName(game.home)} vs ${formatTeamName(game.away)} (${date.split(', ')[1] ?? date})`;
+      });
+      const margins = topRows.map((game) => game.margin);
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Margin of victory',
+              data: margins,
+              backgroundColor: palette.crimson,
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          layout: { padding: { top: 8, right: 12, bottom: 8, left: 12 } },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const game = topRows[context.dataIndex];
+                  const totalPoints = helpers.formatNumber(game.totalPoints, 0);
+                  return `${context.parsed.x} point win • ${totalPoints} total points`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              suggestedMax: Math.max(...margins) + 5,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${value} pts`,
+              },
+            },
+            y: {
+              grid: { display: false },
+            },
+          },
+        },
+      };
+    },
+  },
+]);
+
+bootstrap();

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -202,6 +202,10 @@ section h2 {
   margin-top: 1.5rem;
 }
 
+.summary-cards--compact {
+  margin-top: 1.25rem;
+}
+
 .summary-card {
   position: relative;
   background: var(--surface-alt);
@@ -276,6 +280,50 @@ section h2 {
   display: grid;
   gap: 1.25rem;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline__item {
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.1) 50%, rgba(255, 255, 255, 0.9) 50%);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.timeline__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.timeline__year {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--navy);
+}
+
+.timeline__count {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--royal);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.timeline__detail {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
 }
 
 .story-walkthrough {
@@ -677,6 +725,98 @@ section h2 {
   background: color-mix(in srgb, rgba(244, 181, 63, 0.2) 40%, rgba(255, 255, 255, 0.85) 60%);
   color: var(--navy);
   font-weight: 600;
+}
+
+.list-grid--dense {
+  gap: 0.85rem;
+}
+
+.list-grid .record-item {
+  padding: 0.75rem 0.9rem;
+  background: color-mix(in srgb, rgba(244, 181, 63, 0.18) 55%, rgba(255, 255, 255, 0.92) 45%);
+  display: grid;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.list-grid .record-item__title {
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--navy);
+}
+
+.list-grid .record-item__meta {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+  font-weight: 500;
+}
+
+.table-scroll {
+  overflow-x: auto;
+  border-radius: var(--radius-sm);
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 260px;
+  font-size: 0.92rem;
+}
+
+.history-table thead {
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
+}
+
+.history-table th,
+.history-table td {
+  padding: 0.65rem 0.8rem;
+  text-align: left;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  color: var(--text-subtle);
+}
+
+.history-table th {
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--navy);
+}
+
+.history-table td {
+  color: var(--navy);
+}
+
+.history-table__numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--navy);
+}
+
+.history-facts {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.history-facts__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.history-facts__row dt {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+}
+
+.history-facts__row dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--navy);
 }
 
 .list-grid li span {


### PR DESCRIPTION
## Summary
- replace the History tab placeholders with live archive summaries, decade charts, and postseason breakdowns
- add a history.js module that hydrates summary cards, timelines, record lists, and Chart.js views from the JSON data sets
- extend hub styles with timeline, table, and record list patterns to support the new history layout

## Testing
- python3 -m http.server 8000 (manual UI verification)


------
https://chatgpt.com/codex/tasks/task_e_68d8364898e48327982489fbedfe06ff