### PR TITLE
Clamp chart containers to prevent horizontal overflow

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -1176,10 +1176,16 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .viz-card__title { margin: 0; font-size: 1.05rem; font-weight: 700; color: var(--navy); }
 .viz-card__caption { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
-.viz-canvas { position: relative; min-height: 240px; }
+.viz-canvas {
+  position: relative;
+  min-height: 240px;
+  width: 100%;
+  overflow: hidden;
+}
 .viz-card canvas {
   display: block;
   width: 100% !important;
+  max-width: 100%;
   height: auto !important;
   max-height: 100%;
 }


### PR DESCRIPTION
## Summary
- force visualization canvases to stay within their containers
- hide any stray overflow from Chart.js rendering to stop the horizontal scrollbar flicker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d84f3ec94c8327bfa874d59a7467ab