### PR TITLE
Style the 2024 season rewind page

### DIFF
--- a/public/rewind.html
+++ b/public/rewind.html
@@ -26,15 +26,15 @@
             <a href="about.html">About</a>
           </nav>
         </div>
-        <div class="hero">
+        <div class="hero hero--rewind">
           <span class="eyebrow">Season rewind spotlight · 2024-25</span>
           <h1>Relive the campaign that reset rivalries and redefined the modern rotation.</h1>
-          <p>
+          <p class="hero__lede">
             From breakout backcourts to a finals trilogy rubber match, this rewind distills the core
             beats that shaped the 2024-25 NBA narrative and how they set the stage for the upcoming
             campaign.
           </p>
-          <div class="hero-panels" aria-live="polite">
+          <div class="hero-panels hero-panels--rewind" aria-live="polite">
             <article class="hero-panel hero-panel--primary">
               <span class="hero-panel__eyebrow">Finals snapshot</span>
               <h2 class="hero-panel__headline">Boston 4 – Denver 2</h2>
@@ -161,7 +161,7 @@
               <li class="badge">Zero-rest share: <span data-stat-zero-share>—</span>% of intervals</li>
             </ul>
           </div>
-          <figure class="viz-card viz-card--inline" data-chart-wrapper>
+          <figure class="viz-card viz-card--inline viz-card--rewind" data-chart-wrapper>
             <header class="viz-card__title">Top back-to-back loads</header>
             <div class="viz-canvas">
               <canvas data-chart="back-to-back-loads" aria-describedby="back-to-back-caption"></canvas>
@@ -180,7 +180,7 @@
             analytics, and creative storytelling for the preview cycle.
           </p>
           <div class="summary-cards">
-            <article class="summary-card">
+            <article class="summary-card summary-card--rewind">
               <strong>Switchability surged</strong>
               <p>
                 Lineups with three-plus switchable defenders posted a +4.6 aggregate net rating,
@@ -189,7 +189,7 @@
               </p>
               <a href="teams.html">Compare defensive blueprints →</a>
             </article>
-            <article class="summary-card">
+            <article class="summary-card summary-card--rewind">
               <strong>Half-court maestros</strong>
               <p>
                 Top pick-and-roll duos averaged 1.12 points per direct possession, underscoring the
@@ -197,7 +197,7 @@
               </p>
               <a href="players.html">Dive into player metrics →</a>
             </article>
-            <article class="summary-card">
+            <article class="summary-card summary-card--rewind">
               <strong>In-season tournament impact</strong>
               <p>
                 Cup pool intensity prepared rising teams for playoff atmospheres, with four of eight
@@ -222,7 +222,7 @@
               <li class="badge">Sixth: Malik Monk</li>
             </ul>
           </div>
-          <figure class="viz-card viz-card--inline">
+          <figure class="viz-card viz-card--inline viz-card--rewind">
             <header class="viz-card__title">Clutch time composite</header>
             <div class="viz-canvas">
               <p class="viz-placeholder">
@@ -244,15 +244,15 @@
             spotlight reinforcements, and surface potential regression markers.
           </p>
           <div class="card-grid">
-            <article class="card">
+            <article class="card card--rewind">
               <h3>Continuity index</h3>
               <p>Track returning minute shares to gauge which teams bank on chemistry.</p>
             </article>
-            <article class="card">
+            <article class="card card--rewind">
               <h3>Skill progression reels</h3>
               <p>Transform rewind clips into development reels for internal scouting and marketing.</p>
             </article>
-            <article class="card">
+            <article class="card card--rewind">
               <h3>Regression watchlist</h3>
               <p>Flag shooting spikes or clutch outliers primed for correction.</p>
             </article>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -81,6 +81,40 @@ a:hover, a:focus { color: var(--sky); }
   display: grid;
   gap: clamp(2rem, 4vw, 3rem);
 }
