### PR TITLE
Streamline rewind page layout

### DIFF
--- a/public/rewind.html
+++ b/public/rewind.html
@@ -127,7 +127,7 @@
             </li>
           </ul>
           <div class="season-snapshot__grid">
-            <article class="season-snapshot__panel season-snapshot__panel--wide" data-chart-wrapper>
+            <article class="season-snapshot__panel" data-chart-wrapper>
               <header class="season-snapshot__header">
                 <h3>Schedule tempo tracker</h3>
                 <p>Monthly game volume across the 2024-25 slate.</p>
@@ -163,77 +163,6 @@
                 Zero-rest swings accounted for <span data-stat-zero-share>—</span>% of tracked intervals.
               </p>
             </article>
-            <article class="season-snapshot__panel">
-              <header class="season-snapshot__header">
-                <h3>Signature moments</h3>
-                <p>Global showcases and postseason pivots that defined the rewind.</p>
-              </header>
-              <ol class="timeline" data-special-games>
-                <li class="timeline__placeholder">Loading league touchpoints…</li>
-              </ol>
-            </article>
-          </div>
-        </section>
-
-        <section class="grid-two">
-          <div class="subsection">
-            <h2>Load management watch</h2>
-            <p>
-              Schedule modeling flagged <span data-stat-marathon-teams>—</span> teams with 95+ total games, led by
-              <span data-stat-max-games-team>—</span> charting <span data-stat-max-games>—</span>. The heaviest
-              back-to-back burden hit <span data-stat-b2b-leader-count>—</span> for <span data-stat-b2b-leader-team>—</span>,
-              shaping rest strategies ahead of the 2025-26 build.
-            </p>
-            <ul class="badge-list">
-              <li class="badge">Longest road swing: <span data-stat-longest-road>—</span></li>
-              <li class="badge">Longest home stand: <span data-stat-longest-home>—</span></li>
-              <li class="badge">Zero-rest share: <span data-stat-zero-share>—</span>% of intervals</li>
-            </ul>
-          </div>
-          <figure class="viz-card viz-card--inline viz-card--rewind" data-chart-wrapper>
-            <header class="viz-card__title">Top back-to-back loads</header>
-            <div class="viz-canvas">
-              <canvas data-chart="back-to-back-loads" aria-describedby="back-to-back-caption"></canvas>
-            </div>
-            <figcaption id="back-to-back-caption" class="viz-card__caption">
-              Bars rank the busiest back-to-back schedules in 2024-25, surfacing which contenders needed the most
-              load-balancing support.
-            </figcaption>
-          </figure>
-        </section>
-
-        <section>
-          <h2>How 2024-25 informs the next build</h2>
-          <p class="lead">
-            The rewind isn't just nostalgia—it's a blueprint. Use these takeaways to align scouting,
-            analytics, and creative storytelling for the preview cycle.
-          </p>
-          <div class="summary-cards">
-            <article class="summary-card summary-card--rewind">
-              <strong>Switchability surged</strong>
-              <p>
-                Lineups with three-plus switchable defenders posted a +4.6 aggregate net rating,
-                encouraging front offices to prioritize rangy wings and hybrid bigs in 2025-26 roster
-                shaping.
-              </p>
-              <a href="teams.html">Compare defensive blueprints →</a>
-            </article>
-            <article class="summary-card summary-card--rewind">
-              <strong>Half-court maestros</strong>
-              <p>
-                Top pick-and-roll duos averaged 1.12 points per direct possession, underscoring the
-                value of pace control and late-clock creators when possessions slow.
-              </p>
-              <a href="players.html">Dive into player metrics →</a>
-            </article>
-            <article class="summary-card summary-card--rewind">
-              <strong>In-season tournament impact</strong>
-              <p>
-                Cup pool intensity prepared rising teams for playoff atmospheres, with four of eight
-                quarterfinalists advancing to second-round series in May.
-              </p>
-              <a href="history.html">Track evolving formats →</a>
-            </article>
           </div>
         </section>
 
@@ -264,30 +193,7 @@
           </figure>
         </section>
 
-        <section>
-          <h2>What comes next</h2>
-          <p class="lead">
-            Feed these rewind modules into your 2025-26 preview workflow to highlight continuity,
-            spotlight reinforcements, and surface potential regression markers.
-          </p>
-          <div class="card-grid">
-            <article class="card card--rewind">
-              <h3>Continuity index</h3>
-              <p>Track returning minute shares to gauge which teams bank on chemistry.</p>
-            </article>
-            <article class="card card--rewind">
-              <h3>Skill progression reels</h3>
-              <p>Transform rewind clips into development reels for internal scouting and marketing.</p>
-            </article>
-            <article class="card card--rewind">
-              <h3>Regression watchlist</h3>
-              <p>Flag shooting spikes or clutch outliers primed for correction.</p>
-            </article>
-          </div>
-        </section>
       </main>
