### PR TITLE
Add landing charts and stabilize preseason tour cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,44 @@
           </div>
         </section>
 
+        <section class="league-visuals" id="league-visuals">
+          <div class="section-header">
+            <h2>League pulse in three charts</h2>
+            <p class="lead">
+              Track schedule volume, contender efficiency, and global player pipelines without leaving the landing hub.
+            </p>
+          </div>
+          <div class="viz-grid">
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Season cadence overview</header>
+              <div class="viz-canvas viz-canvas--flush">
+                <canvas data-chart="season-volume" aria-describedby="season-volume-caption"></canvas>
+              </div>
+              <figcaption id="season-volume-caption" class="viz-card__caption">
+                Monthly game counts show how preseason tune-ups give way to the 1,161-game regular season and December cup sprint.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Contender efficiency scatter</header>
+              <div class="viz-canvas viz-canvas--flush">
+                <canvas data-chart="team-efficiency" aria-describedby="team-efficiency-caption"></canvas>
+              </div>
+              <figcaption id="team-efficiency-caption" class="viz-card__caption">
+                Bubble size scales with win rate, helping you spot which top-12 franchises pair elite offense with stingy defense.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Global talent pipeline</header>
+              <div class="viz-canvas viz-canvas--flush">
+                <canvas data-chart="global-pipeline" aria-describedby="global-pipeline-caption"></canvas>
+              </div>
+              <figcaption id="global-pipeline-caption" class="viz-card__caption">
+                Horizontal bars rank the most prolific countries supplying active NBA players heading into the new season.
+              </figcaption>
+            </figure>
+          </div>
+        </section>
+
         <section class="story-verse" aria-labelledby="story-verse-title">
           <div class="section-header">
             <h2 id="story-verse-title">Narratives stitched from the data vault</h2>

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -316,13 +316,21 @@ function renderPreseasonTour(openersData) {
       grid.appendChild(placeholder);
     } else {
       games.forEach((game) => {
-        const card = document.createElement('a');
+        const hasPreview = Boolean(game?.gameId);
+        const card = document.createElement(hasPreview ? 'a' : 'article');
         card.className = 'tour-card';
-        card.href = `previews/preseason-${game.gameId}.html`;
-        card.setAttribute(
-          'aria-label',
-          `${game.teamName} ${game.homeAway === 'home' ? 'vs.' : '@'} ${game.opponentName} preseason opener preview`
-        );
+        const teamLabel = game.teamName ?? 'Preseason opener';
+        const opponentLabel = game.opponentName ?? 'TBD opponent';
+        const homeAway = game.homeAway === 'home' ? 'home' : game.homeAway === 'away' ? 'away' : null;
+        const matchupGlyph = homeAway === 'away' ? '@' : 'vs.';
+
+        if (hasPreview) {
+          card.href = `previews/preseason-${game.gameId}.html`;
+          card.setAttribute('aria-label', `${teamLabel} ${matchupGlyph} ${opponentLabel} preseason opener preview`);
+        } else {
+          card.setAttribute('aria-label', `${teamLabel} preseason opener details pending`);
+          card.setAttribute('role', 'group');
+        }
 
         const date = document.createElement('time');
         date.className = 'tour-card__date';
@@ -335,7 +343,6 @@ function renderPreseasonTour(openersData) {
 
         const identity = document.createElement('div');
         identity.className = 'tour-card__identity';
-        const teamLabel = game.teamName ?? 'Preseason opener';
         identity.appendChild(createTeamLogo(teamLabel, 'team-logo team-logo--medium'));
         const teamName = document.createElement('h3');
         teamName.className = 'tour-card__team';
@@ -349,7 +356,7 @@ function renderPreseasonTour(openersData) {
           opponent.className = 'tour-card__opponent';
           opponent.appendChild(createTeamLogo(game.opponentName, 'team-logo team-logo--tiny'));
           const opponentLabel = document.createElement('span');
-          opponentLabel.textContent = `${game.homeAway === 'home' ? 'vs.' : '@'} ${game.opponentName}`;
+          opponentLabel.textContent = `${matchupGlyph} ${game.opponentName}`;
           opponent.appendChild(opponentLabel);
           matchup.appendChild(opponent);
         } else {
@@ -358,7 +365,7 @@ function renderPreseasonTour(openersData) {
 
         const tag = document.createElement('span');
         tag.className = 'tour-card__tag';
-        tag.textContent = game.homeAway === 'home' ? 'Home start' : 'Road opener';
+        tag.textContent = homeAway === 'home' ? 'Home start' : homeAway === 'away' ? 'Road opener' : 'Tip-off pending';
 
         const venue = document.createElement('p');
         venue.className = 'tour-card__meta';
@@ -390,7 +397,7 @@ function renderPreseasonTour(openersData) {
             timeZoneName: 'short',
           }).format(updatedRaw)
         : 'recently';
-      footnote.textContent = `${total} preseason openers logged — data refreshed ${updated}. Tap any card to explore its placeholder preview.`;
+      footnote.textContent = `${total} preseason openers logged — data refreshed ${updated}. Tap any card to explore its preview capsule.`;
     } else {
       footnote.textContent = 'Preseason openers populate after the league locks each exhibition tip.';
     }


### PR DESCRIPTION
## Summary
- surface season volume, team efficiency, and global talent pipeline charts on the index page so the dashboards render on load
- harden preseason opener cards by avoiding broken preview links, handling missing matchup data, and tightening the footnote copy

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d8744599fc8327b1d6d5e4a1ad29ac