### PR TITLE
Refine power index layout

### DIFF
--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -219,27 +219,37 @@ function hydrateHero(teamData) {
     const item = document.createElement('li');
     item.className = 'power-board__item';
 
-    const rank = document.createElement('span');
-    rank.className = 'power-board__rank';
-    rank.textContent = String(index + 1);
+    const teamLabel = entry.team ?? 'Team';
+
+    const marker = document.createElement('span');
+    marker.className = 'power-board__marker';
+    marker.appendChild(createTeamLogo(teamLabel, 'team-logo team-logo--small'));
 
     const body = document.createElement('div');
     body.className = 'power-board__content';
+
     const identity = document.createElement('div');
     identity.className = 'power-board__identity';
-    const teamLabel = entry.team ?? 'Team';
-    identity.appendChild(createTeamLogo(teamLabel, 'team-logo team-logo--medium'));
+
+    const rank = document.createElement('span');
+    rank.className = 'power-board__rank';
+    rank.textContent = `#${index + 1}`;
+
     const name = document.createElement('p');
     name.className = 'power-board__name';
     name.textContent = teamLabel;
-    identity.appendChild(name);
+
+    identity.append(rank, name);
+
     const note = document.createElement('p');
     note.className = 'power-board__note';
     note.textContent = entry.note;
+
     body.append(identity, note);
 
     const meta = document.createElement('div');
     meta.className = 'power-board__meta';
+
     const tier = document.createElement('span');
     tier.className = 'power-board__tier';
     tier.textContent = entry.tier;
@@ -256,7 +266,9 @@ function hydrateHero(teamData) {
       meta.appendChild(stat);
     }
 
-    item.append(rank, body, meta);
+    body.append(meta);
+
+    item.append(marker, body);
     list.appendChild(item);
   });
 }

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -309,54 +309,52 @@ a:hover, a:focus { color: var(--sky); }
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: start;
-}
-
-.power-board--compact .power-board__list {
-  gap: 0.7rem;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
 .power-board__item {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  display: flex;
+  align-items: flex-start;
   gap: 0.75rem;
-  padding: 0.85rem 1rem 0.95rem;
+  padding: 0.55rem 0.75rem;
   border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
-    linear-gradient(140deg, rgba(17, 86, 214, 0.1), rgba(244, 181, 63, 0.08)),
-    color-mix(in srgb, rgba(255, 255, 255, 0.96) 70%, rgba(242, 246, 255, 0.92) 30%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 12px 24px rgba(11, 37, 69, 0.14);
-  align-items: start;
+    linear-gradient(120deg, rgba(17, 86, 214, 0.09), rgba(244, 181, 63, 0.07)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.96) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55), 0 10px 20px rgba(11, 37, 69, 0.12);
 }
 
-.power-board__rank {
-  display: inline-flex;
+.power-board__marker {
+  flex: 0 0 auto;
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.1rem;
-  height: 2.1rem;
-  border-radius: 0.65rem;
-  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.85));
-  color: #fff;
-  font-weight: 800;
-  font-size: 0.95rem;
-  box-shadow: 0 8px 14px rgba(17, 86, 214, 0.3);
+  padding-top: 0.15rem;
 }
 
 .power-board__content {
+  flex: 1 1 auto;
   display: grid;
-  gap: 0.3rem;
+  gap: 0.25rem;
 }
 
 .power-board__identity {
   display: inline-flex;
-  align-items: center;
-  gap: 0.55rem;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.power-board__rank {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-subtle);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 0;
+  min-width: 1.6rem;
 }
 
 .power-board__name {
@@ -374,10 +372,11 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .power-board__meta {
-  display: grid;
-  gap: 0.35rem;
-  align-content: start;
-  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  color: var(--text-subtle);
 }
 
 .power-board__tier {
@@ -398,20 +397,6 @@ a:hover, a:focus { color: var(--sky); }
 
 .power-board__stat {
   font-size: 0.76rem;
-  color: var(--text-subtle);
-}
-
-@media (min-width: 680px) {
-  .power-board__item {
-    grid-template-columns: auto minmax(0, 1fr) auto;
-    align-items: center;
-  }
-
-  .power-board__meta {
-    grid-column: auto;
-    justify-items: end;
-    text-align: right;
-  }
 }
 
 .power-board__placeholder {


### PR DESCRIPTION
## Summary
- convert the preseason power index grid into a single-column logo-bulleted list
- tighten the supporting styles to minimize vertical space while keeping rankings and metadata readable

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d87333c9b083278160470413f17fb1