### PR TITLE
Enhance season rewind tab with data visualizations

### DIFF
--- a/public/rewind.html
+++ b/public/rewind.html
@@ -75,46 +75,102 @@
               sharpened playoff chessboards.
             </p>
           </div>
+          <ul class="stat-callouts">
+            <li class="stat-callouts__item">
+              <span class="stat-callouts__label">Total games logged</span>
+              <span class="stat-callouts__value" data-stat-total-games>—</span>
+              <span class="stat-callouts__hint">Across preseason, regular season, and postseason windows.</span>
+            </li>
+            <li class="stat-callouts__item">
+              <span class="stat-callouts__label">Average rest window</span>
+              <span class="stat-callouts__value" data-stat-avg-rest>—</span>
+              <span class="stat-callouts__hint">League-wide spacing between scheduled tip-offs.</span>
+            </li>
+            <li class="stat-callouts__item">
+              <span class="stat-callouts__label">Back-to-back intervals</span>
+              <span class="stat-callouts__value" data-stat-back-to-backs>—</span>
+              <span class="stat-callouts__hint">Paired games flagged for workload monitoring.</span>
+            </li>
+            <li class="stat-callouts__item">
+              <span class="stat-callouts__label">Cup &amp; postseason volume</span>
+              <span class="stat-callouts__value" data-stat-alt-games>—</span>
+              <span class="stat-callouts__hint">Represents <span data-stat-alt-share>—</span>% of the schedule.</span>
+            </li>
+          </ul>
           <div class="season-snapshot__grid">
-            <article class="season-snapshot__panel season-snapshot__panel--wide">
+            <article class="season-snapshot__panel season-snapshot__panel--wide" data-chart-wrapper>
               <header class="season-snapshot__header">
-                <h3>Momentum tracker</h3>
-                <p>Monthly net rating delta for the top six teams.</p>
+                <h3>Schedule tempo tracker</h3>
+                <p>Monthly game volume across the 2024-25 slate.</p>
               </header>
-              <div class="contender-grid">
-                <ul class="timeline timeline--compact">
-                  <li><strong>Nov:</strong> Celtics +8.7 fueled by league-best half-court offense.</li>
-                  <li><strong>Jan:</strong> Nuggets rally with +9.1 surge after recalibrating bench units.</li>
-                  <li><strong>Mar:</strong> Thunder defense holds opponents to 108.5 per 100 possessions.</li>
-                  <li><strong>Apr:</strong> Knicks close 15-5 behind dual-big lineup pressure.</li>
-                </ul>
+              <div class="viz-canvas viz-canvas--flush">
+                <canvas data-chart="monthly-games" aria-describedby="monthly-games-caption"></canvas>
               </div>
+              <p id="monthly-games-caption" class="season-snapshot__caption">
+                Regular-season volume peaked in <span data-monthly-peak-month>—</span> with
+                <span data-monthly-peak-games>—</span> games, while auxiliary competitions filled
+                <span data-stat-alt-share>—</span>% of the calendar.
+              </p>
             </article>
             <article class="season-snapshot__panel">
               <header class="season-snapshot__header">
-                <h3>Health ledger</h3>
-                <p>Availability trends that dictated playoff prep.</p>
+                <h3>Recovery ledger</h3>
+                <p>Rest windows and high-intensity runs the medical staffs had to manage.</p>
               </header>
-              <ul class="rest-list">
-                <li><strong>Games lost:</strong> 4,212 combined, down 6% year-over-year.</li>
-                <li><strong>Low-minute caps:</strong> Clippers limited Kawhi to back-to-back rest twice.</li>
-                <li><strong>Return-to-play:</strong> Zion logged 68 appearances, stabilizing New Orleans.</li>
-              </ul>
-              <p class="rest-list__footer">Training staffs reported a 12% drop in soft-tissue setbacks.</p>
+              <div class="rest-overview">
+                <figure class="rest-overview__chart" data-chart-wrapper>
+                  <div class="viz-canvas viz-canvas--compact">
+                    <canvas data-chart="rest-distribution" aria-describedby="rest-distribution-caption"></canvas>
+                  </div>
+                  <figcaption id="rest-distribution-caption" class="season-snapshot__caption">
+                    Schedule engine grouped every travel interval to flag zero-rest, overnight, and extended pauses.
+                  </figcaption>
+                </figure>
+                <ol class="rest-list" data-back-to-back-list>
+                  <li class="rest-list__placeholder">Compiling back-to-back ledger…</li>
+                </ol>
+              </div>
+              <p class="rest-list__footer" data-rest-footer>
+                Zero-rest swings accounted for <span data-stat-zero-share>—</span>% of tracked intervals.
+              </p>
             </article>
             <article class="season-snapshot__panel">
               <header class="season-snapshot__header">
                 <h3>Signature moments</h3>
