### PR TITLE
Fix rewind page stylesheet and improve hero panel layout

### DIFF
--- a/public/rewind.html
+++ b/public/rewind.html
@@ -6,7 +6,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231156d6'/%3E%3Ctext x='50%25' y='52%25' font-family='Inter,Arial,sans-serif' font-size='28' font-weight='700' fill='white' text-anchor='middle'%3ENBA%3C/text%3E%3C/svg%3E'
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%231156d6'/%3E%3Ctext x='50%25' y='52%25' font-family='Inter,Arial,sans-serif' font-size='28' font-weight='700' fill='white' text-anchor='middle'%3ENBA%3C/text%3E%3C/svg%3E"
     />
     <link rel="stylesheet" href="styles/hub.css" />
     <title>2024-2025 Season Rewind | NBA Intelligence Hub</title>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -276,8 +276,17 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 @media (min-width: 900px) {
-  .hero-panels { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .hero-panel--primary { grid-column: span 2; }
+  .hero-panels {
+    grid-template-columns: minmax(260px, 1.15fr) minmax(220px, 0.85fr);
+    align-items: stretch;
+  }
+  .hero-panel--primary {
+    grid-column: 1;
+    grid-row: span 2;
+  }
+  .hero-panels .hero-panel:not(.hero-panel--primary) {
+    grid-column: 2;
+  }
 }
 
 @media (min-width: 960px) {
@@ -1331,6 +1340,12 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   min-height: 240px;
   width: 100%;
   overflow: hidden;
+}
+.viz-canvas canvas {
+  display: block;
+  width: 100% !important;
+  max-width: 100%;
+  height: auto !important;
 }
 .viz-card canvas {
   display: block;


### PR DESCRIPTION
## Summary
- correct the favicon data URI on the rewind page so the shared stylesheet loads again
- update the hero highlight grid to stack supporting cards in the right column on wide screens
- ensure embedded charts respect their containers to avoid runaway scroll width

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d85294a4848327b0d71218fcda5110