### PR TITLE
Remove FAQ and callout sections from landing page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -381,43 +381,6 @@
           </div>
         </section>
 
-        <section class="faq">
-          <h2>Frequently asked questions</h2>
-          <div class="faq-grid">
-            <details>
-              <summary>How often is the preview updated?</summary>
-              <p>
-                Core player, team, and schedule tables update nightly, while preseason scrimmage data
-                and contract moves sync within minutes of official release so every storyline stays current.
-              </p>
-            </details>
-            <details>
-              <summary>Can I remix the visuals for my market?</summary>
-              <p>
-                Absolutely. Each module accepts custom color palettes, annotations, and region-specific
-                sponsor slots so your broadcast or newsletter feels tailor-made.
-              </p>
-            </details>
-            <details>
-              <summary>What happens once the season tips?</summary>
-              <p>
-                We transition the preview into a living dossier—swapping forecasts for trend trackers,
-                adding matchup heat maps, and archiving key predictions for accountability.
-              </p>
-            </details>
-          </div>
-        </section>
-
-        <section class="callout">
-          <div class="callout__content">
-            <h2>Ready to turn the preview into your competitive edge?</h2>
-            <p>
-              Align scouts, executives, and storytellers around one evolving vision of the 2025-26
-              journey. Customize the hub, plug in your secure feeds, and keep the narrative yours.
-            </p>
-          </div>
-          <a class="cta cta--primary" href="mailto:product@nbahub.local">Book a season strategy session</a>
-        </section>
       </main>
 
       <footer class="page-footer">Built for the modern NBA era — expanding with every new story.</footer>


### PR DESCRIPTION
## Summary
- remove the FAQ block from the landing page
- remove the marketing call-to-action block beneath it

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d8443908f48327961a8cf9ac762f82