### PR TITLE
Tighten about page hero spacing

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -26,7 +26,7 @@
             <a class="active" href="about.html">About</a>
           </nav>
         </div>
-        <div class="hero">
+        <div class="hero hero--about">
           <span class="eyebrow">Inside the Hub</span>
           <h1>How the NBA Intelligence Hub was built.</h1>
           <p>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -554,6 +554,20 @@ a:hover, a:focus { color: var(--sky); }
   gap: clamp(2rem, 4vw, 3rem);
 }
 
+.hero--about {
+  padding: clamp(2rem, 5vw, 2.8rem) 0 clamp(1.8rem, 4vw, 2.4rem);
+  gap: clamp(1.4rem, 3.5vw, 2.2rem);
+}
+
+.hero--about h1 {
+  margin-top: 0.35rem;
+  line-height: 1.18;
+}
+
+.hero--about p {
+  margin-top: 0.2rem;
+}
+
 .hero--power {
   padding: clamp(1.8rem, 5vw, 2.6rem) clamp(1rem, 4vw, 1.6rem) clamp(1.6rem, 4vw, 2.1rem);
   display: flex;


### PR DESCRIPTION
## Summary
- reduce the about page hero padding and gap to eliminate excess vertical whitespace
- tweak the hero heading and paragraph spacing for a tighter banner presentation

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d8883f9bb883278bb4f08c656557c8