### PR TITLE
Rework home page power index and preseason spotlight

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,92 +39,48 @@
               </p>
               <div class="cta-group" role="group" aria-label="Primary actions">
                 <a class="cta cta--primary" href="players.html">Dive into player forecasts</a>
-                <a class="cta cta--ghost" href="#story-arcs">Jump to marquee story arcs</a>
+                <a class="cta cta--ghost" href="#spotlight-itinerary">Plan your preseason tour</a>
               </div>
             </div>
             <div class="hero__visual" aria-live="polite">
-              <div class="hero-panels">
-                <article class="hero-panel hero-panel--primary" data-top-team-card>
-                  <span class="hero-panel__eyebrow">Power index</span>
-                  <h2 class="hero-panel__headline">
-                    <span data-top-team-name>Boston Celtics</span>
-                  </h2>
-                  <p class="hero-panel__meta">
-                    <span data-top-team-record>4,091-2,765</span> all-time · +<span data-top-team-margin>3.0</span> nightly margin
-                  </p>
-                  <p class="hero-panel__detail">
-                    Dynasty DNA anchored by <span data-top-team-strength>106.2 points for vs. 103.2 allowed</span> keeps the throne warm.
-                  </p>
-                </article>
-                <article class="hero-panel hero-panel--event" data-cup-highlight>
-                  <span class="hero-panel__eyebrow">Cup crescendo</span>
-                  <h2 class="hero-panel__headline">
-                    <time data-cup-date datetime="2025-12-17">Dec 17 · Las Vegas</time>
-                  </h2>
-                  <p class="hero-panel__meta">
-                    Emirates NBA Cup Championship returns to <span data-cup-arena>T-Mobile Arena</span>.
-                  </p>
-                  <p class="hero-panel__detail">
-                    <span data-cup-story>67 Cup tilts funnel into one desert coronation.</span>
-                  </p>
-                </article>
-                <article class="hero-panel hero-panel--event" data-global-highlight>
-                  <span class="hero-panel__eyebrow">Global stage</span>
-                  <h2 class="hero-panel__headline">
-                    <time data-global-date datetime="2025-10-04">Oct 4 · Abu Dhabi</time>
-                  </h2>
-                  <p class="hero-panel__meta">
-                    <span data-global-match>Nuggets vs. Celtics</span> ignite the worldwide runway.
-                  </p>
-                  <p class="hero-panel__detail">
-                    <span data-global-count>10 neutral-site showcases</span> stretch from Montreal to Macao.
-                  </p>
-                </article>
-              </div>
+              <article class="power-board" data-power-index-card>
+                <header class="power-board__header">
+                  <span class="power-board__eyebrow">Power index</span>
+                  <h2>Preseason conviction board</h2>
+                  <p>Every franchise on our expectation ladder before the 2025-26 tip.</p>
+                </header>
+                <ol class="power-board__list" data-power-index>
+                  <li class="power-board__placeholder">Power index syncing…</li>
+                </ol>
+              </article>
             </div>
           </div>
-          <dl class="hero-metrics" aria-live="polite">
-            <div class="hero-metrics__item">
-              <dt>Rest crunch</dt>
-              <dd>
-                <span data-metric-backtoback>446</span> zero-day turnarounds across
-                <span data-metric-restwindows>2,779</span> rest windows tighten recovery math.
-              </dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Emirates Cup slate</dt>
-              <dd>
-                <span data-metric-cupgames>67</span> tournament clashes channel the league into December drama.
-              </dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Global showcases</dt>
-              <dd>
-                <span data-metric-globalgames>10</span> international spotlight games widen the broadcast canvas.
-              </dd>
-            </div>
-          </dl>
         </div>
       </header>
 
       <main>
-        <section class="preseason-spotlight" id="preseason-slate">
-          <div class="section-header preseason-spotlight__header">
-            <h2>Preseason on the runway</h2>
+        <section class="spotlight-itinerary" id="spotlight-itinerary">
+          <div class="spotlight-itinerary__lead">
+            <span class="chip chip--accent">Spotlight itinerary</span>
+            <h2>Preseason world tour preview</h2>
             <p class="lead">
-              Track the marquee exhibitions warming up the 2025-26 campaign.
+              Our editorial board's can't-miss exhibitions before the regular-season whistle.
             </p>
           </div>
-          <div class="preseason-spotlight__content">
-            <aside class="preseason-spotlight__aside">
-              <p>
-                <strong data-preseason-total>86</strong> tune-ups sharpen rotations before the opening tip, headlined by
-                global showcases from Abu Dhabi to Montreal.
-              </p>
+          <div class="spotlight-itinerary__grid">
+            <article class="spotlight-itinerary__feature" data-itinerary-feature>
+              <p class="spotlight-itinerary__placeholder">Preseason itinerary calibrating…</p>
+            </article>
+            <aside class="spotlight-itinerary__list">
+              <header class="spotlight-itinerary__list-header">
+                <h3>On the docket</h3>
+                <p>Your cheat sheet for camp showcase viewing parties.</p>
+              </header>
+              <ol class="itinerary-list" data-itinerary-list>
+                <li class="itinerary-list__placeholder">Game list warming up…</li>
+              </ol>
+              <p class="spotlight-itinerary__footnote" data-itinerary-footnote></p>
             </aside>
-            <ol class="preseason-schedule" data-preseason-schedule>
-              <li class="preseason-schedule__placeholder">Preseason slate syncing…</li>
-            </ol>
           </div>
         </section>
 
@@ -158,159 +114,6 @@
                 <span data-rest-intervals>2,779</span> tracked windows.
               </p>
             </article>
