### PR TITLE
Refactor players page with immersive visual lab

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -28,82 +28,156 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Player Intelligence</span>
-          <h1>Profiles, performance curves, and signature skill maps.</h1>
+          <h1>Build the NBA's most immersive player observatory.</h1>
           <p>
-            This space will evolve into a searchable atlas of every athlete in the league. Plan the
-            next wave of scouting visuals, from archetype clustering to shot quality heatmaps.
+            Welcome to the lab where biometrics, geography, and legendary performances collide.
+            Each panel below pulls from the repository's player archives and refracts them into
+            visual stories you won't find on the corporate dashboards.
           </p>
         </div>
       </header>
 
-      <main>
-        <section>
-          <h2>Player archetype explorer</h2>
-          <p class="lead">
-            Build interactive scatter plots and radar profiles that let decision makers compare
-            players across roles, pace contexts, and matchup styles.
-          </p>
-          <div class="grid-two">
+      <main class="players-lab">
+        <section class="players-lab__section">
+          <header class="players-lab__section-header">
+            <h2>Morphology lab</h2>
+            <p class="players-lab__lede">
+              Track how body types and roles stretch across eras — from the tallest towers ever
+              logged to the shape of today's positionless rotations.
+            </p>
+          </header>
+          <div class="players-lab__grid viz-grid">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">League height distribution</header>
               <div class="viz-canvas">
-                <canvas data-chart="player-heights" aria-describedby="player-heights-caption"></canvas>
+                <canvas data-chart="league-heights" aria-describedby="league-heights-caption"></canvas>
               </div>
-              <figcaption id="player-heights-caption" class="viz-card__caption">
-                A smoothed density curve of roster heights keeps archetype filters responsive while
-                honoring Phase 2 performance budgets.
+              <figcaption id="league-heights-caption" class="viz-card__caption">
+                Density curve of roster heights sourced from <code>Players.csv</code> buckets — a quick
+                way to spot outlier size archetypes.
               </figcaption>
             </figure>
-            <div class="subsection">
-              <h3>Key ingredients</h3>
-              <div class="badge-list">
-                <span class="badge">Play style vectors</span>
-                <span class="badge">Versatility index</span>
-                <span class="badge">Biomechanics data</span>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Skyline mass bubbles</header>
+              <div class="viz-canvas">
+                <canvas data-chart="tallest-bubbles" aria-describedby="tallest-bubbles-caption"></canvas>
               </div>
-              <p>
-                Import player traits from <code>Players.csv</code> and blend with tracking metrics to
-                categorize emerging roles. Future widgets will allow filtering by age, contract
-                status, and playoff sample size.
-              </p>
-            </div>
+              <figcaption id="tallest-bubbles-caption" class="viz-card__caption">
+                Bubble chart of the league's tallest players — bubble size mirrors listed weight to
+                show which giants carried the most mass.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Role orbit share</header>
+              <div class="viz-canvas">
+                <canvas data-chart="position-orbits" aria-describedby="position-orbits-caption"></canvas>
+              </div>
+              <figcaption id="position-orbits-caption" class="viz-card__caption">
+                Guards, forwards, and centers plotted as a radial orbit to highlight the balance of
+                skill sets across all recorded players.
+              </figcaption>
+            </figure>
           </div>
         </section>
 