-                <p>Dates that defined the rewind narrative.</p>
+                <p>Global showcases and postseason pivots that defined the rewind.</p>
               </header>
-              <ol class="timeline">
-                <li><time datetime="2024-12-07">Dec 7</time> · In-Season Tournament final rematch lights up Las Vegas.</li>
-                <li><time datetime="2025-01-25">Jan 25</time> · Victor Wembanyama drops 48/18/6 against Milwaukee.</li>
-                <li><time datetime="2025-03-17">Mar 17</time> · Knicks clinch first division crown since 2013.</li>
-                <li><time datetime="2025-05-29">May 29</time> · Finals Game 5: Jayson Tatum posts 39-11-8 masterclass.</li>
+              <ol class="timeline" data-special-games>
+                <li class="timeline__placeholder">Loading league touchpoints…</li>
               </ol>
             </article>
           </div>
+        </section>
+
+        <section class="grid-two">
+          <div class="subsection">
+            <h2>Load management watch</h2>
+            <p>
+              Schedule modeling flagged <span data-stat-marathon-teams>—</span> teams with 95+ total games, led by
+              <span data-stat-max-games-team>—</span> charting <span data-stat-max-games>—</span>. The heaviest
+              back-to-back burden hit <span data-stat-b2b-leader-count>—</span> for <span data-stat-b2b-leader-team>—</span>,
+              shaping rest strategies ahead of the 2025-26 build.
+            </p>
+            <ul class="badge-list">
+              <li class="badge">Longest road swing: <span data-stat-longest-road>—</span></li>
+              <li class="badge">Longest home stand: <span data-stat-longest-home>—</span></li>
+              <li class="badge">Zero-rest share: <span data-stat-zero-share>—</span>% of intervals</li>
+            </ul>
+          </div>
+          <figure class="viz-card viz-card--inline" data-chart-wrapper>
+            <header class="viz-card__title">Top back-to-back loads</header>
+            <div class="viz-canvas">
+              <canvas data-chart="back-to-back-loads" aria-describedby="back-to-back-caption"></canvas>
+            </div>
+            <figcaption id="back-to-back-caption" class="viz-card__caption">
+              Bars rank the busiest back-to-back schedules in 2024-25, surfacing which contenders needed the most
+              load-balancing support.
+            </figcaption>
+          </figure>
         </section>
 
         <section>
@@ -206,5 +262,7 @@
 
       <footer class="page-footer">History loops forward—rewind insights fuel the preview engine.</footer>
     </div>
+    <script src="vendor/chart.umd.js" defer></script>
+    <script type="module" src="scripts/rewind.js"></script>
   </body>
 </html>

