### PR TITLE
Reposition rest management radar on hub

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,19 @@
               <li class="power-board__placeholder">Power index syncing…</li>
             </ol>
           </article>
+          <article class="rest-radar-card season-snapshot__panel">
+            <header class="season-snapshot__header">
+              <h3>Rest management radar</h3>
+              <p>Who shoulders the toughest travel math before All-Star weekend.</p>
+            </header>
+            <ul class="rest-list" data-back-to-back-list>
+              <li class="rest-list__placeholder">Back-to-back intensity table incoming…</li>
+            </ul>
+            <p class="rest-list__footer">
+              League average rest: <span data-rest-average>3.0 days</span> across
+              <span data-rest-intervals>2,779</span> tracked windows.
+            </p>
+          </article>
         </div>
       </header>
 
@@ -54,39 +67,6 @@
               <p class="tour-board__placeholder">Preseason openers syncing…</p>
             </div>
             <p class="tour-board__footnote" data-tour-footnote></p>
-          </div>
-        </section>
-
-        <section class="season-snapshot" id="season-panorama">
-          <div class="section-header">
-            <h2>The 2025-26 board, already moving</h2>
-            <p class="lead" data-season-lead>
-              1,161 regular-season games, 446 zero-day rest intervals, and 67 Cup showdowns—every storyline has a lane.
-            </p>
-          </div>
-          <div class="season-snapshot__grid">
-            <article class="season-snapshot__panel season-snapshot__panel--wide">
-              <header class="season-snapshot__header">
-                <h3>Title race velocity</h3>
-                <p>Historical pace leaders power our contender tiers.</p>
-              </header>
-              <div class="contender-grid" data-contender-grid>
-                <p class="contender-grid__placeholder">Loading contender pulses…</p>
-              </div>
-            </article>
-            <article class="season-snapshot__panel">
-              <header class="season-snapshot__header">
-                <h3>Rest management radar</h3>
-                <p>Who shoulders the toughest travel math before All-Star weekend.</p>
-              </header>
-              <ul class="rest-list" data-back-to-back-list>
-                <li class="rest-list__placeholder">Back-to-back intensity table incoming…</li>
-              </ul>
-              <p class="rest-list__footer">
-                League average rest: <span data-rest-average>3.0 days</span> across
-                <span data-rest-intervals>2,779</span> tracked windows.
-              </p>
-            </article>
           </div>
         </section>
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -152,11 +152,21 @@ a:hover, a:focus { color: var(--sky); }
 
 .hero--power {
   padding: clamp(1.8rem, 5vw, 2.6rem) clamp(1rem, 4vw, 1.6rem) clamp(1.6rem, 4vw, 2.1rem);
-  display: flex;
-  justify-content: center;
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2rem);
+  align-items: stretch;
+  justify-items: stretch;
+  grid-template-columns: repeat(auto-fit, minmax(290px, 1fr));
 }
 .hero--power > * {
-  width: 100%;
+  min-width: 0;
+}
+.hero--power .power-board--compact {
+  margin-inline: 0;
+}
+
+.rest-radar-card {
+  position: relative;
 }
 .hero--rewind {
   position: relative;


### PR DESCRIPTION
## Summary
- move the rest management radar card into the hero beside the power index
- remove the former season snapshot board section and adjust hero layout to support the new arrangement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8756703888327952bbeb52a1fb7d0