-        <section>
-          <h2>Game impact timelines</h2>
-          <div class="grid-two">
-            <div class="subsection">
-              <h3>Season arcs</h3>
-              <p>
-                Plan for cumulative win probability charts and health status overlays. Give front
-                offices tools to spot breakout windows or manage workloads over 82 games.
-              </p>
-            </div>
+        <section class="players-lab__section">
+          <header class="players-lab__section-header">
+            <h2>Global &amp; collegiate pipelines</h2>
+            <p class="players-lab__lede">
+              Follow the journeys that feed the league — from international launch pads to the
+              college programs producing the deepest alumni pools.
+            </p>
+          </header>
+          <div class="players-lab__grid viz-grid">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Draft pipeline cadence</header>
+              <header class="viz-card__title">Global talent spectrum</header>
+              <div class="viz-canvas">
+                <canvas data-chart="country-spectrum" aria-describedby="country-spectrum-caption"></canvas>
+              </div>
+              <figcaption id="country-spectrum-caption" class="viz-card__caption">
+                Polar area bloom of the top international contributors — each petal encodes how many
+                pros hail from that nation.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">College pipeline power grid</header>
+              <div class="viz-canvas">
+                <canvas data-chart="college-pipeline" aria-describedby="college-pipeline-caption"></canvas>
+              </div>
+              <figcaption id="college-pipeline-caption" class="viz-card__caption">
+                Horizontal bar ranks for the collegiate programs that have launched the most NBA
+                talent.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Draft cadence stream</header>
               <div class="viz-canvas">
                 <canvas data-chart="draft-timeline" aria-describedby="draft-timeline-caption"></canvas>
               </div>
               <figcaption id="draft-timeline-caption" class="viz-card__caption">
-                Decade-level draft totals are sampled evenly to highlight momentum without shipping
-                the full historical series.
+                Smoothed line of draft counts by decade — a pulse check on how the pipeline has
+                swollen and contracted over time.
               </figcaption>
             </figure>
           </div>
-          <div class="card-grid">
-            <article class="card">
-              <h3>Career compendium</h3>
-              <p>Use dynamic filters to surface comparable players based on advanced metrics.</p>
-            </article>
-            <article class="card">
-              <h3>Scouting briefs</h3>
-              <p>Create one-page exports combining film notes, lineup fits, and biometric flags.</p>
-            </article>
-            <article class="card">
-              <h3>Player availability</h3>
-              <p>Integrate schedule density and travel strain models to project rest nights.</p>
-            </article>
+        </section>
+
+        <section class="players-lab__section">
+          <header class="players-lab__section-header">
+            <h2>Momentum &amp; mythology</h2>
+            <p class="players-lab__lede">
+              Dive into production rhythms, legendary streaks, and single-game supernovas that define
+              the lore of NBA players.
+            </p>
+          </header>
+          <div class="players-lab__grid viz-grid">
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Scoring era waveform</header>
+              <div class="viz-canvas">
+                <canvas data-chart="season-trends" aria-describedby="season-trends-caption"></canvas>
+              </div>
+              <figcaption id="season-trends-caption" class="viz-card__caption">
+                Multi-line stream of league-wide scoring, assisting, and rebounding averages from
+                1946 onward.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Triple-double nebula</header>
+              <div class="viz-canvas">
+                <canvas data-chart="triple-double-cloud" aria-describedby="triple-double-cloud-caption"></canvas>
+              </div>
+              <figcaption id="triple-double-cloud-caption" class="viz-card__caption">
+                Bubble timeline of career triple-double totals — bubble radius scales with how many
+                seasons featured the feat.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Scoring supernovas</header>
+              <div class="viz-canvas">
+                <canvas data-chart="scoring-eruptions" aria-describedby="scoring-eruptions-caption"></canvas>
+              </div>
+              <figcaption id="scoring-eruptions-caption" class="viz-card__caption">
+                Scatter of the biggest single-game point totals — hover to see rebounds, assists, and
+                the minute loads required.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Pantheon production radar</header>
+              <div class="viz-canvas">
+                <canvas data-chart="career-constellation" aria-describedby="career-constellation-caption"></canvas>
+              </div>
+              <figcaption id="career-constellation-caption" class="viz-card__caption">
+                Radar comparison for the top career scorers — normalized blend of points, assists,
+                rebounds, and win percentage.
+              </figcaption>
+            </figure>
           </div>
         </section>
       </main>

--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -2,13 +2,35 @@ import { registerCharts, helpers } from './hub-charts.js';
 
 const palette = {
   royal: '#1156d6',
-  sky: 'rgba(31, 123, 255, 0.75)',
+  sky: '#1f7bff',
   gold: '#f4b53f',
+  coral: '#ef3d5b',
+  teal: '#11b5c6',
+  violet: '#6c4fe0',
+  lime: '#8fd43d',
+  navy: '#0b2545',
 };
