### PR TITLE
Streamline About page content

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -28,216 +28,15 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Inside the Hub</span>
-          <h1>The full story behind the NBA Intelligence Hub project.</h1>
+          <h1>How the NBA Intelligence Hub was built.</h1>
           <p>
-            This space chronicles how the entire multi-page experience—from previews and history
-            deep dives to player dossiers and data tooling—came together. Every line of copy and
-            code across the project was created by Ryan Hicks with the assistance of OpenAI Codex,
-            and the About page now reflects the broader vision beyond a single-season preview.
+            A concise walkthrough of the collaborators, responsibilities, and guardrails that keep
+            this fan-made project focused.
           </p>
         </div>
       </header>
 
       <main>
-        <section class="pillars">
-          <div class="section-header">
-            <h2>How the project came together</h2>
-            <p class="lead">
-              The Hub is a cohesive storytelling laboratory: part data pipeline, part design system,
-              and part long-form magazine. Below is the framework that keeps every page connected.
-            </p>
-          </div>
-          <div class="pillars-grid">
-            <article class="pillar-card">
-              <h3>Creative direction &amp; authorship</h3>
-              <p>
-                Ryan Hicks defined the tone, reporting cadence, and user journeys across the site,
-                using OpenAI Codex as a co-creator to draft copy, wrangle data, and prototype layouts.
-              </p>
-              <ul class="pillar-list">
-                <li>Unified editorial voice across previews, history, and insights</li>
-                <li>Codex-assisted iteration for narrative structures and polish</li>
-                <li>Single-author accountability for quality and accuracy</li>
-              </ul>
-            </article>
-            <article class="pillar-card">
-              <h3>Technical architecture</h3>
-              <p>
-                A static-first build with modular HTML, CSS, and scripted data ingestion powers fast
-                loads and maintainable updates without heavyweight frameworks.
-              </p>
-              <ul class="pillar-list">
-                <li>Reusable component styling in <code>styles/</code></li>
-                <li>Dataset automation via Python notebooks and scripts</li>
-                <li>Accessible-by-default markup and semantic structure</li>
-              </ul>
-            </article>
-            <article class="pillar-card">
-              <h3>Research &amp; storytelling engine</h3>
-              <p>
-                Season previews, historical retrospectives, player dossiers, and data experiments all
-                flow from a shared library of stats, league context, and scenario modeling.
-              </p>
-              <ul class="pillar-list">
-                <li>Cross-era comparisons and trend analysis</li>
-                <li>Playstyle tagging for team and player pages</li>
-                <li>Scenario planners linking insights to future updates</li>
-              </ul>
-            </article>
-          </div>
-        </section>
-
-        <section class="legacy-currents">
-          <div class="section-header">
-            <h2>Legacy currents powering the next chapter</h2>
-            <p class="lead">
-              Career benchmarks from LeBron to Stockton frame how we evaluate the next wave of box-score
-              disruptors and clutch playmakers across every section of the Hub—not just the preview.
-            </p>
-          </div>
-          <div class="legacy-currents__grid">
-            <article class="legacy-card">
-              <div class="legacy-card__header">
-                <span class="legacy-card__tag">Scoring vault</span>
-                <h3>Career arcs we monitor</h3>
-                <p class="legacy-card__summary">
-                  Historical splits from the league’s elite scorers provide baselines for predicting
-                  how current stars will age into 2025-26 roles.
-                </p>
-              </div>
-              <ul class="legacy-card__list">
-                <li class="legacy-card__list-item">
-                  <strong>Kareem Abdul-Jabbar</strong>
-                  <span>38,387 points • 24.6 per game</span>
-                  <span>1970–1989 • Bucks, Lakers</span>
-                </li>
-                <li class="legacy-card__list-item">
-                  <strong>Karl Malone</strong>
-                  <span>36,928 points • 25.0 per game</span>
-                  <span>1986–2004 • Jazz, Lakers</span>
-                </li>
-                <li class="legacy-card__list-item">
-                  <strong>LeBron James</strong>
-                  <span>40,474 points • 27.1 per game</span>
-                  <span>2003–present • Cavaliers, Heat, Lakers</span>
-                </li>
-              </ul>
-            </article>
-            <article class="legacy-card">
-              <div class="legacy-card__header">
-                <span class="legacy-card__tag">Playmaking lineage</span>
-                <h3>Passing benchmarks</h3>
-                <p class="legacy-card__summary">
-                  Assist trails from legends inform the thresholds baked into Tyrese Haliburton and
-                  Luka Dončić projections for the upcoming season.
-                </p>
-              </div>
-              <ul class="legacy-card__list">
-                <li class="legacy-card__list-item">
-                  <strong>John Stockton</strong>
-                  <span>15,806 assists • 10.5 per game</span>
-                  <span>1984–2003 • Utah Jazz</span>
-                </li>
-                <li class="legacy-card__list-item">
-                  <strong>Chris Paul</strong>
-                  <span>11,899 assists • 9.5 per game</span>
-                  <span>2005–present • Hornets, Clippers, Rockets, Thunder, Suns, Warriors, Spurs</span>
-                </li>
-                <li class="legacy-card__list-item">
-                  <strong>Jason Kidd</strong>
-                  <span>12,091 assists • 8.7 per game</span>
-                  <span>1994–2013 • Mavericks, Suns, Nets, Knicks</span>
-                </li>
-              </ul>
-            </article>
-            <article class="legacy-card">
-              <div class="legacy-card__header">
-                <span class="legacy-card__tag">Glass dynasty</span>
-                <h3>Rebounding standards</h3>
-                <p class="legacy-card__summary">
-                  Rebound percentage models lean on this archive to project which modern bigs can anchor
-                  transition defense while sparking breakouts.
-                </p>
-              </div>
-              <ul class="legacy-card__list">
-                <li class="legacy-card__list-item">
-                  <strong>Wilt Chamberlain</strong>
-                  <span>23,924 rebounds • 22.9 per game</span>
-                  <span>1959–1973 • Warriors, 76ers, Lakers</span>
-                </li>
-                <li class="legacy-card__list-item">
-                  <strong>Bill Russell</strong>
-                  <span>21,620 rebounds • 22.5 per game</span>
-                  <span>1956–1969 • Boston Celtics</span>
-                </li>
-                <li class="legacy-card__list-item">
-                  <strong>Tim Duncan</strong>
-                  <span>15,091 rebounds • 11.0 per game</span>
-                  <span>1997–2016 • San Antonio Spurs</span>
-                </li>
-              </ul>
-            </article>
-          </div>
-        </section>
-
-        <section class="insight-preview">
-          <div class="insight-preview__content">
-            <h2>How the story flows from data to drama</h2>
-            <p class="lead">
-              The Intelligence Hub runs on a repeatable workflow: establish the league pulse, layer in
-              archival perspective, then surface actionable insights for fans, analysts, and creators.
-            </p>
-            <ol class="insight-steps">
-              <li>
-                <strong>Scan the league pulse.</strong>
-                Dashboards surface roster churn, chemistry grades, and evolving game plans across the
-                regular season and historical archives.
-              </li>
-              <li>
-                <strong>Deep-dive context.</strong>
-                History archives and Insights Lab experiments layer precedent, comps, and film study
-                nuggets right beside the metrics.
-              </li>
-              <li>
-                <strong>Decide and share.</strong>
-                Export season scenarios, send callouts to collaborators, or embed charts into your
-                preview show rundown.
-              </li>
-            </ol>
-            <a class="cta cta--inline" href="insights.html">See the latest experiments →</a>
-          </div>
-          <aside class="insight-preview__panel" aria-label="Platform coverage">
-            <h3>Coverage for 2025-26</h3>
-            <ul class="coverage-list">
-              <li><span>Live roster &amp; contract tracking</span> <strong>Daily refresh</strong></li>
-              <li><span>Momentum-based offensive &amp; defensive ratings</span> <strong>Rolling 10-game windows</strong></li>
-              <li><span>Prospect runway database</span> <strong>Global leagues + NCAA</strong></li>
-              <li><span>Award race probability tracker</span> <strong>Updated weekly</strong></li>
-            </ul>
-          </aside>
-        </section>
-
-        <section>
-          <h2>Stay locked on the Hub</h2>
-          <div class="card-grid">
-            <article class="card">
-              <h3>Release notes</h3>
-              <p>Track weekly drop-ins as new scripts, datasets, and story packages roll out across the Hub.</p>
-              <a href="insights.html">Follow the changelog →</a>
-            </article>
-            <article class="card">
-              <h3>Contributor guide</h3>
-              <p>Help refine projections, annotate film clips, or craft alternate futures for key teams and eras.</p>
-              <a href="https://github.com/" target="_blank" rel="noreferrer">Join the project workspace →</a>
-            </article>
-            <article class="card">
-              <h3>Data pipelines</h3>
-              <p>See how we sync wearable data, synergy reports, and league APIs into one storytelling stack.</p>
-              <a href="scripts/README.html">View ingestion details →</a>
-            </article>
-          </div>
-        </section>
-
         <section class="pillars">
           <div class="section-header">
             <h2>Legal, attribution, and respect for the game</h2>