-            <article class="season-snapshot__panel">
-              <header class="season-snapshot__header">
-                <h3>Spotlight itinerary</h3>
-                <p>Circle the showcases that define the 2025-26 stage.</p>
-              </header>
-              <ol class="timeline" data-season-timeline>
-                <li class="timeline__placeholder">Key dates loading…</li>
-              </ol>
-            </article>
-          </div>
-        </section>
-
-        <section>
-          <h2>Your 2025-26 systems map</h2>
-          <p class="lead">
-            Follow the interlocking layers—contender DNA, skill ascents, global runway, and tactical
-            experiments—that weaves this campaign into a living broadcast open.
-          </p>
-          <div class="summary-cards">
-            <article class="summary-card">
-              <strong>Contender calculus</strong>
-              <p>
-                Heat maps and flow charts quantify why Boston, Los Angeles, Oklahoma City, and Phoenix
-                headline the margin-of-error elite.
-              </p>
-              <a href="teams.html">Assess the title tier →</a>
-            </article>
-            <article class="summary-card">
-              <strong>Breakout forecast lab</strong>
-              <p>
-                Interactive sliders illustrate usage ceilings for sophomores, stealth veterans, and the
-                triple-double wave cresting at 175 a year.
-              </p>
-              <a href="players.html">Meet the risers →</a>
-            </article>
-            <article class="summary-card">
-              <strong>Rookie runway</strong>
-              <p>
-                Storytelling panels track lottery talent from Abu Dhabi scrimmages to opening-night
-                rotation stakes with global context baked in.
-              </p>
-              <a href="history.html">Explore debut timelines →</a>
-            </article>
-            <article class="summary-card">
-              <strong>Tactical experiments</strong>
-              <p>
-                Animation prototypes break down Cup-specific game plans, heliocentric pivots, and defensive
-                gambles on the wingspan renaissance.
-              </p>
-              <a href="insights.html">See the lab notes →</a>
-            </article>
-          </div>
-        </section>
-
-        <section class="offseason-horizon">
-          <div class="section-header">
-            <h2>Offseason seismic shifts</h2>
-            <p class="lead">
-              These headline moves rewired the race before camp—trace how each tweak reshapes 2025-26
-              rotations, spacing maps, and clutch-time math.
-            </p>
-          </div>
-          <div class="offseason-horizon__grid">
-            <article class="offseason-card">
-              <h3>Title-contender remixes</h3>
-              <p>
-                Boston doubled down on size with a double-big rotation, the Lakers armed Anthony Davis
-                with a pace-and-space backcourt, and Phoenix swapped wings for connective playmaking.
-              </p>
-              <ul>
-                <li>Twin towers lineups +6.7 net rating in preseason sims</li>
-                <li>Los Angeles adds 41% catch-and-shoot gravity alongside AD</li>
-                <li>Suns retool with three initiators above 20% usage</li>
-              </ul>
-            </article>
-            <article class="offseason-card">
-              <h3>Rising-core accelerators</h3>
-              <p>
-                Oklahoma City layered veteran finishing around Shai and Jalen Williams, while Orlando
-                invested in shooting to uncap Franz Wagner’s handle packages.
-              </p>
-              <ul>
-                <li>Thunder bench now projects top-5 in transition efficiency</li>
-                <li>Magic target 36%+ from deep for the first time in a decade</li>
-                <li>Both teams add switchable 6'8" forwards to crunch-time units</li>
-              </ul>
-            </article>
-            <article class="offseason-card">
-              <h3>Rookie shockwaves</h3>
-              <p>
-                Cooper Flagg’s preseason rim deterrence, Matas Buzelis’ jumbo playmaking, and Nikola
-                Topić’s pace artistry headline the debut spotlight.
-              </p>
-              <ul>
-                <li>Flagg projects 2.3 stocks per 24 minutes</li>
-                <li>Buzelis slotting into 4-out wrinkles with Lonzo orchestrating</li>
-                <li>Topić tempo boost pushes Spurs to top-10 assist rate</li>
-              </ul>
-            </article>
-            <article class="offseason-card">
-              <h3>Trade winds still swirling</h3>
-              <p>
-                With multiple All-NBA guards entering contract seasons, front offices have trade
-                packages staged for a midseason talent boom.
-              </p>
-              <ul>
-                <li>Three contenders monitoring Donovan Mitchell’s extension talks</li>
-                <li>Trae Young suitors pitching dual playmaker systems</li>
-                <li>Chicago gauging market for a defensive anchor upgrade</li>
-              </ul>
-            </article>
-          </div>
-        </section>
-
-        <section>
-          <h2>Visuals that paint the 2025-26 stakes</h2>
-          <p class="lead">
-            Every chart is tuned for immediacy—bold color ramps, motion hints, and bite-sized copy so
-            the big questions resolve before tipoff. Watch the preview come alive below.
-          </p>
-          <div class="viz-grid">
-            <figure class="viz-card" data-chart-wrapper>
-              <header class="viz-card__title">Season workload pulse</header>
-              <div class="viz-canvas">
-                <canvas data-chart="season-volume" aria-describedby="season-volume-caption"></canvas>
-              </div>
-              <figcaption id="season-volume-caption" class="viz-card__caption">
-                Track back-to-back clusters, Cup weeks, and rivalry spotlights to see which teams face
-                the sharpest gauntlets between October and April.
-              </figcaption>
-            </figure>
-
-            <figure class="viz-card" data-chart-wrapper>
-              <header class="viz-card__title">Top contender efficiency</header>
-              <div class="viz-canvas">
-                <canvas data-chart="team-efficiency" aria-describedby="team-efficiency-caption"></canvas>
-              </div>
-              <figcaption id="team-efficiency-caption" class="viz-card__caption">
-                Offensive engines and defensive clamps collide—each orbit marks a contender’s balance
-                of shot quality, rim deterrence, and crunch-time execution.
-              </figcaption>
-            </figure>
-
-            <figure class="viz-card" data-chart-wrapper>
-              <header class="viz-card__title">Global breakout pipeline</header>
-              <div class="viz-canvas">
-                <canvas data-chart="global-pipeline" aria-describedby="global-pipeline-caption"></canvas>
-              </div>
-              <figcaption id="global-pipeline-caption" class="viz-card__caption">
-                See where the next wave of playmakers originates—color gradients flag rookie impact
-                probabilities from EuroLeague, G League Ignite, and college strongholds.
-              </figcaption>
-            </figure>
           </div>
         </section>
 
@@ -446,70 +249,9 @@
           </div>
         </section>
 
