### PR TITLE
Refine power index hero layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,34 +27,17 @@
             <a href="about.html">About</a>
           </nav>
         </div>
-        <div class="hero">
-          <div class="hero__layout">
-            <div class="hero__intro">
-              <span class="eyebrow">Season Preview Premiere · 2025-26</span>
-              <h1>The NBA storyworld rendered in color, context, and controlled chaos.</h1>
-              <p class="hero__lede">
-                1,161 regular-season tilts, 67 Emirates NBA Cup showdowns, 10 global showcases, and a
-                cavalcade of roster rewrites—the Intelligence Hub rebuilt the preview so you can feel the
-                season before the opening tip.
-              </p>
-              <div class="cta-group" role="group" aria-label="Primary actions">
-                <a class="cta cta--primary" href="players.html">Dive into player forecasts</a>
-                <a class="cta cta--ghost" href="#spotlight-itinerary">Plan your preseason tour</a>
-              </div>
-            </div>
-            <div class="hero__visual" aria-live="polite">
-              <article class="power-board" data-power-index-card>
-                <header class="power-board__header">
-                  <span class="power-board__eyebrow">Power index</span>
-                  <h2>Preseason conviction board</h2>
-                  <p>Every franchise on our expectation ladder before the 2025-26 tip.</p>
-                </header>
-                <ol class="power-board__list" data-power-index>
-                  <li class="power-board__placeholder">Power index syncing…</li>
-                </ol>
-              </article>
-            </div>
-          </div>
+        <div class="hero hero--power" aria-live="polite">
+          <article class="power-board power-board--compact" data-power-index-card>
+            <header class="power-board__header">
+              <span class="power-board__eyebrow">Power index</span>
+              <h2>Preseason conviction board</h2>
+              <p>Every franchise on our expectation ladder before the 2025-26 tip.</p>
+            </header>
+            <ol class="power-board__list" data-power-index>
+              <li class="power-board__placeholder">Power index syncing…</li>
+            </ol>
+          </article>
         </div>
       </header>
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -81,6 +81,15 @@ a:hover, a:focus { color: var(--sky); }
   display: grid;
   gap: clamp(2rem, 4vw, 3rem);
 }
+
+.hero--power {
+  padding: clamp(1.8rem, 5vw, 2.6rem) clamp(1rem, 4vw, 1.6rem) clamp(1.6rem, 4vw, 2.1rem);
+  display: flex;
+  justify-content: center;
+}
+.hero--power > * {
+  width: 100%;
+}
 .hero--rewind {
   position: relative;
   overflow: hidden;
@@ -150,22 +159,53 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .power-board {
-  width: min(100%, 980px);
+  width: min(100%, 840px);
   display: grid;
-  gap: clamp(1.4rem, 3.5vw, 2.1rem);
-  padding: clamp(1.6rem, 4vw, 2.4rem);
+  gap: clamp(1.1rem, 3vw, 1.8rem);
+  padding: clamp(1.25rem, 3vw, 1.9rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 24%, transparent);
   background:
-    linear-gradient(150deg, rgba(17, 86, 214, 0.18), rgba(239, 61, 91, 0.12)),
-    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
-  box-shadow: 0 28px 48px rgba(11, 37, 69, 0.2);
+    linear-gradient(150deg, rgba(17, 86, 214, 0.14), rgba(239, 61, 91, 0.1)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: 0 20px 36px rgba(11, 37, 69, 0.16);
+}
+
+.power-board--compact {
+  width: min(100%, 760px);
+  gap: clamp(0.95rem, 2.4vw, 1.5rem);
+  margin-inline: auto;
 }
 
 .power-board__header {
   display: grid;
   gap: 0.6rem;
   text-align: center;
+}
+
+.power-board--compact .power-board__header {
+  text-align: left;
+  gap: 0.4rem;
+}
+
+.power-board--compact .power-board__header h2 {
+  font-size: clamp(1.45rem, 3.4vw, 1.85rem);
+}
+
+.power-board--compact .power-board__header p {
+  font-size: 0.9rem;
+}
+
+@media (min-width: 680px) {
+  .power-board--compact .power-board__header {
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 0.5rem 1.25rem;
+  }
+  .power-board--compact .power-board__header p {
+    margin: 0.1rem 0 0;
+    grid-column: span 2;
+  }
 }
 
 .power-board__eyebrow {
@@ -202,54 +242,59 @@ a:hover, a:focus { color: var(--sky); }
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.9rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.power-board--compact .power-board__list {
+  gap: 0.7rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
 }
 
 .power-board__item {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.85rem;
-  padding: 1rem 1.2rem 1.1rem;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem 0.95rem;
   border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
   background:
-    linear-gradient(140deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
-    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.9) 30%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65), 0 16px 28px rgba(11, 37, 69, 0.16);
+    linear-gradient(140deg, rgba(17, 86, 214, 0.1), rgba(244, 181, 63, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.96) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 12px 24px rgba(11, 37, 69, 0.14);
 }
 
 .power-board__rank {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.4rem;
-  height: 2.4rem;
-  border-radius: 0.75rem;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 0.65rem;
   background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.85));
   color: #fff;
   font-weight: 800;
-  font-size: 1rem;
-  box-shadow: 0 10px 16px rgba(17, 86, 214, 0.35);
+  font-size: 0.95rem;
+  box-shadow: 0 8px 14px rgba(17, 86, 214, 0.3);
 }
 
 .power-board__content {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .power-board__name {
   margin: 0;
-  font-size: 1.08rem;
+  font-size: 1.02rem;
   font-weight: 700;
   color: var(--navy);
 }
 
 .power-board__note {
   margin: 0;
-  font-size: 0.86rem;
+  font-size: 0.82rem;
   color: var(--text-subtle);
-  line-height: 1.55;
+  line-height: 1.45;
 }
 
 .power-board__meta {
@@ -263,29 +308,29 @@ a:hover, a:focus { color: var(--sky); }
   align-items: center;
   justify-content: center;
   width: fit-content;
-  padding: 0.25rem 0.65rem;
+  padding: 0.2rem 0.55rem;
   border-radius: 999px;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   font-weight: 700;
   color: var(--royal);
-  background: color-mix(in srgb, rgba(17, 86, 214, 0.16) 60%, rgba(255, 255, 255, 0.92) 40%);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.16) 60%, rgba(255, 255, 255, 0.94) 40%);
   border: 1px solid color-mix(in srgb, var(--royal) 26%, transparent);
 }
 
 .power-board__stat {
-  font-size: 0.78rem;
+  font-size: 0.76rem;
   color: var(--text-subtle);
 }
 
 .power-board__placeholder {
   margin: 0;
-  padding: 1.2rem 1rem;
+  padding: 1rem 0.9rem;
   text-align: center;
   border-radius: var(--radius-md);
   border: 1px dashed color-mix(in srgb, var(--royal) 24%, transparent);
-  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 50%, rgba(255, 255, 255, 0.95) 50%);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 45%, rgba(255, 255, 255, 0.95) 55%);
   color: var(--text-subtle);
 }
 


### PR DESCRIPTION
## Summary
- remove the introductory hero copy on the preview page so the power index card is the focal point
- restyle the power index container and tiles to reduce padding, tighten spacing, and improve readability

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d86c2bd03c8327bcd3e22f80ae31e6