-
-      <footer class="page-footer">History loops forward—rewind insights fuel the preview engine.</footer>
     </div>
     <script src="vendor/chart.umd.js" defer></script>
     <script type="module" src="scripts/rewind.js"></script>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -549,9 +549,9 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .hero {
-  padding: clamp(2.6rem, 6vw, 3.6rem) 0 2.75rem;
+  padding: clamp(2.3rem, 5.5vw, 3.3rem) 0 2.25rem;
   display: grid;
-  gap: clamp(2rem, 4vw, 3rem);
+  gap: clamp(1.75rem, 3.8vw, 2.7rem);
 }
 
 .hero--about {
@@ -579,7 +579,7 @@ a:hover, a:focus { color: var(--sky); }
 .hero--rewind {
   position: relative;
   overflow: hidden;
-  padding: clamp(2.8rem, 6vw, 3.8rem) clamp(1.4rem, 5vw, 2.8rem) clamp(2.6rem, 5vw, 3.4rem);
+  padding: clamp(2.5rem, 5.5vw, 3.5rem) clamp(1.2rem, 4.8vw, 2.4rem) clamp(2.1rem, 4.6vw, 2.8rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
   background:
@@ -853,15 +853,15 @@ a:hover, a:focus { color: var(--sky); }
 .hero-metrics dd { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
 
 .hero-panels {
-  margin: 2.4rem auto 0;
+  margin: 2rem auto 0;
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   max-width: 960px;
 }
 .hero-panels--rewind {
   width: 100%;
-  padding: 1.1rem;
+  padding: 0.9rem;
   border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background: color-mix(in srgb, rgba(255, 255, 255, 0.86) 70%, rgba(17, 86, 214, 0.08) 30%);
@@ -1013,11 +1013,11 @@ a:hover, a:focus { color: var(--sky); }
   }
 }
 
-main { display: grid; gap: 2.25rem; }
+main { display: grid; gap: 1.75rem; }
 
 section {
   background: var(--surface); border-radius: var(--radius-lg);
-  padding: 1.75rem clamp(1.5rem, 4vw, 2.5rem); box-shadow: var(--shadow-soft); border: 1px solid var(--border);
+  padding: 1.4rem clamp(1.25rem, 3.5vw, 2.1rem); box-shadow: var(--shadow-soft); border: 1px solid var(--border);
 }
 
 .spotlight-itinerary {
@@ -1371,15 +1371,15 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 .season-snapshot__grid {
   display: grid;
-  gap: 1.5rem;
+  gap: 1.35rem;
 }
 
 .stat-callouts {
   list-style: none;
-  margin: 1.5rem 0 0;
+  margin: 1.2rem 0 0;
   padding: 0;
   display: grid;
-  gap: 1rem;
+  gap: 0.85rem;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 }
 
@@ -1415,8 +1415,8 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .season-snapshot__panel {
   position: relative;
   display: grid;
-  gap: 1rem;
-  padding: 1.5rem 1.6rem;
+  gap: 0.85rem;
+  padding: 1.35rem 1.45rem;
   border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
   background:
@@ -1433,8 +1433,6 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   background: radial-gradient(circle at center, rgba(244, 181, 63, 0.25), transparent 65%);
   opacity: 0.75;
 }
-
-.season-snapshot__panel--wide::after { inset: auto -18% -35% 45%; }
 
 .season-snapshot__header h3 {
   margin: 0;
@@ -1464,7 +1462,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 .rest-overview {
   display: grid;
-  gap: 1.2rem;
+  gap: 1rem;
 }
 
 .rest-overview__chart {
@@ -1792,8 +1790,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .legacy-card__list-item span { color: var(--text-subtle); font-size: 0.85rem; }
 
 @media (min-width: 960px) {
-  .season-snapshot__grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .season-snapshot__panel--wide { grid-column: span 2; }
+  .season-snapshot__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (min-width: 720px) {
@@ -1838,7 +1835,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .coverage-list strong { font-size: 0.9rem; color: var(--navy); }
 
-.grid-two { display: grid; gap: 2rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.grid-two { display: grid; gap: 1.6rem; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
 
 .subsection { display: grid; gap: 1rem; }
 .subsection h3 { margin: 0; font-size: 1.1rem; color: var(--navy); }


### PR DESCRIPTION
## Summary
- remove unused rewind sections so the page focuses on the core recap and production leaders modules
- tighten hero, section, and grid spacing for a denser presentation across the rewind layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8899da7f48327969dc8e411c1279d