-        <section id="story-arcs">
-          <h2>Story arcs we’re tracking</h2>
-          <p class="lead">
-            From coast-to-coast rivalries to stealth rebuilds, these four arcs anchor our preview and
-            will morph with every new data drop.
-          </p>
-          <ul class="list-grid">
-            <li>
-              Era of jumbo playmakers
-              <span>How positionless initiators from Denver to Detroit are bending defensive schemes.</span>
-            </li>
-            <li>
-              Defense-first renaissance
-              <span>Which coaches are trading pace for physicality—and how it shifts playoff math.</span>
-            </li>
-            <li>
-              Rookie disruptors
-              <span>Lottery wings reimagining switching rules while second-round guards weaponize pace.</span>
-            </li>
-            <li>
-              Contract-year gambles
-              <span>Star extensions on the line as front offices balance patience with blockbuster trades.</span>
-            </li>
-          </ul>
-        </section>
-
-        <section class="countdown-grid">
-          <div class="section-header">
-            <h2>Countdown checkpoints</h2>
-            <p class="lead">
-              Map the season’s first-half flashpoints to plan content drops, travel, and scouting ops.
-            </p>
-          </div>
-          <div class="countdown-grid__items">
-            <article class="countdown-card">
-              <h3>Opening week</h3>
-              <p>Oct 21–27: Seven national broadcasts highlight banner night in Boston and a Finals rematch in Denver.</p>
-              <ul>
-                <li>Back-to-back for Warriors &rarr; Suns on Oct 23-24</li>
-                <li>Rookie debuts stacked across three time zones</li>
-              </ul>
-            </article>
-            <article class="countdown-card">
-              <h3>In-season tournament push</h3>
-              <p>Nov 8–26: Cup group doubleheaders tighten rotations; expect teams to shorten benches to eight.</p>
-              <ul>
-                <li>Projected swing game: Mavericks at Pelicans, Nov 17</li>
-                <li>Travel squeeze: Knicks log 4 games in 6 nights</li>
-              </ul>
-            </article>
-            <article class="countdown-card">
-              <h3>Holiday showcases</h3>
-              <p>Dec 25–Jan 1: Five marquee Christmas matchups plus New Year’s Eve rivalry night anchor the ratings surge.</p>
-              <ul>
-                <li>LeBron vs. Tatum in primetime on Christmas</li>
-                <li>Global broadcast window for Paris preview on Dec 30</li>
-              </ul>
-            </article>
-          </div>
-        </section>
-
       </main>
 
-      <footer class="page-footer">Built for the modern NBA era — expanding with every new story.</footer>
+      
     </div>
     <script src="vendor/chart.umd.js" defer></script>
     <script type="module" src="scripts/index.js"></script>

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -8,6 +8,159 @@ const palette = {
   navy: '#0b2545',
 };
 