+.hero--rewind {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(2.8rem, 6vw, 3.8rem) clamp(1.4rem, 5vw, 2.8rem) clamp(2.6rem, 5vw, 3.4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
+  background:
+    radial-gradient(120% 120% at 12% 15%, rgba(17, 86, 214, 0.35), transparent 60%),
+    radial-gradient(110% 110% at 82% 12%, rgba(239, 61, 91, 0.3), transparent 65%),
+    linear-gradient(140deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
+    color-mix(in srgb, var(--surface-alt) 78%, rgba(255, 255, 255, 0.92) 22%);
+  box-shadow: 0 28px 48px rgba(11, 37, 69, 0.18);
+}
+.hero--rewind::before,
+.hero--rewind::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.75;
+}
+.hero--rewind::before {
+  inset: -42% 52% auto -25%;
+  height: 340px;
+  background: radial-gradient(circle at center, rgba(31, 123, 255, 0.35), transparent 70%);
+}
+.hero--rewind::after {
+  inset: auto -18% -55% 58%;
+  height: 300px;
+  background: radial-gradient(circle at center, rgba(244, 181, 63, 0.35), transparent 72%);
+}
+.hero--rewind > * {
+  position: relative;
+  z-index: 1;
+}
 .hero__layout {
   display: grid;
   gap: clamp(1.6rem, 3.5vw, 3rem);
@@ -147,6 +181,25 @@ a:hover, a:focus { color: var(--sky); }
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   max-width: 960px;
 }
+.hero-panels--rewind {
+  width: 100%;
+  padding: 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.86) 70%, rgba(17, 86, 214, 0.08) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+.hero-panels--rewind .hero-panel {
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.14), rgba(31, 123, 255, 0.06)),
+    color-mix(in srgb, var(--surface-alt) 80%, rgba(255, 255, 255, 0.9) 20%);
+  box-shadow: 0 18px 32px rgba(11, 37, 69, 0.16);
+}
+.hero-panels--rewind .hero-panel--primary {
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.24), rgba(239, 61, 91, 0.2)),
+    color-mix(in srgb, rgba(17, 86, 214, 0.12) 45%, rgba(255, 255, 255, 0.92) 55%);
+}
 
 .hero-panel {
   position: relative;
@@ -177,6 +230,11 @@ a:hover, a:focus { color: var(--sky); }
     linear-gradient(150deg, rgba(17, 86, 214, 0.24), rgba(239, 61, 91, 0.18)),
     color-mix(in srgb, rgba(17, 86, 214, 0.12) 45%, rgba(255, 255, 255, 0.9) 55%);
   color: var(--navy);
+}
+.hero-panel--event {
+  background:
+    linear-gradient(155deg, rgba(31, 123, 255, 0.12), rgba(244, 181, 63, 0.12)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
 }
 
 .hero-panel__eyebrow {
@@ -428,9 +486,25 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .summary-cards--compact { margin-top: 1.25rem; }
 
-.summary-card { 
+.summary-card {
   position: relative; background: var(--surface-alt); padding: 1.4rem 1.3rem; border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent); display: grid; gap: 0.6rem;
+}
+.summary-card--rewind {
+  overflow: hidden;
+  background:
+    linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.92) 30%);
+  border-color: color-mix(in srgb, var(--royal) 22%, transparent);
+  box-shadow: 0 16px 28px rgba(11, 37, 69, 0.14);
+}
+.summary-card--rewind::after {
+  content: '';
+  position: absolute;
+  inset: auto -20% -45% 45%;
+  height: 180px;
+  background: radial-gradient(circle at center, rgba(17, 86, 214, 0.18), transparent 68%);
+  opacity: 0.7;
 }
 .summary-card strong { font-size: 1rem; letter-spacing: 0.02em; color: var(--navy); }
 .summary-card p { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
@@ -441,6 +515,49 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
     linear-gradient(165deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
     var(--surface);
   border-color: color-mix(in srgb, var(--border) 60%, transparent);
+}
+#rewind-summary {
+  position: relative;
+  overflow: hidden;
+}
+#rewind-summary::before,
+#rewind-summary::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.45;
+  pointer-events: none;
+}
+#rewind-summary::before {
+  inset: -45% 65% auto -18%;
+  height: 360px;
+  background: radial-gradient(circle at center, rgba(17, 86, 214, 0.32), transparent 68%);
+}
+#rewind-summary::after {
+  inset: auto -25% -52% 58%;
+  height: 280px;
+  background: radial-gradient(circle at center, rgba(244, 181, 63, 0.3), transparent 72%);
+}
+#rewind-summary > * {
+  position: relative;
+  z-index: 1;
+}
+#rewind-summary .section-header {
+  text-align: left;
+  max-width: 720px;
+}
+#rewind-summary .stat-callouts__item {
+  background:
+    linear-gradient(160deg, rgba(17, 86, 214, 0.12), rgba(255, 255, 255, 0.12)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(242, 246, 255, 0.92) 30%);
+  border-color: color-mix(in srgb, var(--royal) 26%, transparent);
+  backdrop-filter: blur(3px);
+}
+#rewind-summary .season-snapshot__panel {
+  border-color: color-mix(in srgb, var(--royal) 20%, transparent);
+}
+#rewind-summary .season-snapshot__panel::after {
+  background: radial-gradient(circle at center, rgba(17, 86, 214, 0.24), transparent 68%);
 }
 
 .season-snapshot__grid {
@@ -1098,6 +1215,23 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
   background: var(--surface-alt); display: grid; gap: 0.7rem;
 }
