### PR TITLE
Compact power index cards

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -244,6 +244,7 @@ a:hover, a:focus { color: var(--sky); }
   display: grid;
   gap: 0.8rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
 }
 
 .power-board--compact .power-board__list {
@@ -253,7 +254,7 @@ a:hover, a:focus { color: var(--sky); }
 
 .power-board__item {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 0.75rem;
   padding: 0.85rem 1rem 0.95rem;
   border-radius: var(--radius-md);
@@ -262,6 +263,7 @@ a:hover, a:focus { color: var(--sky); }
     linear-gradient(140deg, rgba(17, 86, 214, 0.1), rgba(244, 181, 63, 0.08)),
     color-mix(in srgb, rgba(255, 255, 255, 0.96) 70%, rgba(242, 246, 255, 0.92) 30%);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 12px 24px rgba(11, 37, 69, 0.14);
+  align-items: start;
 }
 
 .power-board__rank {
@@ -301,6 +303,7 @@ a:hover, a:focus { color: var(--sky); }
   display: grid;
   gap: 0.35rem;
   align-content: start;
+  grid-column: 1 / -1;
 }
 
 .power-board__tier {
@@ -322,6 +325,19 @@ a:hover, a:focus { color: var(--sky); }
 .power-board__stat {
   font-size: 0.76rem;
   color: var(--text-subtle);
+}
+
+@media (min-width: 680px) {
+  .power-board__item {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .power-board__meta {
+    grid-column: auto;
+    justify-items: end;
+    text-align: right;
+  }
 }
 
 .power-board__placeholder {


### PR DESCRIPTION
## Summary
- adjust the power index card grid to stop stretching cards taller than their content
- move the tier/stat block beside the team blurb on wide viewports and align grid items from the top

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d86e9857308327822258e552980207