+const preseasonPowerIndex = [
+  {
+    team: 'Boston Celtics',
+    tier: 'Title favorite',
+    note: 'Two-way spine with Tatum, Brown, and double-big coverages keeps them atop the board.',
+  },
+  {
+    team: 'Denver Nuggets',
+    tier: 'Title favorite',
+    note: 'Jokić-Murray continuity still pilots the cleanest half-court offense in basketball.',
+  },
+  {
+    team: 'Oklahoma City Thunder',
+    tier: 'Title hopeful',
+    note: 'Shai-led creation plus length everywhere accelerates their contender timeline.',
+  },
+  {
+    team: 'Minnesota Timberwolves',
+    tier: 'Title hopeful',
+    note: 'League-best defense and ascendant Anthony Edwards keep the ceiling in championship range.',
+  },
+  {
+    team: 'New York Knicks',
+    tier: 'Contender',
+    note: 'Brunson engine and bruising depth give the East a new bully on the block.',
+  },
+  {
+    team: 'Milwaukee Bucks',
+    tier: 'Contender',
+    note: 'Giannis and Dame finally get a full camp to harmonize the downhill spacing map.',
+  },
+  {
+    team: 'Phoenix Suns',
+    tier: 'Contender',
+    note: 'Booker and Beal drive an elite offense if the refreshed supporting size holds up.',
+  },
+  {
+    team: 'Philadelphia 76ers',
+    tier: 'Contender',
+    note: 'Healthy Embiid plus rangier wings keeps them in trophy conversations.',
+  },
+  {
+    team: 'Dallas Mavericks',
+    tier: 'Contender',
+    note: 'Doncic-Irving chemistry with vertical spacing upgrades screams top-five attack.',
+  },
+  {
+    team: 'Cleveland Cavaliers',
+    tier: 'High-ceiling playoff',
+    note: 'Mitchell, Mobley, and a faster tempo aim for deeper May runs.',
+  },
+  {
+    team: 'Los Angeles Lakers',
+    tier: 'High-ceiling playoff',
+    note: 'LeBron and AD flanked by more shooting keeps the window cracked wide.',
+  },
+  {
+    team: 'Golden State Warriors',
+    tier: 'Playoff lock',
+    note: 'Curry still warps defenses while youth infusion protects the engine.',
+  },
+  {
+    team: 'Miami Heat',
+    tier: 'Playoff lock',
+    note: 'Spoelstra structure and Butler-Bam toughness always scale in spring.',
+  },
+  {
+    team: 'Sacramento Kings',
+    tier: 'Playoff lock',
+    note: 'Fox-Sabonis pace remains a nightmare once the threes fall.',
+  },
+  {
+    team: 'Memphis Grizzlies',
+    tier: 'Playoff lock',
+    note: 'Full year of Ja with Smart and Jaren anchors reloads the bite.',
+  },
+  {
+    team: 'New Orleans Pelicans',
+    tier: 'Playoff mix',
+    note: 'Zion and Ingram healthy makes every matchup a mismatch clinic.',
+  },
+  {
+    team: 'Orlando Magic',
+    tier: 'Playoff mix',
+    note: 'Banchero-Wagner leap plus elite length threatens a top-five defense.',
+  },
+  {
+    team: 'Indiana Pacers',
+    tier: 'Playoff mix',
+    note: 'Haliburton pace paired with Siakam keeps the scoreboard glowing.',
+  },
+  {
+    team: 'Los Angeles Clippers',
+    tier: 'Playoff mix',
+    note: 'If Kawhi and PG stay upright, Harden can orchestrate a balanced attack.',
+  },
+  {
+    team: 'Houston Rockets',
+    tier: 'Play-in hunt',
+    note: 'Udoka identity plus blossoming Jalen Green makes their first playoff push real.',
+  },
+  {
+    team: 'Atlanta Hawks',
+    tier: 'Play-in hunt',
+    note: 'Trae and Murray audition for full synergy under Snyder’s modern tweaks.',
+  },
+  {
+    team: 'Chicago Bulls',
+    tier: 'Play-in hunt',
+    note: 'Spacing upgrades and defensive buy-in try to extend the DeRozan window.',
+  },
+  {
+    team: 'San Antonio Spurs',
+    tier: 'Play-in swing',
+    note: 'Year-two Wemby experiments stretch the floor and the imagination.',
+  },
+  {
+    team: 'Brooklyn Nets',
+    tier: 'Play-in swing',
+    note: 'Bridges-led wingspan battalion hunts for enough offense to stick around.',
+  },
+  {
+    team: 'Toronto Raptors',
+    tier: 'Rebuild watch',
+    note: 'Scottie Barnes takes the controls while Masai plots the next core.',
+  },
+  {
+    team: 'Utah Jazz',
+    tier: 'Rebuild watch',
+    note: 'Markkanen firepower and young guards keep them pesky amid a reset.',
+  },
+  {
+    team: 'Detroit Pistons',
+    tier: 'Rebuild watch',
+    note: 'Cade Cunningham finally has vets to translate potential into wins.',
+  },
+  {
+    team: 'Charlotte Hornets',
+    tier: 'Rebuild watch',
+    note: 'LaMelo, Miller, and revamped support need reps before the leap.',
+  },
+  {
+    team: 'Portland Trail Blazers',
+    tier: 'Growth track',
+    note: 'Scoot Henderson’s learning curve defines a development-first season.',
+  },
+  {
+    team: 'Washington Wizards',
+    tier: 'Growth track',
+    note: 'New front office prioritizes reps for Coulibaly, Poole, and the kids.',
+  },
+];
+
 async function fetchJsonSafe(url) {
   try {
     const response = await fetch(url);
@@ -67,68 +220,269 @@ function formatMatchup(game, lookup) {
   return game.subLabel || game.label || 'Showcase';
 }
 
-function hydrateHero(teamData, scheduleData) {
-  const leaders = helpers.rankAndSlice(
-    Array.isArray(teamData?.winPctLeaders) ? teamData.winPctLeaders : [],
-    1,
-    (team) => team.winPct
-  );
-  const topTeam = leaders[0];
-  if (topTeam) {
-    const margin = (topTeam.pointsPerGame ?? 0) - (topTeam.opponentPointsPerGame ?? 0);
-    safeText('[data-top-team-name]', topTeam.team);
-    safeText('[data-top-team-record]', `${helpers.formatNumber(topTeam.wins, 0)}-${helpers.formatNumber(topTeam.losses, 0)}`);
-    safeText('[data-top-team-margin]', helpers.formatNumber(Math.abs(margin), 1));
-    safeText(
-      '[data-top-team-strength]',
-      `${helpers.formatNumber(topTeam.pointsPerGame ?? 0, 1)} points for vs. ${helpers.formatNumber(
-        topTeam.opponentPointsPerGame ?? 0,
-        1
-      )} allowed`
-    );
-  }
-
-  if (!scheduleData) {
+function hydrateHero(teamData) {
+  const list = document.querySelector('[data-power-index]');
+  if (!list) {
     return;
   }
 
-  const restSummary = scheduleData?.restSummary ?? {};
-  const labelBreakdown = Array.isArray(scheduleData?.labelBreakdown) ? scheduleData.labelBreakdown : [];
-  const specialGames = Array.isArray(scheduleData?.specialGames) ? scheduleData.specialGames : [];
-  const globalGames = specialGames.filter((game) => game?.subtype === 'Global Games');
-  const cupGamesEntry = labelBreakdown.find((entry) => entry?.label === 'Emirates NBA Cup');
-  const cupGamesCount = cupGamesEntry?.games ?? 0;
+  list.innerHTML = '';
 
-  safeText('[data-metric-backtoback]', helpers.formatNumber(restSummary.backToBackIntervals ?? 0, 0));
-  safeText('[data-metric-restwindows]', helpers.formatNumber(restSummary.totalIntervals ?? 0, 0));
-  safeText('[data-metric-cupgames]', helpers.formatNumber(cupGamesCount, 0));
-  safeText('[data-metric-globalgames]', helpers.formatNumber(globalGames.length || 0, 0));
-
-  const teamLookup = createTeamLookup(scheduleData);
-
-  const cupHighlight = specialGames
-    .filter((game) => game?.label === 'Emirates NBA Cup' && /championship|final/i.test(game?.subLabel ?? ''))
-    .sort((a, b) => new Date(a.date) - new Date(b.date))[0];
-  if (cupHighlight) {
-    const cupDate = document.querySelector('[data-cup-date]');
-    if (cupDate) {
-      cupDate.dateTime = cupHighlight.date;
-      cupDate.textContent = `${formatDateLabel(cupHighlight.date)} · ${formatLocation(cupHighlight)}`.trim();
-    }
-    safeText('[data-cup-arena]', cupHighlight.arena || 'Neutral site');
-    const cupTotal = cupGamesCount || labelBreakdown.find((entry) => entry?.label === 'Emirates NBA Cup')?.games || 0;
-    safeText('[data-cup-story]', `${helpers.formatNumber(cupTotal, 0)} Cup tilts funnel into one desert coronation.`);
+  const teams = Array.isArray(preseasonPowerIndex) ? preseasonPowerIndex : [];
+  if (!teams.length) {
+    const placeholder = document.createElement('li');
+    placeholder.className = 'power-board__placeholder';
+    placeholder.textContent = 'Power index will populate once the editorial board finalizes rankings.';
+    list.appendChild(placeholder);
+    return;
   }
 
-  const globalHighlight = globalGames.sort((a, b) => new Date(a.date) - new Date(b.date))[0];
-  if (globalHighlight) {
-    const globalDate = document.querySelector('[data-global-date]');
-    if (globalDate) {
-      globalDate.dateTime = globalHighlight.date;
-      globalDate.textContent = `${formatDateLabel(globalHighlight.date)} · ${formatLocation(globalHighlight)}`.trim();
+  const statLookup = new Map();
+  (Array.isArray(teamData?.winPctLeaders) ? teamData.winPctLeaders : []).forEach((team) => {
+    if (team?.team) {
+      statLookup.set(team.team, team);
     }
-    safeText('[data-global-match]', formatMatchup(globalHighlight, teamLookup));
-    safeText('[data-global-count]', `${helpers.formatNumber(globalGames.length || 0, 0)} neutral-site showcases`);
+  });
+
+  teams.forEach((entry, index) => {
+    const item = document.createElement('li');
+    item.className = 'power-board__item';
+
+    const rank = document.createElement('span');
+    rank.className = 'power-board__rank';
+    rank.textContent = String(index + 1);
+
+    const body = document.createElement('div');
+    body.className = 'power-board__content';
+    const name = document.createElement('p');
+    name.className = 'power-board__name';
+    name.textContent = entry.team;
+    const note = document.createElement('p');
+    note.className = 'power-board__note';
+    note.textContent = entry.note;
+    body.append(name, note);
+
+    const meta = document.createElement('div');
+    meta.className = 'power-board__meta';
+    const tier = document.createElement('span');
+    tier.className = 'power-board__tier';
+    tier.textContent = entry.tier;
+    meta.appendChild(tier);
+
+    const stats = statLookup.get(entry.team);
+    if (stats) {
+      const margin = (stats.pointsPerGame ?? 0) - (stats.opponentPointsPerGame ?? 0);
+      const stat = document.createElement('span');
+      stat.className = 'power-board__stat';
+      stat.textContent = `${helpers.formatNumber((stats.winPct ?? 0) * 100, 1)}% win pct · ${
+        margin >= 0 ? '+' : '–'
+      }${helpers.formatNumber(Math.abs(margin), 1)} margin`;
+      meta.appendChild(stat);
+    }
+
+    item.append(rank, body, meta);
+    list.appendChild(item);
+  });
+}
+
+function deriveItineraryContext(game) {
+  const descriptor = `${game?.subLabel ?? ''} ${game?.seriesText ?? ''} ${game?.label ?? ''}`.toLowerCase();
+  const subtype = (game?.subtype ?? '').toLowerCase();
+  if (subtype.includes('global') || descriptor.includes('global') || descriptor.includes('international')) {
+    return {
+      tag: 'Global stage',
+      focus: "International stop spotlights the league's worldwide push before opening night.",
+    };
+  }
+  if (descriptor.includes('abu dhabi') || descriptor.includes('paris') || descriptor.includes('macao')) {
+    return {
+      tag: 'Global stage',
+      focus: "Neutral-site showcase primes worldwide fanbases for the new season.",
+    };
+  }
+  if (descriptor.includes('classic') || descriptor.includes('rival') || descriptor.includes('derby')) {
+    return {
+      tag: 'Marquee rivalry',
+      focus: 'Legacy opponents turn a tune-up into a statement night.',
+    };
+  }
+  if (descriptor.includes('cup') || descriptor.includes('in-season')) {
+    return {
+      tag: 'Cup tune-up',
+      focus: 'Teams rehearse the pace and coverages that decide December tournament nights.',
+    };
+  }
+  if (descriptor.includes('rookie') || descriptor.includes('prospect') || descriptor.includes('sophomore')) {
+    return {
+      tag: 'Rookie spotlight',
+      focus: 'Young cores get extended runway to fight for rotation minutes.',
+    };
+  }
+  if (descriptor.includes('homecoming') || descriptor.includes('heritage') || descriptor.includes('community')) {
+    return {
+      tag: 'Community showcase',
+      focus: 'Local storytelling anchors the preseason party before standings matter.',
+    };
+  }
+  return {
+    tag: 'Camp primer',
+    focus: 'Training camp intensity lifts as rotations tighten toward opening night.',
+  };
+}
+
+function buildItineraryHighlights(game, context) {
+  const highlights = [];
+  const seen = new Set();
+  const addHighlight = (text) => {
+    const trimmed = typeof text === 'string' ? text.trim() : '';
+    if (!trimmed || seen.has(trimmed)) {
+      return;
+    }
+    highlights.push(trimmed);
+    seen.add(trimmed);
+  };
+
+  addHighlight(context.focus);
+
+  const venue = formatLocation(game);
+  if (venue) {
+    addHighlight(`Venue spotlight: ${venue}`);
+  }
+
+  addHighlight(game?.seriesText || game?.subLabel);
+  addHighlight('Rotation battles highlight spacing tweaks and new signings.');
+
+  return highlights.slice(0, 3);
+}
+
+function renderSpotlightItinerary(scheduleData) {
+  const feature = document.querySelector('[data-itinerary-feature]');
+  const list = document.querySelector('[data-itinerary-list]');
+  const footnote = document.querySelector('[data-itinerary-footnote]');
+  if (!feature && !list && !footnote) {
+    return;
+  }
+
+  const scheduleAvailable = Boolean(scheduleData);
+  const teamLookup = scheduleAvailable ? createTeamLookup(scheduleData) : new Map();
+  const seasonStartYear = scheduleAvailable && scheduleData?.dateRange?.start
+    ? new Date(scheduleData.dateRange.start).getFullYear()
+    : null;
+  const gamesSource = scheduleAvailable && Array.isArray(scheduleData?.specialGames) ? scheduleData.specialGames : [];
+  const preseasonGames = gamesSource
+    .filter((game) => `${game?.label ?? ''} ${game?.subLabel ?? ''}`.toLowerCase().includes('preseason'))
+    .map((game) => ({ ...game, parsedDate: game?.date ? new Date(game.date) : null }))
+    .filter((game) => game.parsedDate instanceof Date && !Number.isNaN(game.parsedDate.getTime()))
+    .filter((game) => (seasonStartYear !== null ? game.parsedDate.getFullYear() === seasonStartYear : true))
+    .sort((a, b) => a.parsedDate - b.parsedDate);
+
+  if (feature) {
+    feature.innerHTML = '';
+    if (!preseasonGames.length) {
+      const placeholder = document.createElement('p');
+      placeholder.className = 'spotlight-itinerary__placeholder';
+      placeholder.textContent = 'Feature matchup arrives once the preseason manifest is finalized.';
+      feature.appendChild(placeholder);
+    } else {
+      const headliner = preseasonGames[0];
+      const context = deriveItineraryContext(headliner);
+      const header = document.createElement('header');
+      header.className = 'itinerary-feature__header';
+
+      const tag = document.createElement('span');
+      tag.className = 'itinerary-feature__tag';
+      tag.textContent = context.tag;
+
+      const date = document.createElement('time');
+      date.className = 'itinerary-feature__date';
+      if (headliner.date) {
+        date.dateTime = headliner.date;
+        date.textContent = formatDateLabel(headliner.date, { weekday: 'short', month: 'short', day: 'numeric' });
+      } else {
+        date.textContent = 'Date to be announced';
+      }
+
+      const matchup = document.createElement('h3');
+      matchup.className = 'itinerary-feature__matchup';
+      matchup.textContent = formatMatchup(headliner, teamLookup) || 'Preseason showcase';
+
+      const subtitle = document.createElement('p');
+      subtitle.className = 'itinerary-feature__subtitle';
+      subtitle.textContent = headliner?.subLabel || headliner?.seriesText || 'Flagship preseason tilt';
+
+      const location = document.createElement('p');
+      location.className = 'itinerary-feature__location';
+      location.textContent = formatLocation(headliner) || 'Neutral site';
+
+      header.append(tag, date, matchup, subtitle, location);
+
+      const highlightList = document.createElement('ul');
+      highlightList.className = 'itinerary-feature__highlights';
+      buildItineraryHighlights(headliner, context).forEach((highlight) => {
+        const item = document.createElement('li');
+        item.textContent = highlight;
+        highlightList.appendChild(item);
+      });
+
+      feature.append(header, highlightList);
+    }
+  }
+
+  if (list) {
+    list.innerHTML = '';
+    if (!preseasonGames.length) {
+      const placeholder = document.createElement('li');
+      placeholder.className = 'itinerary-list__placeholder';
+      placeholder.textContent = 'Preseason manifest pending league release.';
+      list.appendChild(placeholder);
+    } else {
+      preseasonGames.slice(0, 8).forEach((game) => {
+        const context = deriveItineraryContext(game);
+        const item = document.createElement('li');
+        item.className = 'itinerary-list__item';
+
+        const date = document.createElement('time');
+        date.className = 'itinerary-list__date';
+        if (game.date) {
+          date.dateTime = game.date;
+          date.textContent = formatDateLabel(game.date, { month: 'short', day: 'numeric' });
+        } else {
+          date.textContent = 'TBD';
+        }
+
+        const body = document.createElement('div');
+        body.className = 'itinerary-list__body';
+
+        const tag = document.createElement('span');
+        tag.className = 'itinerary-list__tag';
+        tag.textContent = context.tag;
+
+        const matchup = document.createElement('p');
+        matchup.className = 'itinerary-list__matchup';
+        matchup.textContent = formatMatchup(game, teamLookup) || 'Preseason showcase';
+
+        const detail = document.createElement('p');
+        detail.className = 'itinerary-list__detail';
+        detail.textContent = game?.subLabel || game?.seriesText || 'Rotation checkup';
+
+        const location = document.createElement('p');
+        location.className = 'itinerary-list__location';
+        location.textContent = formatLocation(game) || 'Neutral site';
+
+        body.append(tag, matchup, detail, location);
+        item.append(date, body);
+        list.appendChild(item);
+      });
+    }
+  }
+
+  if (footnote) {
+    if (preseasonGames.length) {
+      const total = scheduleAvailable ? scheduleData?.totals?.preseason ?? preseasonGames.length : preseasonGames.length;
+      footnote.textContent = `Total preseason exhibitions logged: ${helpers.formatNumber(total, 0)} leaguewide — itinerary updates as slates finalize.`;
+    } else {
+      footnote.textContent = 'League preseason slate is still syncing — check back once the manifest locks.';
+    }
   }
 }
 
@@ -238,154 +592,6 @@ function renderBackToBack(scheduleData) {
     restAverage.textContent = `${helpers.formatNumber(scheduleData?.restSummary?.averageRestDays ?? 0, 2)} days`;
   }
   safeText('[data-rest-intervals]', helpers.formatNumber(scheduleData?.restSummary?.totalIntervals ?? 0, 0));
-}
-
-function renderTimeline(scheduleData) {
-  const list = document.querySelector('[data-season-timeline]');
-  if (!list) {
-    return;
-  }
-  list.innerHTML = '';
-  if (!scheduleData) {
-    const placeholder = document.createElement('li');
-    placeholder.className = 'timeline__placeholder';
-    placeholder.textContent = 'Spotlight dates arrive once the schedule manifest loads.';
-    list.appendChild(placeholder);
-    return;
-  }
-  const specialGames = Array.isArray(scheduleData?.specialGames) ? scheduleData.specialGames : [];
-  const teamLookup = createTeamLookup(scheduleData);
-  const events = [];
-
-  const addEvent = (game, headline) => {
-    if (!game) return;
-    events.push({
-      date: game.date,
-      headline,
-      detail: `${formatMatchup(game, teamLookup)} · ${game.arena || 'Neutral site'}`,
-      location: formatLocation(game),
-    });
-  };
-
-  const sortAsc = (a, b) => new Date(a.date) - new Date(b.date);
-  const globalGame = specialGames.filter((game) => game?.subtype === 'Global Games').sort(sortAsc)[0];
-  addEvent(globalGame, 'Global tip-off');
-  const cupFinal = specialGames
-    .filter((game) => game?.label === 'Emirates NBA Cup' && /championship|final/i.test(game?.subLabel ?? ''))
-    .sort(sortAsc)[0];
-  addEvent(cupFinal, 'Emirates NBA Cup championship');
-  const parisGame = specialGames.filter((game) => game?.label === 'NBA Paris Game').sort(sortAsc)[0];
-  addEvent(parisGame, 'Paris spotlight');
-  const mexicoGame = specialGames.filter((game) => game?.label === 'NBA Mexico City Game').sort(sortAsc)[0];
-  addEvent(mexicoGame, 'Mexico City showcase');
-  const finalsGame = specialGames
-    .filter((game) => game?.label === 'NBA Finals')
-    .sort((a, b) => new Date(b.date) - new Date(a.date))[0];
-  addEvent(finalsGame, 'Projected Finals climax');
-
-  const uniqueEvents = events.filter((event, index, array) => {
-    const key = `${event.headline}-${event.date}`;
-    return array.findIndex((candidate) => `${candidate.headline}-${candidate.date}` === key) === index;
-  });
-
-  if (!uniqueEvents.length) {
-    const placeholder = document.createElement('li');
-    placeholder.className = 'timeline__placeholder';
-    placeholder.textContent = 'Spotlight dates arrive once the schedule manifest loads.';
-    list.appendChild(placeholder);
-    return;
-  }
-
-  uniqueEvents
-    .sort((a, b) => new Date(a.date) - new Date(b.date))
-    .slice(0, 5)
-    .forEach((event) => {
-      const item = document.createElement('li');
-      item.className = 'timeline__item';
-      const dateLabel = document.createElement('time');
-      dateLabel.className = 'timeline__date';
-      dateLabel.dateTime = event.date;
-      dateLabel.textContent = formatDateLabel(event.date, { month: 'short', day: 'numeric', year: 'numeric' });
-      const headline = document.createElement('p');
-      headline.className = 'timeline__headline';
-      headline.textContent = event.headline;
-      const detail = document.createElement('p');
-      detail.className = 'timeline__detail';
-      detail.textContent = `${event.detail} — ${event.location}`;
-      item.append(dateLabel, headline, detail);
-      list.appendChild(item);
-    });
-}
-
-function renderPreseasonSchedule(scheduleData) {
-  const list = document.querySelector('[data-preseason-schedule]');
-  const totalNode = document.querySelector('[data-preseason-total]');
-
-  if (totalNode) {
-    const total = helpers.formatNumber(scheduleData?.totals?.preseason ?? 0, 0);
-    totalNode.textContent = total;
-  }
-
-  if (!list) {
-    return;
-  }
-
-  list.innerHTML = '';
-
-  if (!scheduleData) {
-    const placeholder = document.createElement('li');
-    placeholder.className = 'preseason-schedule__placeholder';
-    placeholder.textContent = 'Preseason fixtures populate once the schedule snapshot loads.';
-    list.appendChild(placeholder);
-    return;
-  }
-
-  const seasonStartYear = scheduleData?.dateRange?.start ? new Date(scheduleData.dateRange.start).getFullYear() : null;
-  const preseasonGames = (Array.isArray(scheduleData?.specialGames) ? scheduleData.specialGames : [])
-    .filter((game) => (game?.label ?? '').toLowerCase().includes('preseason'))
-    .map((game) => ({ ...game, parsedDate: game?.date ? new Date(game.date) : null }))
-    .filter((game) => game.parsedDate instanceof Date && !Number.isNaN(game.parsedDate.getTime()))
-    .filter((game) => (seasonStartYear !== null ? game.parsedDate.getFullYear() === seasonStartYear : true))
-    .sort((a, b) => a.parsedDate - b.parsedDate);
-
-  if (!preseasonGames.length) {
-    const placeholder = document.createElement('li');
-    placeholder.className = 'preseason-schedule__placeholder';
-    placeholder.textContent = 'Preseason fixtures will post once the league finalizes the slate.';
-    list.appendChild(placeholder);
-    return;
-  }
-
-  const teamLookup = createTeamLookup(scheduleData);
-
-  preseasonGames.slice(0, 6).forEach((game) => {
-    const item = document.createElement('li');
-    item.className = 'preseason-game';
-
-    const date = document.createElement('time');
-    date.className = 'preseason-game__date';
-    if (game.date) {
-      date.dateTime = game.date;
-      date.textContent = formatDateLabel(game.date, { weekday: 'short', month: 'short', day: 'numeric' });
-    } else {
-      date.textContent = 'TBD';
-    }
-
-    const matchup = document.createElement('p');
-    matchup.className = 'preseason-game__matchup';
-    matchup.textContent = formatMatchup(game, teamLookup) || 'Preseason showcase';
-
-    const meta = document.createElement('p');
-    meta.className = 'preseason-game__meta';
-    meta.textContent = game.subLabel || game.seriesText || 'Global exhibition';
-
-    const location = document.createElement('p');
-    location.className = 'preseason-game__location';
-    location.textContent = formatLocation(game) || 'Neutral site';
-
-    item.append(date, matchup, meta, location);
-    list.appendChild(item);
-  });
 }
 
 function renderStoryCards(storyData) {
@@ -662,12 +868,11 @@ async function bootstrap() {
     fetchJsonSafe('data/storytelling_walkthroughs.json'),
   ]);
 
-  hydrateHero(teamData, scheduleData);
+  hydrateHero(teamData);
   renderSeasonLead(scheduleData);
-  renderPreseasonSchedule(scheduleData);
+  renderSpotlightItinerary(scheduleData);
   renderContenderGrid(teamData);
   renderBackToBack(scheduleData);
-  renderTimeline(scheduleData);
   renderStoryCards(storyData);
 }
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -149,6 +149,146 @@ a:hover, a:focus { color: var(--sky); }
   justify-content: center;
 }
 
+.power-board {
+  width: min(100%, 980px);
+  display: grid;
+  gap: clamp(1.4rem, 3.5vw, 2.1rem);
+  padding: clamp(1.6rem, 4vw, 2.4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 24%, transparent);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.18), rgba(239, 61, 91, 0.12)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: 0 28px 48px rgba(11, 37, 69, 0.2);
+}
+
+.power-board__header {
+  display: grid;
+  gap: 0.6rem;
+  text-align: center;
+}
+
+.power-board__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  margin-inline: auto;
+  padding: 0.38rem 0.85rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(31, 123, 255, 0.78));
+  color: #fff;
+  font-size: 0.76rem;
+  letter-spacing: 0.14em;
+  font-weight: 700;
+  text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.power-board__header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.6vw, 1.95rem);
+  letter-spacing: -0.01em;
+}
+
+.power-board__header p {
+  margin: 0;
+  font-size: 0.98rem;
+  color: var(--text-subtle);
+}
+
+.power-board__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.power-board__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  padding: 1rem 1.2rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
+  background:
+    linear-gradient(140deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 16px 28px rgba(11, 37, 69, 0.16);
+}
+
+.power-board__rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.85));
+  color: #fff;
+  font-weight: 800;
+  font-size: 1rem;
+  box-shadow: 0 10px 16px rgba(17, 86, 214, 0.35);
+}
+
+.power-board__content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.power-board__name {
+  margin: 0;
+  font-size: 1.08rem;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.power-board__note {
+  margin: 0;
+  font-size: 0.86rem;
+  color: var(--text-subtle);
+  line-height: 1.55;
+}
+
+.power-board__meta {
+  display: grid;
+  gap: 0.35rem;
+  align-content: start;
+}
+
+.power-board__tier {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--royal);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.16) 60%, rgba(255, 255, 255, 0.92) 40%);
+  border: 1px solid color-mix(in srgb, var(--royal) 26%, transparent);
+}
+
+.power-board__stat {
+  font-size: 0.78rem;
+  color: var(--text-subtle);
+}
+
+.power-board__placeholder {
+  margin: 0;
+  padding: 1.2rem 1rem;
+  text-align: center;
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--royal) 24%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 50%, rgba(255, 255, 255, 0.95) 50%);
+  color: var(--text-subtle);
+}
+
 .cta-group { margin-top: 1.4rem; display: flex; justify-content: center; flex-wrap: wrap; gap: 0.75rem; }
 .cta {
   display: inline-flex; align-items: center; justify-content: center; gap: 0.4rem; padding: 0.75rem 1.4rem;
@@ -315,89 +455,234 @@ section {
   padding: 1.75rem clamp(1.5rem, 4vw, 2.5rem); box-shadow: var(--shadow-soft); border: 1px solid var(--border);
 }
 
-.preseason-spotlight {
+.spotlight-itinerary {
   display: grid;
-  gap: clamp(1.4rem, 3vw, 2rem);
+  gap: clamp(1.8rem, 4vw, 2.4rem);
+  background:
+    linear-gradient(165deg, rgba(17, 86, 214, 0.14), rgba(244, 181, 63, 0.12)),
+    var(--surface);
+  border-color: color-mix(in srgb, var(--border) 55%, transparent);
 }
-.preseason-spotlight__content {
+
+.spotlight-itinerary__lead {
   display: grid;
-  gap: clamp(1.2rem, 3vw, 1.8rem);
+  gap: 0.8rem;
+  text-align: center;
 }
-.preseason-spotlight__aside {
-  padding: 1.1rem 1.4rem;
-  border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
-  background: color-mix(in srgb, rgba(17, 86, 214, 0.08) 40%, rgba(255, 255, 255, 0.92) 60%);
-  box-shadow: var(--shadow-soft);
+
+.spotlight-itinerary__lead .chip {
+  margin-inline: auto;
+}
+
+.spotlight-itinerary__grid {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2.4rem);
+}
+
+.spotlight-itinerary__feature,
+.spotlight-itinerary__list {
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(31, 123, 255, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: 0 22px 36px rgba(11, 37, 69, 0.16);
+  padding: clamp(1.5rem, 4vw, 2.3rem);
+}
+
+.spotlight-itinerary__placeholder {
+  margin: 0;
+  text-align: center;
   color: var(--text-subtle);
   font-size: 0.95rem;
-  line-height: 1.6;
 }
-.preseason-spotlight__aside strong {
-  display: block;
-  font-size: 1.45rem;
-  color: var(--royal);
-  margin-bottom: 0.4rem;
-}
-.preseason-schedule {
-  margin: 0;
-  padding: 0;
-  list-style: none;
+
+.itinerary-feature__header {
   display: grid;
-  gap: 1rem;
+  gap: 0.5rem;
 }
-.preseason-schedule__placeholder {
-  margin: 0;
-  padding: 1.4rem 1.2rem;
-  text-align: center;
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, rgba(17, 86, 214, 0.1) 40%, rgba(242, 246, 255, 0.9) 60%);
-  color: var(--text-subtle);
-  border: 1px dashed color-mix(in srgb, var(--royal) 35%, transparent);
-}
-.preseason-game {
-  display: grid;
-  gap: 0.45rem;
-  padding: 1rem 1.2rem 1.1rem;
-  border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
-  background:
-    linear-gradient(135deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
-    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.9) 30%);
-  box-shadow: var(--shadow-soft);
-}
-.preseason-game__date {
-  font-size: 0.75rem;
+
+.itinerary-feature__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 0.28rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(17, 86, 214, 0.85);
+  font-weight: 700;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.18) 60%, rgba(239, 61, 91, 0.1) 40%);
+  color: var(--royal);
+}
+
+.itinerary-feature__date {
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(17, 86, 214, 0.8);
   font-weight: 700;
 }
-.preseason-game__matchup {
+
+.itinerary-feature__matchup {
   margin: 0;
-  font-size: 1.05rem;
-  font-weight: 700;
+  font-size: clamp(1.35rem, 3.2vw, 1.7rem);
+  font-weight: 800;
   color: var(--navy);
 }
-.preseason-game__meta {
+
+.itinerary-feature__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+.itinerary-feature__location {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(11, 37, 69, 0.7);
+  font-weight: 600;
+}
+
+.itinerary-feature__highlights {
+  list-style: none;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.itinerary-feature__highlights li {
+  position: relative;
+  padding-left: 1.35rem;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+  line-height: 1.6;
+}
+
+.itinerary-feature__highlights li::before {
+  content: '•';
+  position: absolute;
+  left: 0;
+  color: var(--royal);
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.spotlight-itinerary__list-header {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.spotlight-itinerary__list-header h3 {
+  margin: 0;
+  font-size: 1.08rem;
+  color: var(--navy);
+}
+
+.spotlight-itinerary__list-header p {
   margin: 0;
   font-size: 0.9rem;
   color: var(--text-subtle);
 }
-.preseason-game__location {
+
+.itinerary-list {
+  list-style: none;
   margin: 0;
-  font-size: 0.85rem;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.itinerary-list__placeholder {
+  margin: 0;
+  padding: 1.35rem 1.1rem;
+  text-align: center;
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--royal) 25%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.1) 45%, rgba(255, 255, 255, 0.95) 55%);
+  color: var(--text-subtle);
+}
+
+.itinerary-list__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  padding: 0.95rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background:
+    linear-gradient(140deg, rgba(17, 86, 214, 0.06), rgba(244, 181, 63, 0.06)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.itinerary-list__date {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.14) 60%, rgba(255, 255, 255, 0.92) 40%);
+  color: var(--royal);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.itinerary-list__body {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.itinerary-list__tag {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.55rem;
+  border-radius: 0.65rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 50%, rgba(239, 61, 91, 0.09) 50%);
+  color: var(--royal);
+}
+
+.itinerary-list__matchup {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.itinerary-list__detail {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--text-subtle);
+}
+
+.itinerary-list__location {
+  margin: 0;
+  font-size: 0.84rem;
   color: rgba(11, 37, 69, 0.65);
 }
 
-@media (min-width: 880px) {
-  .preseason-spotlight__content {
-    grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+.spotlight-itinerary__footnote {
+  margin: 1.3rem 0 0;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+  text-align: center;
+}
+
+@media (min-width: 960px) {
+  .spotlight-itinerary__grid {
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
     align-items: start;
-  }
-  .preseason-spotlight__aside {
-    position: sticky;
-    top: 1.5rem;
   }
 }
 section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spacing: 0.01em; color: var(--navy); }


### PR DESCRIPTION
## Summary
- replace the hero power index panel with a full-team preseason ranking board
- rebuild the spotlight itinerary section into a richer preseason preview and retire outdated panels
- refresh supporting scripts and styles for the new power board and itinerary layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d86930b1a48327a9876067552ce6ac