### PR TITLE
Update about page with project overview and legal disclaimers

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -28,10 +28,12 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Inside the Hub</span>
-          <h1>How the preview engine is assembled and evolves.</h1>
+          <h1>The full story behind the NBA Intelligence Hub project.</h1>
           <p>
-            The About space documents the methodology, contributor workflow, and data pipelines that
-            power every 2025-26 graphic, projection, and narrative beat on the Intelligence Hub.
+            This space chronicles how the entire multi-page experience—from previews and history
+            deep dives to player dossiers and data tooling—came together. Every line of copy and
+            code across the project was created by Ryan Hicks with the assistance of OpenAI Codex,
+            and the About page now reflects the broader vision beyond a single-season preview.
           </p>
         </div>
       </header>
@@ -39,47 +41,47 @@
       <main>
         <section class="pillars">
           <div class="section-header">
-            <h2>How we built the preview narrative</h2>
+            <h2>How the project came together</h2>
             <p class="lead">
-              This isn’t a blog post dressed up in charts—it’s a multi-threaded story engine balancing
-              probability, personality, and spectacle so the 2025-26 canvas feels alive.
+              The Hub is a cohesive storytelling laboratory: part data pipeline, part design system,
+              and part long-form magazine. Below is the framework that keeps every page connected.
             </p>
           </div>
           <div class="pillars-grid">
             <article class="pillar-card">
-              <h3>Continuity index</h3>
+              <h3>Creative direction &amp; authorship</h3>
               <p>
-                Blending roster carryover, coaching stability, and playbook similarity to color each
-                contender’s storyline with confidence or chaos.
+                Ryan Hicks defined the tone, reporting cadence, and user journeys across the site,
+                using OpenAI Codex as a co-creator to draft copy, wrangle data, and prototype layouts.
               </p>
               <ul class="pillar-list">
-                <li>Weighted rotation minutes retained</li>
-                <li>Adjusted synergy from lineup data</li>
-                <li>Injury volatility flags</li>
+                <li>Unified editorial voice across previews, history, and insights</li>
+                <li>Codex-assisted iteration for narrative structures and polish</li>
+                <li>Single-author accountability for quality and accuracy</li>
               </ul>
             </article>
             <article class="pillar-card">
-              <h3>Momentum visual grammar</h3>
+              <h3>Technical architecture</h3>
               <p>
-                Shared motion cues and palette shifts highlight when a graphic moves from signal to
-                alarm, guiding the eye through the preview like a broadcast open.
+                A static-first build with modular HTML, CSS, and scripted data ingestion powers fast
+                loads and maintainable updates without heavyweight frameworks.
               </p>
               <ul class="pillar-list">
-                <li>Color-coded confidence bands</li>
-                <li>Radial burst win projections</li>
-                <li>Accessible caption hierarchy</li>
+                <li>Reusable component styling in <code>styles/</code></li>
+                <li>Dataset automation via Python notebooks and scripts</li>
+                <li>Accessible-by-default markup and semantic structure</li>
               </ul>
             </article>
             <article class="pillar-card">
-              <h3>Story beats toolkit</h3>
+              <h3>Research &amp; storytelling engine</h3>
               <p>
-                Reusable ledes, sidebars, and “if-this-then-that” callouts ensure each section reads
-                like a mini docuseries episode anchored in the data.
+                Season previews, historical retrospectives, player dossiers, and data experiments all
+                flow from a shared library of stats, league context, and scenario modeling.
               </p>
               <ul class="pillar-list">
-                <li>Cause-and-effect framing</li>
-                <li>Quote-ready stat nuggets</li>
-                <li>Future-cast scenario notes</li>
+                <li>Cross-era comparisons and trend analysis</li>
+                <li>Playstyle tagging for team and player pages</li>
+                <li>Scenario planners linking insights to future updates</li>
               </ul>
             </article>
           </div>
@@ -90,7 +92,7 @@
             <h2>Legacy currents powering the next chapter</h2>
             <p class="lead">
               Career benchmarks from LeBron to Stockton frame how we evaluate the next wave of box-score
-              disruptors and clutch playmakers.
+              disruptors and clutch playmakers across every section of the Hub—not just the preview.
             </p>
           </div>
           <div class="legacy-currents__grid">
@@ -182,14 +184,14 @@
           <div class="insight-preview__content">
             <h2>How the story flows from data to drama</h2>
             <p class="lead">
