### PR TITLE
Deduplicate preseason tour matchups on preview page

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -1108,9 +1108,18 @@ a.tour-board__link:hover {
 .tour-board__matchup {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.45rem;
   font-size: 0.88rem;
   color: color-mix(in srgb, var(--text-subtle) 85%, var(--text-strong) 15%);
+}
+
+.tour-board__matchup-divider {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-subtle) 65%, var(--text-strong) 35%);
 }
 
 .tour-board__opponent {


### PR DESCRIPTION
## Summary
- group preseason world tour entries by game so each matchup renders once with both teams
- update the tour card markup to show combined team chips and adjust tagging/accessibility labels
- tweak hub stylesheet with a matchup divider style that supports the new layout

## Testing
- Manual QA: Viewed http://127.0.0.1:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68d88048a7cc8327979dc4931bd1e325