+
+const accents = [palette.royal, palette.gold, palette.coral, palette.violet, palette.teal, '#9050d8', palette.sky, '#f48fb1'];
+
+function createVerticalGradient(context, stops) {
+  const { chart } = context;
+  const { ctx, chartArea } = chart || {};
+  if (!ctx || !chartArea) {
+    return stops?.[0] ?? palette.sky;
+  }
+  const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+  const colorStops = Array.isArray(stops) && stops.length ? stops : [palette.sky, 'rgba(31, 123, 255, 0.05)'];
+  const step = 1 / Math.max(colorStops.length - 1, 1);
+  colorStops.forEach((color, index) => {
+    gradient.addColorStop(Math.min(index * step, 1), color);
+  });
+  return gradient;
+}
 
 registerCharts([
   {
-    element: document.querySelector('[data-chart="player-heights"]'),
+    element: document.querySelector('[data-chart="league-heights"]'),
     source: 'data/players_overview.json',
     async createConfig(data) {
       const buckets = Array.isArray(data?.heightBuckets) ? data.heightBuckets : [];
@@ -26,15 +48,17 @@ registerCharts([
               data: totals,
               fill: true,
               borderColor: palette.royal,
-              backgroundColor: 'rgba(17, 86, 214, 0.18)',
+              backgroundColor: (context) =>
+                createVerticalGradient(context, ['rgba(17, 86, 214, 0.45)', 'rgba(17, 86, 214, 0.05)']),
               tension: 0.32,
               pointRadius: 0,
               pointHoverRadius: 4,
+              borderWidth: 2.5,
             },
           ],
         },
         options: {
-          layout: { padding: { left: 4, right: 4, top: 8, bottom: 8 } },
+          layout: { padding: { left: 4, right: 4, top: 8, bottom: 12 } },
           plugins: {
             legend: { display: false },
             tooltip: {
@@ -48,6 +72,7 @@ registerCharts([
           scales: {
             x: {
               grid: { display: false },
+              ticks: { maxRotation: 0, autoSkipPadding: 10 },
             },
             y: {
               beginAtZero: true,
@@ -62,16 +87,187 @@ registerCharts([
     },
   },
   {
-    element: document.querySelector('[data-chart="draft-timeline"]'),
+    element: document.querySelector('[data-chart="tallest-bubbles"]'),
     source: 'data/players_overview.json',
     async createConfig(data) {
-      const decadeCounts = Array.isArray(data?.draftSummary?.decadeCounts)
-        ? data.draftSummary.decadeCounts.filter((entry) => /\d{4}s/.test(entry.decade))
-        : [];
-      if (!decadeCounts.length) return null;
-      const trimmed = helpers.evenSample(decadeCounts, 10);
-      const labels = trimmed.map((entry) => entry.decade);
-      const drafted = trimmed.map((entry) => entry.players);
+      const players = Array.isArray(data?.tallestPlayers) ? data.tallestPlayers : [];
+      if (!players.length) return null;
+      const weighted = players.filter((player) => Number.isFinite(player?.weightPounds));
+      const fallbackWeight = weighted.length
+        ? weighted.reduce((sum, player) => sum + player.weightPounds, 0) / weighted.length
+        : 280;
+
+      const dataset = players.map((player, index) => {
+        const height = Number.isFinite(player?.heightInches) ? player.heightInches : null;
+        if (!height) {
+          return null;
+        }
+        const listedWeight = Number.isFinite(player?.weightPounds) ? player.weightPounds : null;
+        const weight = listedWeight ?? fallbackWeight;
+        return {
+          x: height,
+          y: weight,
+          r: Math.max(7, Math.sqrt(Math.max(weight - 200, 30)) * 1.4),
+          player,
+          listedWeight,
+          backgroundColor: accents[index % accents.length],
+        };
+      });
+
+      const points = dataset.filter(Boolean);
+      if (!points.length) return null;
+
+      return {
+        type: 'bubble',
+        data: {
+          datasets: [
+            {
+              label: 'Height vs weight',
+              data: points,
+              parsing: false,
+              backgroundColor: points.map((point) => point.backgroundColor),
+              borderColor: 'rgba(11, 37, 69, 0.2)',
+              borderWidth: 1,
+              hoverBorderWidth: 2,
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const { player, listedWeight } = context.raw || {};
+                  if (!player) return null;
+                  const height = helpers.formatNumber(player.heightInches, 0);
+                  const weightText = listedWeight
+                    ? `${helpers.formatNumber(listedWeight, 0)} lbs`
+                    : 'weight not listed';
+                  return `${player.name} · ${height}" · ${weightText}`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              title: { display: true, text: 'Height (inches)' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              min: 82,
+              max: 92,
+            },
+            y: {
+              title: { display: true, text: 'Weight (pounds)' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              suggestedMin: 190,
+              suggestedMax: 370,
+              ticks: {
+                callback: (value) => `${helpers.formatNumber(value, 0)}`,
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="position-orbits"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const totals = data?.totals;
+      const segments = [
+        { label: 'Guards', value: totals?.guards ?? 0, color: palette.sky },
+        { label: 'Forwards', value: totals?.forwards ?? 0, color: palette.violet },
+        { label: 'Centers', value: totals?.centers ?? 0, color: palette.gold },
+      ].filter((segment) => segment.value > 0);
+      if (!segments.length) return null;
+      const totalPlayers = segments.reduce((sum, segment) => sum + segment.value, 0);
+
+      return {
+        type: 'doughnut',
+        data: {
+          labels: segments.map((segment) => segment.label),
+          datasets: [
+            {
+              data: segments.map((segment) => segment.value),
+              backgroundColor: segments.map((segment) => segment.color),
+              borderColor: '#ffffff',
+              borderWidth: 2,
+              hoverOffset: 12,
+            },
+          ],
+        },
+        options: {
+          cutout: '55%',
+          layout: { padding: { top: 10, bottom: 10, left: 6, right: 6 } },
+          plugins: {
+            legend: {
+              position: 'right',
+              labels: { usePointStyle: true, padding: 16 },
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const value = context.parsed;
+                  const share = totalPlayers ? (value / totalPlayers) * 100 : 0;
+                  return `${context.label}: ${helpers.formatNumber(value, 0)} players (${helpers.formatNumber(share, 1)}%)`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="country-spectrum"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const countries = helpers.rankAndSlice(Array.isArray(data?.countries) ? data.countries : [], 7, (item) => item.players);
+      if (!countries.length) return null;
+
+      return {
+        type: 'polarArea',
+        data: {
+          labels: countries.map((country) => country.country),
+          datasets: [
+            {
+              data: countries.map((country) => country.players),
+              backgroundColor: countries.map((_, index) => accents[index % accents.length]),
+              borderWidth: 1,
+              borderColor: 'rgba(255, 255, 255, 0.6)',
+            },
+          ],
+        },
+        options: {
+          scales: {
+            r: {
+              ticks: { display: false },
+              grid: { color: 'rgba(11, 37, 69, 0.12)' },
+            },
+          },
+          plugins: {
+            legend: { position: 'right' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed, 0)} players`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="college-pipeline"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const colleges = helpers.rankAndSlice(Array.isArray(data?.colleges) ? data.colleges : [], 8, (item) => item.players);
+      if (!colleges.length) return null;
+      const labels = colleges.map((college) => college.program);
+      const totals = colleges.map((college) => college.players);
 
       return {
         type: 'bar',
@@ -79,16 +275,76 @@ registerCharts([
           labels,
           datasets: [
             {
-              label: 'Drafted players',
-              data: drafted,
-              backgroundColor: palette.gold,
-              borderColor: 'rgba(244, 181, 63, 0.8)',
-              borderWidth: 1,
+              label: 'Players',
+              data: totals,
+              borderRadius: 12,
+              borderSkipped: false,
+              backgroundColor: (context) =>
+                createVerticalGradient(context, ['rgba(244, 181, 63, 0.75)', 'rgba(239, 61, 91, 0.35)']),
             },
           ],
         },
         options: {
-          layout: { padding: { top: 4, right: 8, bottom: 4, left: 8 } },
+          indexAxis: 'y',
+          layout: { padding: { top: 6, bottom: 6, left: 4, right: 4 } },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.x, 0)} players`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+            y: {
+              grid: { display: false },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="draft-timeline"]'),
+    source: 'data/players_overview.json',
+    async createConfig(data) {
+      const decadeCounts = Array.isArray(data?.draftSummary?.decadeCounts)
+        ? data.draftSummary.decadeCounts.filter((entry) => /\d{4}s/.test(entry.decade))
+        : [];
+      if (!decadeCounts.length) return null;
+      const trimmed = helpers.evenSample(decadeCounts, 16);
+      const labels = trimmed.map((entry) => entry.decade);
+      const drafted = trimmed.map((entry) => entry.players);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Drafted players',
+              data: drafted,
+              fill: true,
+              borderColor: palette.teal,
+              backgroundColor: (context) =>
+                createVerticalGradient(context, ['rgba(17, 181, 198, 0.45)', 'rgba(17, 181, 198, 0.05)']),
+              tension: 0.28,
+              pointRadius: 3,
+              pointHoverRadius: 6,
+            },
+          ],
+        },
+        options: {
+          interaction: { mode: 'index', intersect: false },
           plugins: {
             legend: { display: false },
             tooltip: {
@@ -101,13 +357,304 @@ registerCharts([
           },
           scales: {
             x: {
-              grid: { display: false },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
             },
             y: {
               beginAtZero: true,
               grid: { color: 'rgba(11, 37, 69, 0.1)' },
               ticks: {
-                callback: (value) => `${helpers.formatNumber(value, 0)}`,
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="season-trends"]'),
+    source: 'data/player_season_insights.json',
+    async createConfig(data) {
+      const seasons = Array.isArray(data?.seasonTrends) ? data.seasonTrends : [];
+      if (!seasons.length) return null;
+      const labels = seasons.map((entry) => entry.season);
+      const points = seasons.map((entry) => entry.avgPoints ?? 0);
+      const assists = seasons.map((entry) => entry.avgAssists ?? 0);
+      const rebounds = seasons.map((entry) => entry.avgRebounds ?? 0);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Points per game',
+              data: points,
+              borderColor: palette.coral,
+              backgroundColor: 'rgba(239, 61, 91, 0.08)',
+              tension: 0.3,
+              borderWidth: 2,
+              pointRadius: 0,
+              pointHoverRadius: 3,
+            },
+            {
+              label: 'Assists per game',
+              data: assists,
+              borderColor: palette.sky,
+              backgroundColor: 'rgba(31, 123, 255, 0.08)',
+              tension: 0.3,
+              borderDash: [6, 4],
+              borderWidth: 2,
+              pointRadius: 0,
+              pointHoverRadius: 3,
+            },
+            {
+              label: 'Rebounds per game',
+              data: rebounds,
+              borderColor: palette.gold,
+              backgroundColor: 'rgba(244, 181, 63, 0.12)',
+              tension: 0.3,
+              borderWidth: 2,
+              pointRadius: 0,
+              pointHoverRadius: 3,
+            },
+          ],
+        },
+        options: {
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                title(contexts) {
+                  if (!contexts?.length) return '';
+                  return `Season ${contexts[0].label}`;
+                },
+                label(context) {
+                  return `${context.dataset.label}: ${helpers.formatNumber(context.parsed.y, 2)}`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.05)' },
+              ticks: {
+                maxRotation: 0,
+                callback(value, index, values) {
+                  const label = labels[index];
+                  return index % 5 === 0 ? label : '';
+                },
+              },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="triple-double-cloud"]'),
+    source: 'data/player_season_insights.json',
+    async createConfig(data) {
+      const leaders = helpers.rankAndSlice(Array.isArray(data?.tripleDoubleLeaders) ? data.tripleDoubleLeaders : [], 12, (item) => item.tripleDoubles ?? 0);
+      if (!leaders.length) return null;
+
+      const points = leaders.map((leader, index) => {
+        const start = Number.isFinite(leader?.careerSpan?.start) ? leader.careerSpan.start : leader?.bestSeason?.season;
+        const end = Number.isFinite(leader?.careerSpan?.end) ? leader.careerSpan.end : leader?.bestSeason?.season;
+        const midpoint = Number.isFinite(start) && Number.isFinite(end) ? (start + end) / 2 : start ?? end;
+        return {
+          x: midpoint,
+          y: leader.tripleDoubles ?? 0,
+          r: Math.max(9, Math.sqrt(leader.seasonsWithTripleDouble ?? 1) * 4.2),
+          leader,
+          backgroundColor: accents[index % accents.length],
+        };
+      });
+
+      return {
+        type: 'bubble',
+        data: {
+          datasets: [
+            {
+              label: 'Career triple-doubles',
+              data: points,
+              parsing: false,
+              backgroundColor: points.map((point) => point.backgroundColor),
+              borderColor: 'rgba(11, 37, 69, 0.2)',
+              borderWidth: 1,
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const { leader } = context.raw || {};
+                  if (!leader) return null;
+                  const seasons = leader.seasonsWithTripleDouble ?? 0;
+                  const spanStart = leader?.careerSpan?.start;
+                  const spanEnd = leader?.careerSpan?.end;
+                  const spanText = spanStart && spanEnd ? `${spanStart}–${spanEnd}` : leader?.bestSeason?.season;
+                  return `${leader.name}: ${helpers.formatNumber(leader.tripleDoubles ?? 0, 0)} triple-doubles · ${helpers.formatNumber(seasons, 0)} seasons · ${spanText}`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              type: 'linear',
+              title: { display: true, text: 'Career span midpoint' },
+              grid: { color: 'rgba(11, 37, 69, 0.06)' },
+              suggestedMin: 1955,
+              suggestedMax: 2030,
+            },
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'Total triple-doubles' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="scoring-eruptions"]'),
+    source: 'data/player_leaders.json',
+    async createConfig(data) {
+      const games = Array.isArray(data?.singleGameHighs?.points) ? data.singleGameHighs.points.slice(0, 20) : [];
+      if (!games.length) return null;
+      const points = games.map((game, index) => {
+        const rebounds = Number.isFinite(game?.rebounds) ? game.rebounds : 0;
+        const assists = Number.isFinite(game?.assists) ? game.assists : 0;
+        return {
+          x: Number(game?.minutes) || 0,
+          y: Number(game?.points) || 0,
+          r: Math.max(6, Math.sqrt(rebounds + assists + 1) * 2.4),
+          game,
+          backgroundColor: accents[index % accents.length],
+        };
+      });
+
+      return {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'Single game highs',
+              data: points,
+              parsing: false,
+              pointBackgroundColor: points.map((point) => point.backgroundColor),
+              pointBorderColor: 'rgba(11, 37, 69, 0.2)',
+              pointBorderWidth: 1,
+              pointHoverBorderWidth: 2,
+            },
+          ],
+        },
+        options: {
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const { game } = context.raw || {};
+                  if (!game) return null;
+                  const rebounds = helpers.formatNumber(game.rebounds ?? 0, 0);
+                  const assists = helpers.formatNumber(game.assists ?? 0, 0);
+                  const minutes = helpers.formatNumber(game.minutes ?? 0, 0);
+                  const date = game.gameDate ? new Date(game.gameDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' }) : 'Unknown date';
+                  return `${game.name} · ${helpers.formatNumber(game.points ?? 0, 0)} pts · ${rebounds} reb · ${assists} ast · ${minutes} min (${date})`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              title: { display: true, text: 'Minutes played' },
+              grid: { color: 'rgba(11, 37, 69, 0.05)' },
+            },
+            y: {
+              title: { display: true, text: 'Points scored' },
+              beginAtZero: false,
+              suggestedMin: 40,
+              suggestedMax: 110,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="career-constellation"]'),
+    source: 'data/player_leaders.json',
+    async createConfig(data) {
+      const leaders = (Array.isArray(data?.careerLeaders?.points) ? data.careerLeaders.points : []).slice(0, 4);
+      if (!leaders.length) return null;
+      const metrics = [
+        { key: 'pointsPerGame', label: 'Points/G', formatter: (value) => `${helpers.formatNumber(value, 2)} PPG` },
+        { key: 'assistsPerGame', label: 'Assists/G', formatter: (value) => `${helpers.formatNumber(value, 2)} APG` },
+        { key: 'reboundsPerGame', label: 'Rebounds/G', formatter: (value) => `${helpers.formatNumber(value, 2)} RPG` },
+        { key: 'winPct', label: 'Win %', formatter: (value) => `${helpers.formatNumber((value ?? 0) * 100, 1)}% win` },
+      ];
+
+      const maxima = metrics.map((metric) =>
+        leaders.reduce((max, leader) => Math.max(max, Number(leader?.[metric.key]) || 0), 0)
+      );
+      if (!maxima.some((value) => value > 0)) return null;
+
+      const datasets = leaders.map((leader, index) => {
+        const rawValues = metrics.map((metric) => Number(leader?.[metric.key]) || 0);
+        return {
+          label: leader.name,
+          data: rawValues.map((value, metricIndex) =>
+            Number(((value / (maxima[metricIndex] || 1)) * 100).toFixed(2))
+          ),
+          rawValues,
+          borderColor: accents[index % accents.length],
+          backgroundColor: `${accents[index % accents.length]}29`,
+          borderWidth: 2,
+          fill: true,
+          pointRadius: 3,
+          pointHoverRadius: 5,
+        };
+      });
+
+      return {
+        type: 'radar',
+        data: {
+          labels: metrics.map((metric) => metric.label),
+          datasets,
+        },
+        options: {
+          scales: {
+            r: {
+              angleLines: { color: 'rgba(11, 37, 69, 0.12)' },
+              grid: { color: 'rgba(11, 37, 69, 0.12)' },
+              suggestedMin: 0,
+              suggestedMax: 105,
+              ticks: { display: false },
+            },
+          },
+          plugins: {
+            legend: { position: 'bottom' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const dataset = context.dataset;
+                  const metric = metrics[context.dataIndex];
+                  const rawValue = dataset.rawValues?.[context.dataIndex] ?? 0;
+                  return `${dataset.label}: ${metric.formatter(rawValue)}`;
+                },
               },
             },
           },

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -2424,6 +2424,17 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 /* Viz */
 .viz-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.players-lab { display: grid; gap: clamp(2.4rem, 5vw, 3.8rem); margin-bottom: 4rem; }
+.players-lab__section { display: grid; gap: 1.5rem; }
+.players-lab__section-header { display: grid; gap: 0.6rem; max-width: 660px; }
+.players-lab__section-header h2 { margin: 0; font-size: clamp(1.6rem, 3vw, 1.9rem); }
+.players-lab__lede {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
+}
+.players-lab__grid { align-items: stretch; }
 .viz-card {
   position: relative; display: grid; gap: 0.9rem; padding: 1.2rem 1.3rem 1.4rem; border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--border) 75%, transparent);


### PR DESCRIPTION
## Summary
- replace the players page layout with three thematic sections that feature ten interactive canvases
- add styling hooks for the new players lab layout to keep the grid consistent with the site aesthetic
- wire up new Chart.js configurations to visualize player size, geography, pipelines, records, and legends using repo data

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d88a96b3348327938960fb4141564c