--- a/public/scripts/rewind.js
+++ b/public/scripts/rewind.js
@@ -1,0 +1,527 @@
+import { registerCharts, helpers } from './hub-charts.js';
+
+const palette = {
+  royal: '#1156d6',
+  sky: 'rgba(31, 123, 255, 0.78)',
+  gold: 'rgba(244, 181, 63, 0.85)',
+  coral: 'rgba(239, 61, 91, 0.82)',
+  teal: 'rgba(47, 180, 200, 0.78)',
+  navy: '#0b2545',
+};
+
+const scheduleDataPromise = fetch('data/season_24_25_schedule.json').then((response) => {
+  if (!response.ok) {
+    throw new Error(`Failed to load schedule data: ${response.status}`);
+  }
+  return response.json();
+});
+
+function setStat(attribute, value, formatter = (v) => v, fallback = '—') {
+  const nodes = document.querySelectorAll(`[data-${attribute}]`);
+  const hasValue = value !== undefined && value !== null && !(typeof value === 'number' && Number.isNaN(value));
+  nodes.forEach((node) => {
+    node.textContent = hasValue ? formatter(value) : fallback;
+  });
+}
+
+registerCharts([
+  {
+    element: document.querySelector('[data-chart="monthly-games"]'),
+    async createConfig() {
+      const data = await scheduleDataPromise;
+      const monthlyCounts = Array.isArray(data?.monthlyCounts) ? data.monthlyCounts : [];
+      if (!monthlyCounts.length) return null;
+
+      const labels = monthlyCounts.map((entry) => entry.label ?? '');
+      const regularSeason = monthlyCounts.map((entry) => entry.regularSeason ?? 0);
+      const auxiliary = monthlyCounts.map((entry) => {
+        const games = entry.games ?? 0;
+        const primary = entry.regularSeason ?? 0;
+        return Math.max(0, games - primary);
+      });
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Regular season',
+              data: regularSeason,
+              backgroundColor: palette.royal,
+              borderRadius: 6,
+              maxBarThickness: 32,
+            },
+            {
+              label: 'Cup & postseason',
+              data: auxiliary,
+              backgroundColor: palette.gold,
+              borderRadius: 6,
+              maxBarThickness: 32,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { top: 4, right: 12, bottom: 8, left: 8 } },
+          plugins: {
+            legend: { position: 'top', labels: { usePointStyle: true } },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const value = helpers.formatNumber(context.parsed.y, 0);
+                  return `${context.dataset.label}: ${value} games`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              stacked: true,
+              grid: { display: false },
+            },
+            y: {
+              stacked: true,
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="rest-distribution"]'),
+    async createConfig() {
+      const data = await scheduleDataPromise;
+      const restBuckets = Array.isArray(data?.restBuckets) ? data.restBuckets : [];
+      if (!restBuckets.length) return null;
+      const totalIntervals = restBuckets.reduce((sum, bucket) => sum + (bucket.intervals ?? 0), 0);
+
+      return {
+        type: 'doughnut',
+        data: {
+          labels: restBuckets.map((bucket) => bucket.label ?? ''),
+          datasets: [
+            {
+              data: restBuckets.map((bucket) => bucket.intervals ?? 0),
+              backgroundColor: [palette.coral, palette.gold, palette.sky, palette.teal],
+              borderColor: '#ffffff',
+              borderWidth: 2,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { top: 8, right: 8, bottom: 8, left: 8 } },
+          plugins: {
+            legend: { position: 'bottom', labels: { usePointStyle: true } },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const value = context.parsed;
+                  const share = totalIntervals ? (value / totalIntervals) * 100 : 0;
+                  return `${context.label}: ${helpers.formatNumber(value, 0)} intervals (${helpers.formatNumber(share, 1)}%)`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="back-to-back-loads"]'),
+    async createConfig() {
+      const data = await scheduleDataPromise;
+      const leaders = Array.isArray(data?.backToBackLeaders) ? data.backToBackLeaders : [];
+      const ranked = helpers.rankAndSlice(leaders, 8, (entry) => entry.backToBacks ?? 0);
+      if (!ranked.length) return null;
+
+      return {
+        type: 'bar',
+        data: {
+          labels: ranked.map((entry) => entry.abbreviation ?? entry.name ?? ''),
+          datasets: [
+            {
+              label: 'Back-to-backs',
+              data: ranked.map((entry) => entry.backToBacks ?? 0),
+              backgroundColor: palette.royal,
+              borderRadius: 8,
+              maxBarThickness: 26,
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          layout: { padding: { top: 8, right: 16, bottom: 8, left: 8 } },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const team = ranked[context.dataIndex];
+                  const rest = team?.averageRestDays;
+                  const segments = [`${helpers.formatNumber(context.parsed.x, 0)} back-to-backs`];
+                  if (typeof rest === 'number') {
+                    segments.push(`avg rest ${helpers.formatNumber(rest, 1)} days`);
+                  }
+                  return segments.join(' · ');
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+            y: {
+              grid: { display: false },
+            },
+          },
+        },
+      };
+    },
+  },
+]);
+
+function formatMatchup(event, teamMap) {
+  const home = teamMap.get(event.hometeamId);
+  const away = teamMap.get(event.awayteamId);
+  if (home && away) {
+    const homeLabel = home.abbreviation ?? home.name;
+    const awayLabel = away.abbreviation ?? away.name;
+    return `${awayLabel} at ${homeLabel}`;
+  }
+  return '';
+}
+
+function formatLocation(event) {
+  const parts = [];
+  if (event.arena) parts.push(event.arena);
+  const city = [event.city, event.state].filter(Boolean).join(', ');
+  if (city) parts.push(city);
+  return parts.join(' · ');
+}
+
+function buildEventCopy(event, teamMap) {
+  const matchup = formatMatchup(event, teamMap);
+  const location = formatLocation(event);
+  if (event.subLabel === 'NBA Abu Dhabi Game') {
+    return {
+      headline: 'Global preseason lift-off',
+      detail: [matchup, location].filter(Boolean).join(' · ') || location,
+    };
+  }
+  if (event.label === 'NBA Mexico City Game') {
+    return {
+      headline: 'Mexico City global showcase',
+      detail: [matchup, location].filter(Boolean).join(' · ') || location,
+    };
+  }
+  if (event.label === 'Emirates NBA Cup' && event.subLabel === 'Championship') {
+    return {
+      headline: 'Cup championship night in Las Vegas',
+      detail: location || 'Neutral-site finale crowns the field.',
+    };
+  }
+  if (event.label === 'Emirates NBA Cup') {
+    const detailParts = [];
+    if (matchup) detailParts.push(matchup);
+    if (event.subLabel) detailParts.push(event.subLabel);
+    return {
+      headline: 'Cup group play tips off',
+      detail: detailParts.join(' · ') || location,
+    };
+  }
+  if (event.label === 'NBA Paris Game') {
+    return {
+      headline: 'Paris matinee shifts the spotlight',
+      detail: [matchup, location].filter(Boolean).join(' · ') || location,
+    };
+  }
+  if (event.label === 'NBA Finals') {
+    const detailParts = [];
+    if (matchup) detailParts.push(matchup);
+    if (event.subLabel) detailParts.push(event.subLabel);
+    if (event.seriesText) detailParts.push(event.seriesText);
+    return {
+      headline: 'Finals stage set',
+      detail: detailParts.join(' · ') || location,
+    };
+  }
+  const fallbackDetail = [matchup, location].filter(Boolean).join(' · ');
+  return {
+    headline: event.subLabel ? `${event.label} · ${event.subLabel}` : event.label,
+    detail: fallbackDetail,
+  };
+}
+
+function renderBackToBackList(data) {
+  const list = document.querySelector('[data-back-to-back-list]');
+  if (!list) return;
+  list.innerHTML = '';
+  const teams = Array.isArray(data?.backToBackLeaders) ? data.backToBackLeaders : [];
+  const leaders = helpers.rankAndSlice(teams, 5, (entry) => entry.backToBacks ?? 0);
+  if (!leaders.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'rest-list__placeholder';
+    placeholder.textContent = 'Back-to-back insights unavailable.';
+    list.appendChild(placeholder);
+    return;
+  }
+
+  leaders.forEach((team, index) => {
+    const item = document.createElement('li');
+    item.className = 'rest-list__item';
+
+    const rank = document.createElement('span');
+    rank.className = 'rest-list__rank';
+    rank.textContent = String(index + 1);
+
+    const content = document.createElement('div');
+    content.className = 'rest-list__content';
+
+    const name = document.createElement('p');
+    name.className = 'rest-list__team';
+    name.textContent = team.name ?? team.abbreviation ?? 'Team';
+
+    const meta = document.createElement('p');
+    meta.className = 'rest-list__meta';
+    const rest = typeof team.averageRestDays === 'number' ? helpers.formatNumber(team.averageRestDays, 1) : null;
+    meta.textContent = rest
+      ? `${helpers.formatNumber(team.backToBacks ?? 0, 0)} back-to-backs · avg rest ${rest} days`
+      : `${helpers.formatNumber(team.backToBacks ?? 0, 0)} back-to-backs`;
+
+    const notes = document.createElement('p');
+    notes.className = 'rest-list__notes';
+    const longestRoad =
+      typeof team.longestRoadTrip === 'number'
+        ? `${helpers.formatNumber(team.longestRoadTrip ?? 0, 0)}-game road swing`
+        : null;
+    const longestHome =
+      typeof team.longestHomeStand === 'number'
+        ? `${helpers.formatNumber(team.longestHomeStand ?? 0, 0)}-game home stand`
+        : null;
+    const noteParts = [];
+    if (longestRoad) noteParts.push(`Longest road: ${longestRoad}`);
+    if (longestHome) noteParts.push(`Longest home: ${longestHome}`);
+    notes.textContent = noteParts.join(' · ');
+
+    content.append(name, meta);
+    if (noteParts.length) {
+      content.append(notes);
+    }
+
+    item.append(rank, content);
+    list.append(item);
+  });
+}
+
+function renderTimeline(data) {
+  const list = document.querySelector('[data-special-games]');
+  if (!list) return;
+  list.innerHTML = '';
+
+  const specialGames = Array.isArray(data?.specialGames) ? data.specialGames : [];
+  if (!specialGames.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'timeline__placeholder';
+    placeholder.textContent = 'Special event timeline unavailable.';
+    list.appendChild(placeholder);
+    return;
+  }
+
+  const sorted = [...specialGames].sort((a, b) => new Date(a.date) - new Date(b.date));
+  const selectors = [
+    (games) => games.find((game) => game.subLabel === 'NBA Abu Dhabi Game'),
+    (games) => games.find((game) => game.label === 'NBA Mexico City Game'),
+    (games) => games.find((game) => game.label === 'Emirates NBA Cup' && game.subtype === 'in-season'),
+    (games) => games.find((game) => game.label === 'Emirates NBA Cup' && game.subLabel === 'Championship'),
+    (games) => games.find((game) => game.label === 'NBA Paris Game'),
+    (games) => {
+      const finals = games.filter((game) => game.label === 'NBA Finals');
+      finals.sort((a, b) => new Date(a.date) - new Date(b.date));
+      return finals[0];
+    },
+  ];
+
+  const highlights = [];
+  const usedKeys = new Set();
+  selectors.forEach((select) => {
+    const event = select(sorted);
+    if (event) {
+      const key = `${event.label}-${event.subLabel ?? ''}-${event.date}`;
+      if (!usedKeys.has(key)) {
+        usedKeys.add(key);
+        highlights.push(event);
+      }
+    }
+  });
+
+  if (!highlights.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'timeline__placeholder';
+    placeholder.textContent = 'Special event timeline unavailable.';
+    list.appendChild(placeholder);
+    return;
+  }
+
+  const formatter = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' });
+  const teamMap = new Map((Array.isArray(data?.teams) ? data.teams : []).map((team) => [team.teamId, team]));
+
+  highlights
+    .sort((a, b) => new Date(a.date) - new Date(b.date))
+    .forEach((event) => {
+      const item = document.createElement('li');
+      item.className = 'timeline__item';
+
+      const dateEl = document.createElement('time');
+      dateEl.className = 'timeline__date';
+      dateEl.dateTime = event.date ?? '';
+      try {
+        dateEl.textContent = formatter.format(new Date(event.date));
+      } catch (error) {
+        dateEl.textContent = event.date ?? '';
+      }
+
+      const { headline, detail } = buildEventCopy(event, teamMap);
+
+      const headlineEl = document.createElement('p');
+      headlineEl.className = 'timeline__headline';
+      headlineEl.textContent = headline;
+
+      item.append(dateEl, headlineEl);
+
+      if (detail) {
+        const detailEl = document.createElement('p');
+        detailEl.className = 'timeline__detail';
+        detailEl.textContent = detail;
+        item.append(detailEl);
+      }
+
+      list.append(item);
+    });
+}
+
+function populateCallouts(data) {
+  const totals = data?.totals ?? {};
+  const restSummary = data?.restSummary ?? {};
+  const restBuckets = Array.isArray(data?.restBuckets) ? data.restBuckets : [];
+  const zeroIntervals = restBuckets.find((bucket) => bucket.label === '0 days')?.intervals ?? 0;
+  const totalIntervals = restSummary.totalIntervals ?? restBuckets.reduce((sum, bucket) => sum + (bucket.intervals ?? 0), 0);
+  const zeroShare = totalIntervals ? (zeroIntervals / totalIntervals) * 100 : null;
+
+  setStat('stat-total-games', totals.games, (value) => helpers.formatNumber(value, 0));
+  setStat('stat-avg-rest', restSummary.averageRestDays, (value) => `${helpers.formatNumber(value, 1)} days`);
+  setStat('stat-back-to-backs', restSummary.backToBackIntervals, (value) => helpers.formatNumber(value, 0));
+  setStat('stat-alt-games', totals.other, (value) => helpers.formatNumber(value, 0));
+  setStat('stat-alt-share', totals.games ? (totals.other / totals.games) * 100 : null, (value) => helpers.formatNumber(value, 1));
+  setStat('stat-zero-share', zeroShare, (value) => helpers.formatNumber(value, 1));
+
+  const monthlyCounts = Array.isArray(data?.monthlyCounts) ? data.monthlyCounts : [];
+  const peakMonth = monthlyCounts
+    .filter((entry) => typeof entry.regularSeason === 'number' && entry.regularSeason > 0)
+    .reduce((peak, entry) => (entry.regularSeason > (peak?.regularSeason ?? -Infinity) ? entry : peak), null);
+  setStat('monthly-peak-month', peakMonth?.label, (value) => value);
+  setStat('monthly-peak-games', peakMonth?.regularSeason, (value) => helpers.formatNumber(value, 0));
+}
+
+function populateLoadHighlights(data) {
+  const teams = Array.isArray(data?.teams) ? data.teams : [];
+  if (!teams.length) {
+    setStat('stat-marathon-teams', null);
+    setStat('stat-max-games-team', null);
+    setStat('stat-max-games', null);
+    setStat('stat-b2b-leader-count', null);
+    setStat('stat-b2b-leader-team', null);
+    setStat('stat-longest-road', null);
+    setStat('stat-longest-home', null);
+    return;
+  }
+
+  const marathonTeams = teams.filter((team) => (team.totalGames ?? 0) >= 95);
+  const maxGamesTeam = teams.reduce((best, team) => (team.totalGames > (best?.totalGames ?? -Infinity) ? team : best), null);
+  const longestRoad = teams.reduce(
+    (best, team) => (team.longestRoadTrip > (best?.longestRoadTrip ?? -Infinity) ? team : best),
+    null
+  );
+  const longestHome = teams.reduce(
+    (best, team) => (team.longestHomeStand > (best?.longestHomeStand ?? -Infinity) ? team : best),
+    null
+  );
+
+  const b2bLeaders = Array.isArray(data?.backToBackLeaders) ? data.backToBackLeaders : [];
+  const topBackToBack = helpers.rankAndSlice(b2bLeaders, 1, (entry) => entry.backToBacks ?? 0)[0];
+
+  setStat('stat-marathon-teams', marathonTeams.length, (value) => helpers.formatNumber(value, 0));
+  setStat('stat-max-games-team', maxGamesTeam?.name, (value) => value);
+  setStat('stat-max-games', maxGamesTeam?.totalGames, (value) => `${helpers.formatNumber(value, 0)} games`);
+  setStat('stat-b2b-leader-count', topBackToBack?.backToBacks, (value) => helpers.formatNumber(value, 0));
+  setStat('stat-b2b-leader-team', topBackToBack?.name ?? topBackToBack?.abbreviation, (value) => value);
+
+  const longestRoadLabel = longestRoad
+    ? `${helpers.formatNumber(longestRoad.longestRoadTrip ?? 0, 0)} (${longestRoad.abbreviation ?? longestRoad.name})`
+    : null;
+  const longestHomeLabel = longestHome
+    ? `${helpers.formatNumber(longestHome.longestHomeStand ?? 0, 0)} (${longestHome.abbreviation ?? longestHome.name})`
+    : null;
+
+  setStat('stat-longest-road', longestRoadLabel, (value) => value);
+  setStat('stat-longest-home', longestHomeLabel, (value) => value);
+}
+
+function populateRestFooter(data) {
+  const footer = document.querySelector('[data-rest-footer]');
+  if (!footer) return;
+  const restSummary = data?.restSummary ?? {};
+  const restBuckets = Array.isArray(data?.restBuckets) ? data.restBuckets : [];
+  const totalIntervals = restSummary.totalIntervals ?? restBuckets.reduce((sum, bucket) => sum + (bucket.intervals ?? 0), 0);
+  const zeroIntervals = restBuckets.find((bucket) => bucket.label === '0 days')?.intervals ?? 0;
+  if (!totalIntervals) {
+    footer.textContent = 'Rest distribution data unavailable.';
+    return;
+  }
+  const share = (zeroIntervals / totalIntervals) * 100;
+  footer.textContent = `Zero-rest swings accounted for ${helpers.formatNumber(share, 1)}% of ${helpers.formatNumber(
+    totalIntervals,
+    0
+  )} tracked intervals.`;
+}
+
+scheduleDataPromise
+  .then((data) => {
+    populateCallouts(data);
+    renderBackToBackList(data);
+    renderTimeline(data);
+    populateLoadHighlights(data);
+    populateRestFooter(data);
+  })
+  .catch((error) => {
+    console.error('Unable to hydrate season rewind view', error);
+    const backToBackList = document.querySelector('[data-back-to-back-list]');
+    if (backToBackList) {
+      backToBackList.innerHTML = '';
+      const placeholder = document.createElement('li');
+      placeholder.className = 'rest-list__placeholder';
+      placeholder.textContent = 'Season rewind data unavailable.';
+      backToBackList.appendChild(placeholder);
+    }
+    const timeline = document.querySelector('[data-special-games]');
+    if (timeline) {
+      timeline.innerHTML = '';
+      const placeholder = document.createElement('li');
+      placeholder.className = 'timeline__placeholder';
+      placeholder.textContent = 'Special event timeline unavailable.';
+      timeline.appendChild(placeholder);
+    }
+    const footer = document.querySelector('[data-rest-footer]');
+    if (footer) {
+      footer.textContent = 'Rest distribution data unavailable.';
+    }
+  });

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -313,6 +313,44 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   gap: 1.5rem;
 }
 
+.stat-callouts {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stat-callouts__item {
+  display: grid;
+  gap: 0.45rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 50%, rgba(255, 255, 255, 0.92) 50%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.stat-callouts__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--royal);
+}
+
+.stat-callouts__value {
+  font-size: 1.35rem;
+  font-weight: 800;
+  color: var(--navy);
+}
+
+.stat-callouts__hint {
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
 .season-snapshot__panel {
   position: relative;
   display: grid;
@@ -347,6 +385,31 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   margin: 0;
   font-size: 0.95rem;
   color: var(--text-subtle);
+}
+
+.season-snapshot__caption {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--text-subtle);
+}
+
+.viz-canvas--flush {
+  min-height: 280px;
+}
+
+.viz-canvas--compact {
+  min-height: 220px;
+}
+
+.rest-overview {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.rest-overview__chart {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
 }
 
 .contender-grid {
@@ -658,6 +721,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 @media (min-width: 960px) {
   .season-snapshot__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .season-snapshot__panel--wide { grid-column: span 2; }
+}
+
+@media (min-width: 720px) {
+  .rest-overview {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: center;
+  }
 }
 .summary-card a:hover, .summary-card a:focus-visible { color: var(--red); }
 


### PR DESCRIPTION
## Summary
- add data-driven callouts, charts, and schedule insights to the season rewind page
- implement dedicated JavaScript to hydrate charts, callouts, and event timelines from 2024-25 schedule data
- extend shared styles to support new metric callouts and rest overview layouts

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d84a0db47083279ed8596df46f05c2