### PR TITLE
Build immersive 2025-26 NBA season landing preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,62 +25,159 @@
           </nav>
         </div>
         <div class="hero">
-          <span class="eyebrow">Season Preview Special</span>
-          <h1>The definitive 2025-26 NBA outlook from Intelligence Hub.</h1>
+          <span class="eyebrow">Season Preview Premiere · 2025-26</span>
+          <h1>The NBA storyworld rendered in color, context, and controlled chaos.</h1>
           <p>
-            Step onto the catwalk of the coming season with bold visuals, data-driven storylines,
-            and the narrative framing only our analysts can deliver. From contender DNA to rookie
-            disruption and tactical reinventions, this preview distills thousands of data points into
-            a cinematic tour of what awaits in 2025-26.
+            1,161 regular-season tilts, 67 Emirates NBA Cup showdowns, 10 global showcases, and a
+            cavalcade of roster rewrites—the Intelligence Hub rebuilt the preview so you can feel the
+            season before the opening tip.
           </p>
+          <div class="hero-panels" aria-live="polite">
+            <article class="hero-panel hero-panel--primary" data-top-team-card>
+              <span class="hero-panel__eyebrow">Power index</span>
+              <h2 class="hero-panel__headline">
+                <span data-top-team-name>Boston Celtics</span>
+              </h2>
+              <p class="hero-panel__meta">
+                <span data-top-team-record>4,091-2,765</span> all-time · +<span data-top-team-margin>3.0</span> nightly margin
+              </p>
+              <p class="hero-panel__detail">
+                Dynasty DNA anchored by <span data-top-team-strength>106.2 points for vs. 103.2 allowed</span> keeps the throne warm.
+              </p>
+            </article>
+            <article class="hero-panel hero-panel--event" data-cup-highlight>
+              <span class="hero-panel__eyebrow">Cup crescendo</span>
+              <h2 class="hero-panel__headline">
+                <time data-cup-date datetime="2025-12-17">Dec 17 · Las Vegas</time>
+              </h2>
+              <p class="hero-panel__meta">
+                Emirates NBA Cup Championship returns to <span data-cup-arena>T-Mobile Arena</span>.
+              </p>
+              <p class="hero-panel__detail">
+                <span data-cup-story>67 Cup tilts funnel into one desert coronation.</span>
+              </p>
+            </article>
+            <article class="hero-panel hero-panel--event" data-global-highlight>
+              <span class="hero-panel__eyebrow">Global stage</span>
+              <h2 class="hero-panel__headline">
+                <time data-global-date datetime="2025-10-04">Oct 4 · Abu Dhabi</time>
+              </h2>
+              <p class="hero-panel__meta">
+                <span data-global-match>Nuggets vs. Celtics</span> ignite the worldwide runway.
+              </p>
+              <p class="hero-panel__detail">
+                <span data-global-count>10 neutral-site showcases</span> stretch from Montreal to Macao.
+              </p>
+            </article>
+          </div>
           <div class="cta-group" role="group" aria-label="Primary actions">
             <a class="cta cta--primary" href="players.html">Dive into player forecasts</a>
             <a class="cta cta--ghost" href="#story-arcs">Jump to marquee story arcs</a>
           </div>
-          <dl class="hero-metrics">
+          <dl class="hero-metrics" aria-live="polite">
             <div class="hero-metrics__item">
-              <dt>Contenders spotlighted</dt>
-              <dd>8 franchises graded on continuity, depth, and upside momentum.</dd>
+              <dt>Rest crunch</dt>
+              <dd>
+                <span data-metric-backtoback>446</span> zero-day turnarounds across
+                <span data-metric-restwindows>2,779</span> rest windows tighten recovery math.
+              </dd>
             </div>
             <div class="hero-metrics__item">
-              <dt>Breakout candidates</dt>
-              <dd>26 players modeled for usage leaps and efficiency spikes.</dd>
+              <dt>Emirates Cup slate</dt>
+              <dd>
+                <span data-metric-cupgames>67</span> tournament clashes channel the league into December drama.
+              </dd>
             </div>
             <div class="hero-metrics__item">
-              <dt>Season simulations</dt>
-              <dd>40,000 Monte Carlo runs fused into narrative-ready probability tiers.</dd>
+              <dt>Global showcases</dt>
+              <dd>
+                <span data-metric-globalgames>10</span> international spotlight games widen the broadcast canvas.
+              </dd>
             </div>
           </dl>
         </div>
       </header>
 
       <main>