+.card--rewind {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(31, 123, 255, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
+  border-color: color-mix(in srgb, var(--royal) 18%, transparent);
+  box-shadow: 0 18px 32px rgba(11, 37, 69, 0.14);
+}
+.card--rewind::after {
+  content: '';
+  position: absolute;
+  inset: auto -22% -48% 48%;
+  height: 170px;
+  background: radial-gradient(circle at center, rgba(244, 181, 63, 0.22), transparent 68%);
+  opacity: 0.65;
+}
 .card h3 { margin: 0; font-size: 1.1rem; color: var(--navy); }
 .card p { margin: 0; color: var(--text-subtle); font-size: 0.95rem; }
 .card--placeholder { text-align: center; font-style: italic; color: var(--text-subtle); min-height: 140px; align-content: center; }
@@ -1170,6 +1304,22 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   background: linear-gradient(160deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.1)); box-shadow: var(--shadow-soft);
 }
+.viz-card--rewind {
+  overflow: hidden;
+  border-color: color-mix(in srgb, var(--royal) 20%, transparent);
+  background:
+    linear-gradient(165deg, rgba(17, 86, 214, 0.14), rgba(244, 181, 63, 0.12)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: 0 20px 36px rgba(11, 37, 69, 0.16);
+}
+.viz-card--rewind::after {
+  content: '';
+  position: absolute;
+  inset: auto -18% -42% 40%;
+  height: 200px;
+  background: radial-gradient(circle at center, rgba(239, 61, 91, 0.18), transparent 70%);
+  opacity: 0.65;
+}
 .viz-card--inline {
   height: 100%;
   grid-template-rows: auto minmax(0, 1fr) auto;
@@ -1188,6 +1338,20 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   max-width: 100%;
   height: auto !important;
   max-height: 100%;
+}
+.viz-placeholder {
+  margin: 0;
+  min-height: 220px;
+  padding: 1.4rem 1.2rem;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  font-size: 0.95rem;
+  font-style: italic;
+  color: var(--text-subtle);
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--royal) 25%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 50%, rgba(255, 255, 255, 0.88) 50%);
 }
 .viz-error { border-color: rgba(239, 61, 91, 0.4); }
 .viz-error__message {


### PR DESCRIPTION
## Summary
- Add a themed hero variant for the Season Rewind page so the headline and spotlight panels match the Intelligence Hub visual system.
- Polish the schedule snapshot and storytelling sections with branded gradients, borders, and typography treatments across stat callouts and timeline modules.
- Introduce styled variants for summary cards, viz cards, placeholders, and future roadmap tiles to keep supporting modules on-brand.

## Testing
- No automated tests were run (static styling update).


------
https://chatgpt.com/codex/tasks/task_e_68d85045a208832794d91b1b3c499061