@@ -290,6 +89,54 @@
             publication and agree not to misrepresent it as an official NBA property. Thanks for
             letting us obsess over basketball lore in peace.
           </p>
+        </section>
+
+        <section class="pillars">
+          <div class="section-header">
+            <h2>How the project came together</h2>
+            <p class="lead">
+              The Hub is a cohesive storytelling laboratory: part data pipeline, part design system,
+              and part long-form magazine. Below is the framework that keeps every page connected.
+            </p>
+          </div>
+          <div class="pillars-grid">
+            <article class="pillar-card">
+              <h3>Creative direction &amp; authorship</h3>
+              <p>
+                Ryan Hicks defined the tone, reporting cadence, and user journeys across the site,
+                using OpenAI Codex as a co-creator to draft copy, wrangle data, and prototype layouts.
+              </p>
+              <ul class="pillar-list">
+                <li>Unified editorial voice across previews, history, and insights</li>
+                <li>Codex-assisted iteration for narrative structures and polish</li>
+                <li>Single-author accountability for quality and accuracy</li>
+              </ul>
+            </article>
+            <article class="pillar-card">
+              <h3>Technical architecture</h3>
+              <p>
+                A static-first build with modular HTML, CSS, and scripted data ingestion powers fast
+                loads and maintainable updates without heavyweight frameworks.
+              </p>
+              <ul class="pillar-list">
+                <li>Reusable component styling in <code>styles/</code></li>
+                <li>Dataset automation via Python notebooks and scripts</li>
+                <li>Accessible-by-default markup and semantic structure</li>
+              </ul>
+            </article>
+            <article class="pillar-card">
+              <h3>Research &amp; storytelling engine</h3>
+              <p>
+                Season previews, historical retrospectives, player dossiers, and data experiments all
+                flow from a shared library of stats, league context, and scenario modeling.
+              </p>
+              <ul class="pillar-list">
+                <li>Cross-era comparisons and trend analysis</li>
+                <li>Playstyle tagging for team and player pages</li>
+                <li>Scenario planners linking insights to future updates</li>
+              </ul>
+            </article>
+          </div>
         </section>
       </main>
 


### PR DESCRIPTION
## Summary
- tighten the About page hero copy so the banner feels more concise and balanced
- remove legacy, workflow, and hub engagement sections to focus the page on legal and project foundations
- move the legal and attribution guidance above the project overview for faster clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8875b0f7083278f477ee33edbe43b