### PR TITLE
Fix chart cards from creating runaway height

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -524,11 +524,19 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   background: linear-gradient(160deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.1)); box-shadow: var(--shadow-soft);
 }
-.viz-card--inline { height: 100%; grid-template-rows: auto 1fr auto; }
+.viz-card--inline {
+  height: 100%;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
 .viz-card__title { margin: 0; font-size: 1.05rem; font-weight: 700; color: var(--navy); }
 .viz-card__caption { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
 .viz-canvas { position: relative; min-height: 240px; }
-.viz-card canvas { width: 100% !important; height: 100% !important; }
+.viz-card canvas {
+  display: block;
+  width: 100% !important;
+  height: auto !important;
+  max-height: 100%;
+}
 .viz-error { border-color: rgba(239, 61, 91, 0.4); }
 .viz-error__message {
   margin: 0; padding: 0.75rem 1rem; border-radius: var(--radius-sm);


### PR DESCRIPTION
## Summary
- prevent inline viz cards from allocating unbounded row height in CSS grid layouts
- allow charts to size themselves vertically while respecting container bounds

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d83a8c5c8083279e8d941459c74736