+        <section class="season-snapshot" id="season-panorama">
+          <div class="section-header">
+            <h2>The 2025-26 board, already moving</h2>
+            <p class="lead" data-season-lead>
+              1,161 regular-season games, 446 zero-day rest intervals, and 67 Cup showdowns—every storyline has a lane.
+            </p>
+          </div>
+          <div class="season-snapshot__grid">
+            <article class="season-snapshot__panel season-snapshot__panel--wide">
+              <header class="season-snapshot__header">
+                <h3>Title race velocity</h3>
+                <p>Historical pace leaders power our contender tiers.</p>
+              </header>
+              <div class="contender-grid" data-contender-grid>
+                <p class="contender-grid__placeholder">Loading contender pulses…</p>
+              </div>
+            </article>
+            <article class="season-snapshot__panel">
+              <header class="season-snapshot__header">
+                <h3>Rest management radar</h3>
+                <p>Who shoulders the toughest travel math before All-Star weekend.</p>
+              </header>
+              <ul class="rest-list" data-back-to-back-list>
+                <li class="rest-list__placeholder">Back-to-back intensity table incoming…</li>
+              </ul>
+              <p class="rest-list__footer">
+                League average rest: <span data-rest-average>3.0 days</span> across
+                <span data-rest-intervals>2,779</span> tracked windows.
+              </p>
+            </article>
+            <article class="season-snapshot__panel">
+              <header class="season-snapshot__header">
+                <h3>Spotlight itinerary</h3>
+                <p>Circle the showcases that define the 2025-26 stage.</p>
+              </header>
+              <ol class="timeline" data-season-timeline>
+                <li class="timeline__placeholder">Key dates loading…</li>
+              </ol>
+            </article>
+          </div>
+        </section>
+
         <section>
-          <h2>2025-26 season preview, condensed and vivid</h2>
+          <h2>Your 2025-26 systems map</h2>
           <p class="lead">
-            We rewired the landing experience around the questions fans and front offices are asking
-            right now. Follow the threads, jump into the dashboards, and let the visuals bend the
-            narrative toward opening night.
+            Follow the interlocking layers—contender DNA, skill ascents, global runway, and tactical
+            experiments—that weaves this campaign into a living broadcast open.
           </p>
           <div class="summary-cards">
             <article class="summary-card">
               <strong>Contender calculus</strong>
-              <p>Heat maps and flow charts explain why each favorite can—or can’t—outlast June.</p>
+              <p>
+                Heat maps and flow charts quantify why Boston, Los Angeles, Oklahoma City, and Phoenix
+                headline the margin-of-error elite.
+              </p>
               <a href="teams.html">Assess the title tier →</a>
             </article>
             <article class="summary-card">
               <strong>Breakout forecast lab</strong>
-              <p>Interactive sliders illustrate usage ceilings for sophomores and stealth veterans.</p>
+              <p>
+                Interactive sliders illustrate usage ceilings for sophomores, stealth veterans, and the
+                triple-double wave cresting at 175 a year.
+              </p>
               <a href="players.html">Meet the risers →</a>
             </article>
             <article class="summary-card">
               <strong>Rookie runway</strong>
-              <p>Storytelling panels track lottery talent from Summer League sparks to rotation stakes.</p>
+              <p>
+                Storytelling panels track lottery talent from Abu Dhabi scrimmages to opening-night
+                rotation stakes with global context baked in.
+              </p>
               <a href="history.html">Explore debut timelines →</a>
             </article>
             <article class="summary-card">
               <strong>Tactical experiments</strong>
-              <p>Animation prototypes break down spacing gambits, heliocentric pivots, and defensive gambles.</p>
+              <p>
+                Animation prototypes break down Cup-specific game plans, heliocentric pivots, and defensive
+                gambles on the wingspan renaissance.
+              </p>
               <a href="insights.html">See the lab notes →</a>
             </article>
           </div>
@@ -173,6 +270,30 @@
                 probabilities from EuroLeague, G League Ignite, and college strongholds.
               </figcaption>
             </figure>
+          </div>
+        </section>
+
+        <section class="story-verse" aria-labelledby="story-verse-title">
+          <div class="section-header">
+            <h2 id="story-verse-title">Narratives stitched from the data vault</h2>
+            <p class="lead">
+              Editorial walkthroughs pair raw metrics with context clips so your rundown reads like a docuseries binge.
+            </p>
+          </div>
+          <div class="story-verse__grid" data-story-grid>
+            <article class="story-verse__placeholder">Loading narrative reels…</article>
+          </div>
+        </section>
+
+        <section class="legacy-currents">
+          <div class="section-header">
+            <h2>Legacy currents powering the next chapter</h2>
+            <p class="lead">
+              Career benchmarks from LeBron to Stockton frame how we evaluate the next wave of box-score disruptors and clutch playmakers.
+            </p>
+          </div>
+          <div class="legacy-currents__grid" data-legacy-grid>
+            <article class="legacy-card legacy-card--placeholder">Pulling legend resumes…</article>
           </div>
         </section>
 

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -8,6 +8,460 @@ const palette = {
   navy: '#0b2545',
 };
 