-              We choreographed the preview like a broadcast segment: open with table-setting visuals,
-              drill into context clips, then leave you with decisive next steps for every franchise.
+              The Intelligence Hub runs on a repeatable workflow: establish the league pulse, layer in
+              archival perspective, then surface actionable insights for fans, analysts, and creators.
             </p>
             <ol class="insight-steps">
               <li>
                 <strong>Scan the league pulse.</strong>
-                Our dashboards surface roster churn, preseason chemistry grades, and evolving game plans
-                in real time.
+                Dashboards surface roster churn, chemistry grades, and evolving game plans across the
+                regular season and historical archives.
               </li>
               <li>
                 <strong>Deep-dive context.</strong>
@@ -216,16 +218,16 @@
         </section>
 
         <section>
-          <h2>Stay locked on the preview beat</h2>
+          <h2>Stay locked on the Hub</h2>
           <div class="card-grid">
             <article class="card">
               <h3>Release notes</h3>
-              <p>Track weekly drop-ins as training camp intel and preseason tape reshape the outlook.</p>
+              <p>Track weekly drop-ins as new scripts, datasets, and story packages roll out across the Hub.</p>
               <a href="insights.html">Follow the changelog →</a>
             </article>
             <article class="card">
               <h3>Contributor guide</h3>
-              <p>Help us refine projections, annotate film clips, or craft alternate futures for key teams.</p>
+              <p>Help refine projections, annotate film clips, or craft alternate futures for key teams and eras.</p>
               <a href="https://github.com/" target="_blank" rel="noreferrer">Join the project workspace →</a>
             </article>
             <article class="card">
@@ -235,9 +237,63 @@
             </article>
           </div>
         </section>
+
+        <section class="pillars">
+          <div class="section-header">
+            <h2>Legal, attribution, and respect for the game</h2>
+            <p class="lead">
+              This project is a fan-made, educational showcase. It exists to celebrate basketball
+              storytelling—not to infringe on the rights of the NBA, its teams, or its players.
+            </p>
+          </div>
+          <div class="pillars-grid">
+            <article class="pillar-card">
+              <h3>Trademark acknowledgements</h3>
+              <p>
+                All NBA logos, team names, player likenesses, and league marks referenced or displayed
+                here remain the exclusive property of the National Basketball Association and its
+                respective teams. Their appearance is purely for identification and commentary.
+              </p>
+              <ul class="pillar-list">
+                <li>No sponsorship, endorsement, or partnership is implied</li>
+                <li>Usage is intended under nominative fair use and educational commentary</li>
+                <li>Requests for removal will be honored promptly upon verified notice</li>
+              </ul>
+            </article>
+            <article class="pillar-card">
+              <h3>Content purpose &amp; limitations</h3>
+              <p>
+                The Hub provides informational analysis, creative storytelling, and fan perspectives.
+                It is not an official NBA product, betting service, or commercial enterprise.
+              </p>
+              <ul class="pillar-list">
+                <li>Materials are offered “as-is” without warranties, express or implied</li>
+                <li>No challenge to any intellectual property rights is intended</li>
+                <li>Contact <a href="mailto:hello@ryanhicks.co">hello@ryanhicks.co</a> for inquiries</li>
+              </ul>
+            </article>
+            <article class="pillar-card">
+              <h3>Good-faith collaboration</h3>
+              <p>
+                Ryan Hicks and Codex-assisted contributors are committed to honoring takedown requests,
+                crediting primary data sources, and keeping the tone respectful of the league.
+              </p>
+              <ul class="pillar-list">
+                <li>Primary data sourced from publicly available league reports and research</li>
+                <li>Non-commercial distribution with clear attribution</li>
+                <li>Rapid compliance with any rights-holder guidance or notices</li>
+              </ul>
+            </article>
+          </div>
+          <p class="lead" style="margin-top: 2rem; text-align: center;">
+            By viewing or interacting with this site you acknowledge that it is an independent fan
+            publication and agree not to misrepresent it as an official NBA property. Thanks for
+            letting us obsess over basketball lore in peace.
+          </p>
+        </section>
       </main>
 
-      <footer class="page-footer">Built for the modern NBA era — expanding with every new story.</footer>
+      <footer class="page-footer">Fan-made by Ryan Hicks with OpenAI Codex — celebrating the NBA while respecting its legends and legal guardians.</footer>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the About page hero and project description to cover the entire NBA Intelligence Hub experience
- credit Ryan Hicks and OpenAI Codex for authorship and add details on the site-wide architecture and workflow
- add a comprehensive legal and attribution section clarifying the fan-made nature of the project and respect for NBA trademarks

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8822fdf0c832784b920f5c7e145cb