### PR TITLE
Fix chart canvas resizing loop

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -2388,13 +2388,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   display: block;
   width: 100% !important;
   max-width: 100%;
-  height: auto !important;
+  height: auto;
 }
 .viz-card canvas {
   display: block;
   width: 100% !important;
   max-width: 100%;
-  height: auto !important;
+  height: auto;
   max-height: 100%;
 }
 .viz-placeholder {


### PR DESCRIPTION
## Summary
- allow Chart.js canvases to control their rendered height to prevent runaway growth

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d87dd4453c8327a02fba454b67f65b