+async function fetchJsonSafe(url) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to load ${url}: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.warn('Unable to fetch preview data', url, error);
+    return null;
+  }
+}
+
+function safeText(target, value) {
+  const node = typeof target === 'string' ? document.querySelector(target) : target;
+  if (node && typeof value !== 'undefined' && value !== null) {
+    node.textContent = value;
+  }
+}
+
+function formatDateLabel(dateString, options = { month: 'short', day: 'numeric' }) {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return new Intl.DateTimeFormat('en-US', options).format(date);
+}
+
+function createTeamLookup(scheduleData) {
+  const map = new Map();
+  const teams = Array.isArray(scheduleData?.teams) ? scheduleData.teams : [];
+  teams.forEach((team) => {
+    if (team?.teamId) {
+      map.set(String(team.teamId), team);
+    }
+  });
+  return map;
+}
+
+function formatLocation(game) {
+  if (!game) return '';
+  const segments = [game.city, game.state].filter(Boolean);
+  return segments.join(', ') || 'Neutral site';
+}
+
+function formatMatchup(game, lookup) {
+  if (!game) return '';
+  const home = lookup.get(String(game.hometeamId))?.name;
+  const away = lookup.get(String(game.awayteamId))?.name;
+  if (home && away) {
+    return `${away} vs. ${home}`;
+  }
+  if (home || away) {
+    return home || away;
+  }
+  return game.subLabel || game.label || 'Showcase';
+}
+
+function hydrateHero(teamData, scheduleData) {
+  const leaders = helpers.rankAndSlice(
+    Array.isArray(teamData?.winPctLeaders) ? teamData.winPctLeaders : [],
+    1,
+    (team) => team.winPct
+  );
+  const topTeam = leaders[0];
+  if (topTeam) {
+    const margin = (topTeam.pointsPerGame ?? 0) - (topTeam.opponentPointsPerGame ?? 0);
+    safeText('[data-top-team-name]', topTeam.team);
+    safeText('[data-top-team-record]', `${helpers.formatNumber(topTeam.wins, 0)}-${helpers.formatNumber(topTeam.losses, 0)}`);
+    safeText('[data-top-team-margin]', helpers.formatNumber(Math.abs(margin), 1));
+    safeText(
+      '[data-top-team-strength]',
+      `${helpers.formatNumber(topTeam.pointsPerGame ?? 0, 1)} points for vs. ${helpers.formatNumber(
+        topTeam.opponentPointsPerGame ?? 0,
+        1
+      )} allowed`
+    );
+  }
+
+  if (!scheduleData) {
+    return;
+  }
+
+  const restSummary = scheduleData?.restSummary ?? {};
+  const labelBreakdown = Array.isArray(scheduleData?.labelBreakdown) ? scheduleData.labelBreakdown : [];
+  const specialGames = Array.isArray(scheduleData?.specialGames) ? scheduleData.specialGames : [];
+  const globalGames = specialGames.filter((game) => game?.subtype === 'Global Games');
+  const cupGamesEntry = labelBreakdown.find((entry) => entry?.label === 'Emirates NBA Cup');
+  const cupGamesCount = cupGamesEntry?.games ?? 0;
+
+  safeText('[data-metric-backtoback]', helpers.formatNumber(restSummary.backToBackIntervals ?? 0, 0));
+  safeText('[data-metric-restwindows]', helpers.formatNumber(restSummary.totalIntervals ?? 0, 0));
+  safeText('[data-metric-cupgames]', helpers.formatNumber(cupGamesCount, 0));
+  safeText('[data-metric-globalgames]', helpers.formatNumber(globalGames.length || 0, 0));
+
+  const teamLookup = createTeamLookup(scheduleData);
+
+  const cupHighlight = specialGames
+    .filter((game) => game?.label === 'Emirates NBA Cup' && /championship|final/i.test(game?.subLabel ?? ''))
+    .sort((a, b) => new Date(a.date) - new Date(b.date))[0];
+  if (cupHighlight) {
+    const cupDate = document.querySelector('[data-cup-date]');
+    if (cupDate) {
+      cupDate.dateTime = cupHighlight.date;
+      cupDate.textContent = `${formatDateLabel(cupHighlight.date)} · ${formatLocation(cupHighlight)}`.trim();
+    }
+    safeText('[data-cup-arena]', cupHighlight.arena || 'Neutral site');
+    const cupTotal = cupGamesCount || labelBreakdown.find((entry) => entry?.label === 'Emirates NBA Cup')?.games || 0;
+    safeText('[data-cup-story]', `${helpers.formatNumber(cupTotal, 0)} Cup tilts funnel into one desert coronation.`);
+  }
+
+  const globalHighlight = globalGames.sort((a, b) => new Date(a.date) - new Date(b.date))[0];
+  if (globalHighlight) {
+    const globalDate = document.querySelector('[data-global-date]');
+    if (globalDate) {
+      globalDate.dateTime = globalHighlight.date;
+      globalDate.textContent = `${formatDateLabel(globalHighlight.date)} · ${formatLocation(globalHighlight)}`.trim();
+    }
+    safeText('[data-global-match]', formatMatchup(globalHighlight, teamLookup));
+    safeText('[data-global-count]', `${helpers.formatNumber(globalGames.length || 0, 0)} neutral-site showcases`);
+  }
+}
+
+function renderSeasonLead(scheduleData) {
+  const lead = document.querySelector('[data-season-lead]');
+  if (!lead || !scheduleData) {
+    return;
+  }
+  const totals = scheduleData?.totals ?? {};
+  const restSummary = scheduleData?.restSummary ?? {};
+  const cupGamesEntry = Array.isArray(scheduleData?.labelBreakdown)
+    ? scheduleData.labelBreakdown.find((entry) => entry?.label === 'Emirates NBA Cup')
+    : null;
+  const cupGamesCount = cupGamesEntry?.games ?? 0;
+  const text = `${helpers.formatNumber(totals.regularSeason ?? totals.games ?? 0, 0)} regular-season games, ${helpers.formatNumber(
+    restSummary.backToBackIntervals ?? 0,
+    0
+  )} zero-day rest intervals, and ${helpers.formatNumber(cupGamesCount, 0)} Cup showdowns—every storyline has a lane.`;
+  lead.textContent = text;
+}
+
+function renderContenderGrid(teamData) {
+  const container = document.querySelector('[data-contender-grid]');
+  if (!container) {
+    return;
+  }
+  container.innerHTML = '';
+  const teams = helpers
+    .rankAndSlice(Array.isArray(teamData?.winPctLeaders) ? teamData.winPctLeaders : [], 6, (team) => team.winPct)
+    .sort((a, b) => b.winPct - a.winPct);
+  if (!teams.length) {
+    const placeholder = document.createElement('p');
+    placeholder.className = 'contender-grid__placeholder';
+    placeholder.textContent = 'Contender data is warming up—check back soon.';
+    container.appendChild(placeholder);
+    return;
+  }
+
+  teams.forEach((team, index) => {
+    const card = document.createElement('article');
+    card.className = 'contender-card';
+    const margin = (team.pointsPerGame ?? 0) - (team.opponentPointsPerGame ?? 0);
+    const marginLabel = `${margin >= 0 ? '+' : '–'}${helpers.formatNumber(Math.abs(margin), 1)}`;
+    card.innerHTML = `
+      <header class="contender-card__header">
+        <span class="contender-card__rank">${index + 1}</span>
+        <h4 class="contender-card__team">${team.team}</h4>
+      </header>
+      <dl class="contender-card__metrics">
+        <div><dt>Win rate</dt><dd>${helpers.formatNumber((team.winPct ?? 0) * 100, 1)}%</dd></div>
+        <div><dt>Scoring margin</dt><dd>${marginLabel}</dd></div>
+        <div><dt>Assist engine</dt><dd>${helpers.formatNumber(team.assistsPerGame ?? 0, 1)} apg</dd></div>
+      </dl>
+      <p class="contender-card__note">${helpers.formatNumber(team.pointsPerGame ?? 0, 1)} points per night, ${helpers.formatNumber(
+      team.opponentPointsPerGame ?? 0,
+      1
+    )} allowed.</p>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function renderBackToBack(scheduleData) {
+  const list = document.querySelector('[data-back-to-back-list]');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  const leaders = Array.isArray(scheduleData?.backToBackLeaders) ? scheduleData.backToBackLeaders.slice(0, 5) : [];
+  if (!leaders.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'rest-list__placeholder';
+    placeholder.textContent = 'Back-to-back intensity data is still syncing.';
+    list.appendChild(placeholder);
+  } else {
+    leaders.forEach((entry, index) => {
+      const item = document.createElement('li');
+      item.className = 'rest-list__item';
+      const rank = document.createElement('span');
+      rank.className = 'rest-list__rank';
+      rank.textContent = String(index + 1);
+      const body = document.createElement('div');
+      body.className = 'rest-list__content';
+      const team = document.createElement('p');
+      team.className = 'rest-list__team';
+      team.textContent = entry.name;
+      const meta = document.createElement('p');
+      meta.className = 'rest-list__meta';
+      meta.textContent = `${helpers.formatNumber(entry.backToBacks ?? 0, 0)} back-to-backs · ${helpers.formatNumber(
+        entry.averageRestDays ?? 0,
+        2
+      )} avg rest days`;
+      const notes = document.createElement('p');
+      notes.className = 'rest-list__notes';
+      notes.textContent = `Home stand max: ${helpers.formatNumber(entry.longestHomeStand ?? 0, 0)} · Road trip max: ${helpers.formatNumber(
+        entry.longestRoadTrip ?? 0,
+        0
+      )}`;
+      body.append(team, meta, notes);
+      item.append(rank, body);
+      list.appendChild(item);
+    });
+  }
+
+  const restAverage = document.querySelector('[data-rest-average]');
+  if (restAverage) {
+    restAverage.textContent = `${helpers.formatNumber(scheduleData?.restSummary?.averageRestDays ?? 0, 2)} days`;
+  }
+  safeText('[data-rest-intervals]', helpers.formatNumber(scheduleData?.restSummary?.totalIntervals ?? 0, 0));
+}
+
+function renderTimeline(scheduleData) {
+  const list = document.querySelector('[data-season-timeline]');
+  if (!list) {
+    return;
+  }
+  list.innerHTML = '';
+  if (!scheduleData) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'timeline__placeholder';
+    placeholder.textContent = 'Spotlight dates arrive once the schedule manifest loads.';
+    list.appendChild(placeholder);
+    return;
+  }
+  const specialGames = Array.isArray(scheduleData?.specialGames) ? scheduleData.specialGames : [];
+  const teamLookup = createTeamLookup(scheduleData);
+  const events = [];
+
+  const addEvent = (game, headline) => {
+    if (!game) return;
+    events.push({
+      date: game.date,
+      headline,
+      detail: `${formatMatchup(game, teamLookup)} · ${game.arena || 'Neutral site'}`,
+      location: formatLocation(game),
+    });
+  };
+
+  const sortAsc = (a, b) => new Date(a.date) - new Date(b.date);
+  const globalGame = specialGames.filter((game) => game?.subtype === 'Global Games').sort(sortAsc)[0];
+  addEvent(globalGame, 'Global tip-off');
+  const cupFinal = specialGames
+    .filter((game) => game?.label === 'Emirates NBA Cup' && /championship|final/i.test(game?.subLabel ?? ''))
+    .sort(sortAsc)[0];
+  addEvent(cupFinal, 'Emirates NBA Cup championship');
+  const parisGame = specialGames.filter((game) => game?.label === 'NBA Paris Game').sort(sortAsc)[0];
+  addEvent(parisGame, 'Paris spotlight');
+  const mexicoGame = specialGames.filter((game) => game?.label === 'NBA Mexico City Game').sort(sortAsc)[0];
+  addEvent(mexicoGame, 'Mexico City showcase');
+  const finalsGame = specialGames
+    .filter((game) => game?.label === 'NBA Finals')
+    .sort((a, b) => new Date(b.date) - new Date(a.date))[0];
+  addEvent(finalsGame, 'Projected Finals climax');
+
+  const uniqueEvents = events.filter((event, index, array) => {
+    const key = `${event.headline}-${event.date}`;
+    return array.findIndex((candidate) => `${candidate.headline}-${candidate.date}` === key) === index;
+  });
+
+  if (!uniqueEvents.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'timeline__placeholder';
+    placeholder.textContent = 'Spotlight dates arrive once the schedule manifest loads.';
+    list.appendChild(placeholder);
+    return;
+  }
+
+  uniqueEvents
+    .sort((a, b) => new Date(a.date) - new Date(b.date))
+    .slice(0, 5)
+    .forEach((event) => {
+      const item = document.createElement('li');
+      item.className = 'timeline__item';
+      const dateLabel = document.createElement('time');
+      dateLabel.className = 'timeline__date';
+      dateLabel.dateTime = event.date;
+      dateLabel.textContent = formatDateLabel(event.date, { month: 'short', day: 'numeric', year: 'numeric' });
+      const headline = document.createElement('p');
+      headline.className = 'timeline__headline';
+      headline.textContent = event.headline;
+      const detail = document.createElement('p');
+      detail.className = 'timeline__detail';
+      detail.textContent = `${event.detail} — ${event.location}`;
+      item.append(dateLabel, headline, detail);
+      list.appendChild(item);
+    });
+}
+
+function renderStoryCards(storyData) {
+  const grid = document.querySelector('[data-story-grid]');
+  if (!grid) {
+    return;
+  }
+  grid.innerHTML = '';
+  const stories = Array.isArray(storyData?.stories) ? storyData.stories.slice(0, 3) : [];
+  if (!stories.length) {
+    const placeholder = document.createElement('article');
+    placeholder.className = 'story-verse__placeholder';
+    placeholder.textContent = 'Narrative walkthroughs unlock as soon as the data feed syncs.';
+    grid.appendChild(placeholder);
+    return;
+  }
+
+  stories.forEach((story) => {
+    const card = document.createElement('article');
+    card.className = 'story-card';
+    const header = document.createElement('header');
+    header.className = 'story-card__header';
+    const eyebrow = document.createElement('span');
+    eyebrow.className = 'story-card__eyebrow';
+    eyebrow.textContent = story.metric?.label ?? 'Featured metric';
+    const title = document.createElement('h3');
+    title.textContent = story.title;
+    header.append(eyebrow, title);
+
+    const lede = document.createElement('p');
+    lede.className = 'story-card__lede';
+    lede.textContent = story.lede;
+
+    const metric = document.createElement('div');
+    metric.className = 'story-card__metric';
+    const metricValue = document.createElement('span');
+    metricValue.className = 'story-card__metric-value';
+    metricValue.textContent = story.metric?.value ?? '';
+    const metricContext = document.createElement('span');
+    metricContext.className = 'story-card__metric-context';
+    metricContext.textContent = story.metric?.context ?? '';
+    metric.append(metricValue, metricContext);
+
+    const points = document.createElement('ul');
+    points.className = 'story-card__points';
+    (Array.isArray(story.editorial) ? story.editorial.slice(0, 3) : []).forEach((point) => {
+      const li = document.createElement('li');
+      li.textContent = point;
+      points.appendChild(li);
+    });
+
+    const spotlights = document.createElement('div');
+    spotlights.className = 'story-card__spotlights';
+    (Array.isArray(story.spotlights) ? story.spotlights.slice(0, 3) : []).forEach((spotlight) => {
+      const highlight = document.createElement('span');
+      highlight.className = 'story-card__spotlight';
+      const value = document.createElement('strong');
+      value.textContent = spotlight.value;
+      const label = document.createElement('small');
+      label.textContent = spotlight.label;
+      const context = document.createElement('em');
+      context.textContent = spotlight.context;
+      highlight.append(value, label, context);
+      spotlights.appendChild(highlight);
+    });
+
+    card.append(header, lede, metric, points, spotlights);
+    grid.appendChild(card);
+  });
+}
+
+function renderLegacy(leadersData) {
+  const grid = document.querySelector('[data-legacy-grid]');
+  if (!grid) {
+    return;
+  }
+  grid.innerHTML = '';
+  const categories = [
+    { key: 'points', label: 'Scoring vault', valueKey: 'points', perGameKey: 'pointsPerGame', unit: 'pts' },
+    { key: 'assists', label: 'Playmaking lineage', valueKey: 'assists', perGameKey: 'assistsPerGame', unit: 'ast' },
+    { key: 'rebounds', label: 'Glass dynasty', valueKey: 'rebounds', perGameKey: 'reboundsPerGame', unit: 'reb' },
+  ];
+
+  if (!leadersData) {
+    const placeholder = document.createElement('article');
+    placeholder.className = 'legacy-card legacy-card--placeholder';
+    placeholder.textContent = 'Legendary benchmarks will populate once the leader archive loads.';
+    grid.appendChild(placeholder);
+    return;
+  }
+
+  categories.forEach((category) => {
+    const list = Array.isArray(leadersData?.careerLeaders?.[category.key])
+      ? leadersData.careerLeaders[category.key].slice(0, 3)
+      : [];
+    const card = document.createElement('article');
+    card.className = 'legacy-card';
+    const header = document.createElement('div');
+    header.className = 'legacy-card__header';
+    const tag = document.createElement('span');
+    tag.className = 'legacy-card__tag';
+    tag.textContent = category.label;
+    const title = document.createElement('h3');
+    title.textContent = list[0]?.name ?? 'Legacy leaders';
+    const summary = document.createElement('p');
+    summary.className = 'legacy-card__summary';
+    summary.textContent = list[0]
+      ? `${helpers.formatNumber(list[0][category.valueKey] ?? 0, 0)} ${category.unit} career • ${helpers.formatNumber(
+          list[0][category.perGameKey] ?? 0,
+          2
+        )} per game`
+      : 'Benchmarks updating in real time.';
+    header.append(tag, title, summary);
+
+    const ul = document.createElement('ul');
+    ul.className = 'legacy-card__list';
+    if (!list.length) {
+      const placeholder = document.createElement('li');
+      placeholder.className = 'legacy-card__list-item';
+      placeholder.textContent = 'Data pending for this category.';
+      ul.appendChild(placeholder);
+    } else {
+      list.forEach((player) => {
+        const li = document.createElement('li');
+        li.className = 'legacy-card__list-item';
+        const name = document.createElement('strong');
+        name.textContent = player.name;
+        const totals = document.createElement('span');
+        totals.textContent = `${helpers.formatNumber(player[category.valueKey] ?? 0, 0)} ${category.unit} • ${helpers.formatNumber(
+          player[category.perGameKey] ?? 0,
+          2
+        )} per game`;
+        const era = document.createElement('span');
+        const seasons = [player.firstSeason, player.lastSeason].filter((season) => typeof season === 'number');
+        const window = seasons.length === 2 ? `${seasons[0]}–${seasons[1]}` : '';
+        const teams = Array.isArray(player.teams) ? player.teams.slice(0, 3).join(', ') : '';
+        era.textContent = [window, teams].filter(Boolean).join(' • ');
+        li.append(name, totals, era);
+        ul.appendChild(li);
+      });
+    }
+
+    card.append(header, ul);
+    grid.appendChild(card);
+  });
+}
+
 async function resolveScheduleSource() {
   const fallback = 'data/season_25_26_schedule.json';
   try {
@@ -206,6 +660,21 @@ async function bootstrap() {
       },
     },
   ]);
+
+  const [scheduleData, teamData, storyData, leaderData] = await Promise.all([
+    fetchJsonSafe(scheduleSource),
+    fetchJsonSafe('data/team_performance.json'),
+    fetchJsonSafe('data/storytelling_walkthroughs.json'),
+    fetchJsonSafe('data/player_leaders.json'),
+  ]);
+
+  hydrateHero(teamData, scheduleData);
+  renderSeasonLead(scheduleData);
+  renderContenderGrid(teamData);
+  renderBackToBack(scheduleData);
+  renderTimeline(scheduleData);
+  renderStoryCards(storyData);
+  renderLegacy(leaderData);
 }
 
 bootstrap();

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -110,6 +110,88 @@ a:hover, a:focus { color: var(--sky); }
 }
 .hero-metrics dd { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
 
+.hero-panels {
+  margin: 2.4rem auto 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  max-width: 960px;
+}
+
+.hero-panel {
+  position: relative;
+  overflow: hidden;
+  padding: 1.35rem 1.4rem 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.18), rgba(244, 181, 63, 0.12)),
+    color-mix(in srgb, var(--surface-alt) 75%, rgba(255, 255, 255, 0.9) 25%);
+  box-shadow: 0 14px 28px rgba(11, 37, 69, 0.18);
+  display: grid;
+  gap: 0.65rem;
+  text-align: left;
+}
+
+.hero-panel::after {
+  content: '';
+  position: absolute;
+  inset: auto -15% -35% 35%;
+  height: 110px;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.55), transparent 65%);
+  opacity: 0.85;
+}
+
+.hero-panel--primary {
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.24), rgba(239, 61, 91, 0.18)),
+    color-mix(in srgb, rgba(17, 86, 214, 0.12) 45%, rgba(255, 255, 255, 0.9) 55%);
+  color: var(--navy);
+}
+
+.hero-panel__eyebrow {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(17, 86, 214, 0.85);
+}
+
+.hero-panel--primary .hero-panel__eyebrow {
+  color: rgba(239, 61, 91, 0.85);
+}
+
+.hero-panel__headline {
+  margin: 0;
+  font-size: clamp(1.2rem, 3vw, 1.6rem);
+  letter-spacing: 0.01em;
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.hero-panel__meta {
+  margin: 0;
+  font-size: 0.92rem;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+  font-weight: 600;
+}
+
+.hero-panel__detail {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
+.hero-panel time {
+  font-weight: inherit;
+  color: inherit;
+}
+
+@media (min-width: 900px) {
+  .hero-panels { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .hero-panel--primary { grid-column: span 2; }
+}
+
 main { display: grid; gap: 2.25rem; }
 
 section {
@@ -211,13 +293,372 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .summary-cards--compact { margin-top: 1.25rem; }
 
-.summary-card {
+.summary-card { 
   position: relative; background: var(--surface-alt); padding: 1.4rem 1.3rem; border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent); display: grid; gap: 0.6rem;
 }
 .summary-card strong { font-size: 1rem; letter-spacing: 0.02em; color: var(--navy); }
 .summary-card p { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
 .summary-card a { font-weight: 600; text-decoration: none; color: var(--royal); }
+
+.season-snapshot {
+  background:
+    linear-gradient(165deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
+    var(--surface);
+  border-color: color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.season-snapshot__grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.season-snapshot__panel {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+  padding: 1.5rem 1.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+  background:
+    linear-gradient(160deg, rgba(17, 86, 214, 0.1), rgba(17, 86, 214, 0.02)),
+    color-mix(in srgb, var(--surface-alt) 80%, rgba(255, 255, 255, 0.9) 20%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 18px 32px rgba(11, 37, 69, 0.12);
+}
+
+.season-snapshot__panel::after {
+  content: '';
+  position: absolute;
+  inset: auto -12% -30% 32%;
+  height: 120px;
+  background: radial-gradient(circle at center, rgba(244, 181, 63, 0.25), transparent 65%);
+  opacity: 0.75;
+}
+
+.season-snapshot__panel--wide::after { inset: auto -18% -35% 45%; }
+
+.season-snapshot__header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--navy);
+}
+
+.season-snapshot__header p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+.contender-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.contender-grid__placeholder {
+  margin: 0;
+  font-style: italic;
+  color: var(--text-subtle);
+}
+
+.contender-card {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.2rem 1.35rem 1.3rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.14) 55%, rgba(255, 255, 255, 0.9) 45%);
+  box-shadow: 0 12px 24px rgba(11, 37, 69, 0.14);
+}
+
+.contender-card__header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+}
+
+.contender-card__rank {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(239, 61, 91, 0.85));
+  color: #fff;
+  font-size: 0.9rem;
+}
+
+.contender-card__team {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.contender-card__metrics {
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.contender-card__metrics div {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+  gap: 0.5rem;
+}
+
+.contender-card__metrics dt { font-weight: 600; }
+.contender-card__metrics dd { margin: 0; font-weight: 700; color: var(--navy); }
+
+.contender-card__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
+}
+
+.rest-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.rest-list__placeholder { margin: 0; font-style: italic; color: var(--text-subtle); }
+
+.rest-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.65rem 0.85rem;
+  align-items: center;
+}
+
+.rest-list__rank {
+  display: inline-flex;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
+  color: var(--royal);
+}
+
+.rest-list__content { display: grid; gap: 0.3rem; }
+
+.rest-list__team {
+  margin: 0;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.rest-list__meta, .rest-list__notes {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+}
+
+.rest-list__footer {
+  margin: 0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.timeline__placeholder { margin: 0; font-style: italic; color: var(--text-subtle); }
+
+.timeline__item {
+  display: grid;
+  gap: 0.3rem;
+  border-left: 3px solid color-mix(in srgb, var(--royal) 35%, transparent);
+  padding-left: 1rem;
+}
+
+.timeline__date {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--royal);
+}
+
+.timeline__headline {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--navy);
+}
+
+.timeline__detail {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+}
+
+.story-verse__grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.story-verse__placeholder {
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--royal) 40%, transparent);
+  text-align: center;
+  font-style: italic;
+  color: var(--text-subtle);
+}
+
+.story-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.5rem 1.6rem 1.7rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    linear-gradient(165deg, rgba(239, 61, 91, 0.14), rgba(17, 86, 214, 0.08)),
+    color-mix(in srgb, var(--surface-alt) 75%, rgba(255, 255, 255, 0.9) 25%);
+  box-shadow: 0 16px 32px rgba(11, 37, 69, 0.16);
+}
+
+.story-card__header { display: grid; gap: 0.4rem; }
+.story-card__eyebrow {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(239, 61, 91, 0.85);
+}
+.story-card__header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: var(--navy);
+}
+.story-card__lede {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+.story-card__metric {
+  display: grid;
+  gap: 0.15rem;
+}
+.story-card__metric-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--navy);
+}
+.story-card__metric-context {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.story-card__points {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.45rem;
+  color: var(--text-subtle);
+  font-size: 0.92rem;
+}
+.story-card__points li::marker { color: var(--gold); }
+
+.story-card__spotlights {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.story-card__spotlight {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.65rem 0.8rem;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 55%, rgba(255, 255, 255, 0.92) 45%);
+  border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
+}
+
+.story-card__spotlight strong { font-size: 0.95rem; color: var(--navy); }
+.story-card__spotlight small { font-size: 0.75rem; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(17, 86, 214, 0.8); }
+.story-card__spotlight em { font-size: 0.8rem; color: var(--text-subtle); font-style: normal; }
+
+.legacy-currents__grid {
+  display: grid;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.legacy-card {
+  display: grid;
+  gap: 0.8rem;
+  padding: 1.5rem 1.6rem 1.7rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  background:
+    linear-gradient(165deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
+    color-mix(in srgb, var(--surface-alt) 80%, rgba(255, 255, 255, 0.92) 20%);
+  box-shadow: 0 14px 30px rgba(11, 37, 69, 0.14);
+}
+
+.legacy-card--placeholder {
+  padding: 1.5rem;
+  text-align: center;
+  font-style: italic;
+  color: var(--text-subtle);
+  border: 1px dashed color-mix(in srgb, var(--royal) 35%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.05) 60%, rgba(255, 255, 255, 0.95) 40%);
+}
+
+.legacy-card__header { display: grid; gap: 0.45rem; }
+.legacy-card__tag {
+  width: fit-content;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--royal);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.15) 60%, rgba(255, 255, 255, 0.9) 40%);
+}
+.legacy-card__header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--navy);
+}
+.legacy-card__summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+}
+
+.legacy-card__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.legacy-card__list-item { display: grid; gap: 0.25rem; }
+.legacy-card__list-item strong { color: var(--navy); font-size: 0.95rem; }
+.legacy-card__list-item span { color: var(--text-subtle); font-size: 0.85rem; }
+
+@media (min-width: 960px) {
+  .season-snapshot__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .season-snapshot__panel--wide { grid-column: span 2; }
+}
 .summary-card a:hover, .summary-card a:focus-visible { color: var(--red); }
 
 .pillars { display: grid; gap: 1.5rem; }


### PR DESCRIPTION
## Summary
- redesign the landing hero with premiere metrics, Cup/global highlights, and refreshed copy for the 2025-26 preview
- add season snapshot, story-verse, and legacy currents sections with vibrant styling and responsive layouts
- hydrate hero metrics, contender cards, timeline, narratives, and legacy leaders by loading schedule, team, and storytelling data

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d8410271748327aa8e001be25a3cae