### PR TITLE
Refactor teams page into multi-chart data lab

### DIFF
--- a/public/scripts/teams.js
+++ b/public/scripts/teams.js
@@ -4,6 +4,9 @@ const palette = {
   royal: '#1156d6',
   red: '#ef3d5b',
   teal: 'rgba(17, 86, 214, 0.2)',
+  gold: '#f4b53f',
+  midnight: '#0b2545',
+  sand: '#f5e6c8',
 };
 
 registerCharts([
@@ -150,6 +153,546 @@ registerCharts([
                 color: '#42526c',
                 font: { size: 12 },
               },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="expansion-waves"]'),
+    source: 'data/active_franchises.json',
+    async createConfig(data) {
+      const decades = Array.isArray(data?.decades) ? data.decades : [];
+      const timeline = decades
+        .filter((entry) => Number.isFinite(entry?.total))
+        .sort((a, b) => a.decade - b.decade);
+      if (!timeline.length) return null;
+
+      const labels = timeline.map((entry) => `${entry.decade}s`);
+      const totals = timeline.map((entry) => entry.total);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Active franchises',
+              data: totals,
+              fill: 'start',
+              tension: 0.35,
+              borderColor: palette.royal,
+              backgroundColor: 'rgba(17, 86, 214, 0.22)',
+              pointBackgroundColor: palette.red,
+              pointBorderColor: '#ffffff',
+              pointBorderWidth: 1.5,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: { top: 6, right: 10, bottom: 10, left: 6 } },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Decade expansion arcs',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.y, 0)} franchises active`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c', font: { size: 12 } },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+                color: '#42526c',
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="offense-synergy"]'),
+    source: 'data/team_performance.json',
+    async createConfig(data) {
+      const leaders = helpers.rankAndSlice(Array.isArray(data?.winPctLeaders) ? data.winPctLeaders : [], 12, (team) => team.winPct);
+      if (!leaders.length) return null;
+
+      const points = leaders.map((team) => ({
+        x: Number(team.pointsPerGame?.toFixed(2) ?? 0),
+        y: Number(team.opponentPointsPerGame?.toFixed(2) ?? 0),
+        r: Math.max(8, Math.min(18, (team.assistsPerGame ?? 0) * 0.6)),
+        team: team.team,
+        assists: team.assistsPerGame ?? 0,
+        winPct: team.winPct ?? 0,
+      }));
+
+      return {
+        type: 'bubble',
+        data: {
+          datasets: [
+            {
+              label: 'Efficiency blend',
+              data: points,
+              backgroundColor: (ctx) => (ctx?.raw?.winPct ?? 0) >= 0.55 ? 'rgba(17, 86, 214, 0.75)' : 'rgba(239, 61, 91, 0.68)',
+              borderColor: 'rgba(17, 86, 214, 0.28)',
+              borderWidth: 1.5,
+              hoverBorderWidth: 2,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: 8 },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Points vs opponent points',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const raw = context.raw ?? {};
+                  const win = helpers.formatNumber((raw.winPct ?? 0) * 100, 1);
+                  return `${raw.team}: ${helpers.formatNumber(raw.x, 2)} PPG • ${helpers.formatNumber(raw.y, 2)} OPPG • ${helpers.formatNumber(raw.assists, 2)} APG • ${win}% win rate`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              title: { display: true, text: 'Points per game' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c', font: { size: 12 } },
+            },
+            y: {
+              title: { display: true, text: 'Opponent points per game' },
+              reverse: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c', font: { size: 12 } },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="assist-fireworks"]'),
+    source: 'data/team_performance.json',
+    async createConfig(data) {
+      const games = helpers
+        .rankAndSlice(Array.isArray(data?.singleGameHighs?.assists) ? data.singleGameHighs.assists : [], 12, (game) => game.assists)
+        .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+      if (!games.length) return null;
+
+      const labels = games.map((game) => {
+        const date = new Date(game.date);
+        return `${date.getFullYear()} • ${game.team}`;
+      });
+      const assists = games.map((game) => game.assists ?? 0);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Single-game assists',
+              data: assists,
+              tension: 0.35,
+              borderColor: 'rgba(239, 61, 91, 0.85)',
+              backgroundColor: 'rgba(239, 61, 91, 0.18)',
+              fill: 'start',
+              pointRadius: 4,
+              pointHoverRadius: 6,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: { top: 8, right: 10, bottom: 6, left: 6 } },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Assist eruption history',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const game = games[context.dataIndex];
+                  const opponent = game.opponent ?? 'Opponent';
+                  const venue = game.home ? 'Home floor' : 'Road trip';
+                  return `${game.team} vs ${opponent}: ${helpers.formatNumber(context.parsed.y, 0)} assists • ${venue}`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.06)' },
+              ticks: { color: '#42526c', autoSkip: true, maxRotation: 0, minRotation: 0 },
+            },
+            y: {
+              beginAtZero: true,
+              suggestedMax: Math.max(...assists) + 5,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c' },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="margin-surges"]'),
+    source: 'data/team_performance.json',
+    async createConfig(data) {
+      const surges = helpers
+        .rankAndSlice(Array.isArray(data?.singleGameHighs?.margins) ? data.singleGameHighs.margins : [], 10, (game) => game.margin)
+        .sort((a, b) => a.margin - b.margin);
+      if (!surges.length) return null;
+
+      const labels = surges.map((game) => `${game.team} vs ${game.opponent}`);
+      const margins = surges.map((game) => game.margin ?? 0);
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Point margin',
+              data: margins,
+              backgroundColor: 'rgba(17, 86, 214, 0.78)',
+              borderRadius: 10,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          layout: { padding: { top: 6, right: 10, bottom: 6, left: 6 } },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Largest single-game margins',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: +${helpers.formatNumber(context.parsed.x, 0)} margin`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c', callback: (value) => `+${helpers.formatNumber(value, 0)}` },
+            },
+            y: {
+              grid: { display: false },
+              ticks: { color: palette.midnight, font: { weight: 600, size: 11 } },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="rest-spectrum"]'),
+    source: 'data/season_24_25_schedule.json',
+    async createConfig(data) {
+      const buckets = Array.isArray(data?.restBuckets) ? data.restBuckets : [];
+      if (!buckets.length) return null;
+
+      const labels = buckets.map((bucket) => bucket.label ?? '');
+      const values = buckets.map((bucket) => bucket.intervals ?? 0);
+      const colors = [
+        'rgba(239, 61, 91, 0.78)',
+        'rgba(17, 86, 214, 0.75)',
+        'rgba(17, 86, 214, 0.5)',
+        'rgba(244, 181, 63, 0.78)',
+      ];
+
+      return {
+        type: 'polarArea',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Rest intervals',
+              data: values,
+              backgroundColor: colors,
+              borderColor: 'rgba(255, 255, 255, 0.7)',
+              borderWidth: 1.2,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: 10 },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Rest day distribution',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { position: 'bottom' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed, 0)} intervals`;
+                },
+              },
+            },
+          },
+          scales: {},
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="homestand-radar"]'),
+    source: 'data/season_24_25_schedule.json',
+    async createConfig(data) {
+      const teams = helpers
+        .rankAndSlice(Array.isArray(data?.teams) ? data.teams : [], 6, (team) => Math.max(team.longestHomeStand ?? 0, team.longestRoadTrip ?? 0));
+      if (!teams.length) return null;
+
+      const labels = teams.map((team) => team.abbreviation ?? team.name);
+      const home = teams.map((team) => team.longestHomeStand ?? 0);
+      const road = teams.map((team) => team.longestRoadTrip ?? 0);
+
+      return {
+        type: 'radar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Home stand',
+              data: home,
+              backgroundColor: 'rgba(17, 86, 214, 0.25)',
+              borderColor: palette.royal,
+              pointBackgroundColor: palette.royal,
+            },
+            {
+              label: 'Road trip',
+              data: road,
+              backgroundColor: 'rgba(239, 61, 91, 0.2)',
+              borderColor: palette.red,
+              pointBackgroundColor: palette.red,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: 10 },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Longest schedule swings',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { position: 'bottom' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.dataset.label}: ${helpers.formatNumber(context.parsed.r, 0)} games`;
+                },
+              },
+            },
+          },
+          scales: {
+            r: {
+              beginAtZero: true,
+              angleLines: { color: 'rgba(11, 37, 69, 0.08)' },
+              grid: { color: 'rgba(11, 37, 69, 0.12)' },
+              ticks: { backdropColor: 'transparent', color: '#42526c', stepSize: 1 },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="monthly-volume"]'),
+    source: 'data/season_24_25_schedule.json',
+    async createConfig(data) {
+      const months = Array.isArray(data?.monthlyCounts) ? data.monthlyCounts : [];
+      if (!months.length) return null;
+
+      const labels = months.map((month) => month.label ?? month.month ?? '');
+      const preseason = months.map((month) => month.preseason ?? 0);
+      const regular = months.map((month) => month.regularSeason ?? 0);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Preseason volume',
+              data: preseason,
+              borderColor: 'rgba(244, 181, 63, 0.88)',
+              backgroundColor: 'rgba(244, 181, 63, 0.28)',
+              fill: 'origin',
+              tension: 0.35,
+              pointRadius: 3,
+            },
+            {
+              label: 'Regular season load',
+              data: regular,
+              borderColor: 'rgba(17, 86, 214, 0.85)',
+              backgroundColor: 'rgba(17, 86, 214, 0.22)',
+              fill: 'origin',
+              tension: 0.35,
+              pointRadius: 3,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: { top: 6, right: 14, bottom: 8, left: 6 } },
+          interaction: { mode: 'index', intersect: false },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Monthly game flow',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { position: 'bottom' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.dataset.label}: ${helpers.formatNumber(context.parsed.y, 0)} games`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.06)' },
+              ticks: { color: '#42526c' },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c', callback: (value) => helpers.formatNumber(value, 0) },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="back-to-back"]'),
+    source: 'data/season_24_25_schedule.json',
+    async createConfig(data) {
+      const teams = helpers
+        .rankAndSlice(Array.isArray(data?.backToBackLeaders) ? data.backToBackLeaders : [], 10, (team) => team.backToBacks)
+        .sort((a, b) => b.backToBacks - a.backToBacks);
+      if (!teams.length) return null;
+
+      const labels = teams.map((team) => team.abbreviation ?? team.name);
+      const totals = teams.map((team) => team.backToBacks ?? 0);
+      const rest = teams.map((team) => team.averageRestDays ?? 0);
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Back-to-back sets',
+              data: totals,
+              backgroundColor: 'rgba(17, 86, 214, 0.8)',
+              borderRadius: 10,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          layout: { padding: { top: 6, right: 8, bottom: 6, left: 8 } },
+          plugins: {
+            title: {
+              display: true,
+              text: 'Back-to-back burden',
+              align: 'start',
+              color: palette.midnight,
+              font: { weight: 700, size: 14 },
+              padding: { bottom: 8 },
+            },
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const averageRest = rest[context.dataIndex] ?? 0;
+                  return `${context.label}: ${helpers.formatNumber(context.parsed.y, 0)} sets • ${helpers.formatNumber(averageRest, 2)} avg rest days`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { display: false },
+              ticks: { color: '#42526c', font: { weight: 600 } },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: { color: '#42526c', callback: (value) => helpers.formatNumber(value, 0) },
             },
           },
         },

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -2420,6 +2420,34 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .release-checklist__progress-value { font-size: 0.75rem; font-weight: 700; color: var(--royal); justify-self: end; }
 
 /* Viz */
+.team-lab { display: grid; gap: clamp(2rem, 4vw, 3rem); }
+.team-lab__header { display: grid; gap: clamp(1.4rem, 3vw, 2rem); }
+.team-lab__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+.team-lab__legend { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+.team-lab__grid { margin-top: 0.2rem; }
+.metric-tile {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+  background:
+    linear-gradient(135deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.85) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+.metric-tile__label {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(17, 86, 214, 0.78);
+}
+.metric-tile__value { font-size: 1.05rem; font-weight: 700; color: var(--navy); }
 .viz-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
 .viz-card {
   position: relative; display: grid; gap: 0.9rem; padding: 1.2rem 1.3rem 1.4rem; border-radius: var(--radius-md);

--- a/public/teams.html
+++ b/public/teams.html
@@ -29,109 +29,64 @@
         <div class="hero">
           <span class="eyebrow">Team Systems</span>
           <h1>Benchmark every franchise from culture to crunch time.</h1>
-          <p>
-            Map out the forthcoming dashboards that surface team DNA, lineup chemistry, and schematic
-            evolution throughout the season.
-          </p>
+          <dl class="hero-metrics">
+            <div class="hero-metrics__item">
+              <dt>Active franchises</dt>
+              <dd>35 programs tracking toward 2100</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Average rest window</dt>
+              <dd>3.04 days between tilts</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Historic win apex</dt>
+              <dd>59.7% pace from Boston</dd>
+            </div>
+          </dl>
         </div>
       </header>
 
       <main>
-        <section class="team-overview">
-          <div class="section-heading">
-            <div>
-              <h2>Franchise health monitor</h2>
-              <p class="lead">
-                Design modular views that blend efficiency numbers with qualitative markers so front
-                offices can assess culture, continuity, and coaching tweaks at a glance.
-              </p>
+        <section class="team-lab">
+          <div class="team-lab__header">
+            <div class="team-lab__title">
+              <h2>Franchise systems observatory</h2>
             </div>
-            <div class="section-heading__actions">
-              <span class="chip chip--accent">MVP scope</span>
-              <span class="chip">Culture index</span>
-              <span class="chip">Roster churn</span>
-              <span class="chip">Financial runway</span>
-            </div>
-          </div>
-          <div class="team-overview__body">
-            <article class="team-overview__summary">
-              <h3>Organization pulse</h3>
-              <p>
-                Extend <code>TeamHistories.csv</code> with modern pace-and-space indicators to see how
-                strategies evolve. Layer on roster churn, draft capital, and development pathways to
-                reveal which franchises are building lasting systems.
-              </p>
-              <ul class="checklist">
-                <li>Normalize pace arcs to compare dynasties across eras.</li>
-                <li>Overlay scouting intel with scouting grades from partner clubs.</li>
-                <li>Bookmark chemistry breakpoints before trade and free agency windows.</li>
-              </ul>
-            </article>
-            <div class="team-overview__panels">
-              <div class="team-kpi-grid">
-                <article class="metric-card">
-                  <header class="metric-card__head">
-                    <span class="metric-card__label">Dynasty tier</span>
-                    <span class="metric-card__pill">Historical</span>
-                  </header>
-                  <p class="metric-card__value">Top 10</p>
-                  <p class="metric-card__hint">Clubs living above a 60% win pace, updated nightly.</p>
-                </article>
-                <article class="metric-card">
-                  <header class="metric-card__head">
-                    <span class="metric-card__label">Continuity meter</span>
-                    <span class="metric-card__pill">Rolling 30 days</span>
-                  </header>
-                  <p class="metric-card__value">87%</p>
-                  <p class="metric-card__hint">Lineup overlap weighted by clutch possessions.</p>
-                </article>
-                <article class="metric-card">
-                  <header class="metric-card__head">
-                    <span class="metric-card__label">Travel tax</span>
-                    <span class="metric-card__pill">Season to date</span>
-                  </header>
-                  <p class="metric-card__value">1.6</p>
-                  <p class="metric-card__hint">Average rest advantage compared to opponents.</p>
-                </article>
-                <article class="metric-card">
-                  <header class="metric-card__head">
-                    <span class="metric-card__label">Playbook depth</span>
-                    <span class="metric-card__pill">Video tags</span>
-                  </header>
-                  <p class="metric-card__value">42</p>
-                  <p class="metric-card__hint">Tracked sets with confirmed counters this month.</p>
-                </article>
+            <div class="team-lab__metrics">
+              <div class="metric-tile">
+                <span class="metric-tile__label">Average rest</span>
+                <span class="metric-tile__value">3.04 days</span>
               </div>
-              <figure class="viz-card viz-card--inline team-overview__viz" data-chart-wrapper>
-                <header class="viz-card__title">Historical win rate leaders</header>
-                <div class="viz-canvas">
-                  <canvas data-chart="win-leaders" aria-describedby="win-leaders-caption"></canvas>
-                </div>
-                <figcaption id="win-leaders-caption" class="viz-card__caption">
-                  Horizontal bars spotlight the ten most efficient franchises ever, trimmed via ranked
-                  slicing to keep render times snappy.
-                </figcaption>
-              </figure>
+              <div class="metric-tile">
+                <span class="metric-tile__label">Total schedule intervals</span>
+                <span class="metric-tile__value">2,779</span>
+              </div>
+              <div class="metric-tile">
+                <span class="metric-tile__label">Historic assist spike</span>
+                <span class="metric-tile__value">53 dimes</span>
+              </div>
+              <div class="metric-tile">
+                <span class="metric-tile__label">Expansion waves</span>
+                <span class="metric-tile__value">6 surges</span>
+              </div>
+            </div>
+            <div class="team-lab__legend">
+              <span class="chip chip--accent">Team performance archives</span>
+              <span class="chip">Active franchise census</span>
+              <span class="chip chip--ghost">Season 24-25 schedule telemetry</span>
             </div>
           </div>
-        </section>
-
-        <section class="team-analytics">
-          <div class="section-heading">
-            <div>
-              <h2>Lineup chemistry lab</h2>
-              <p class="lead">
-                Translate schedule strain, spacing scores, and defensive tags into actionable lineup
-                experiments before the playoffs hit.
-              </p>
-            </div>
-            <div class="section-heading__actions section-heading__actions--ghost">
-              <span class="chip chip--ghost">Spacing scores</span>
-              <span class="chip chip--ghost">Defensive tags</span>
-              <span class="chip chip--ghost">Clutch usage</span>
-            </div>
-          </div>
-          <div class="team-analytics__grid">
+          <div class="team-lab__grid viz-grid">
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Historical win rate leaders</header>
+              <div class="viz-canvas">
+                <canvas data-chart="win-leaders" aria-describedby="win-leaders-caption"></canvas>
+              </div>
+              <figcaption id="win-leaders-caption" class="viz-card__caption">
+                Horizontal bars spotlight the ten most efficient franchises ever, trimmed via ranked
+                slicing to keep render times snappy.
+              </figcaption>
+            </figure>
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Schedule strain navigator</header>
               <div class="viz-canvas">
@@ -142,50 +97,85 @@
                 back-to-back sets and average rest days for busy clubs.
               </figcaption>
             </figure>
-            <div class="stacked-panel">
-              <h3>Key overlays</h3>
-              <p>
-                Feed in the latest shifts from <code>TeamStatistics.zip</code> as the data warehouse is
-                unlocked. Allow coaches to stress-test lineup combinations and anticipate fatigue
-                spikes weeks in advance.
-              </p>
-              <div class="badge-list">
-                <span class="badge">Spacing scores</span>
-                <span class="badge">Defensive tags</span>
-                <span class="badge">Clutch usage</span>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Expansion wave tracker</header>
+              <div class="viz-canvas">
+                <canvas data-chart="expansion-waves" aria-describedby="expansion-waves-caption"></canvas>
               </div>
-              <div class="callout-grid">
-                <article class="callout-card">
-                  <span class="callout-card__label">Continuity lenses</span>
-                  <p>Blend substitution patterns with culture grades to flag lineup volatility.</p>
-                </article>
-                <article class="callout-card">
-                  <span class="callout-card__label">Load management</span>
-                  <p>Surface travel burdens and altitude swings before scheduling rest days.</p>
-                </article>
-                <article class="callout-card">
-                  <span class="callout-card__label">Playbook sync</span>
-                  <p>Connect scout reports with video tags so staff can demo counters instantly.</p>
-                </article>
+              <figcaption id="expansion-waves-caption" class="viz-card__caption">
+                Filled line shows how franchise counts ballooned across decades, highlighting eighties
+                and tens surges.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Offensive identity scatter</header>
+              <div class="viz-canvas">
+                <canvas data-chart="offense-synergy" aria-describedby="offense-synergy-caption"></canvas>
               </div>
-            </div>
-          </div>
-          <div class="team-initiatives">
-            <h3>Activation backlog</h3>
-            <div class="card-grid">
-              <article class="card">
-                <h3>Schedule strain</h3>
-                <p>Quantify back-to-back fatigue, travel, and altitude changes in a single gauge.</p>
-              </article>
-              <article class="card">
-                <h3>Game plan repository</h3>
-                <p>Store scout reports, counter plays, and set breakdowns for each opponent.</p>
-              </article>
-              <article class="card">
-                <h3>Community signals</h3>
-                <p>Integrate fan sentiment and social listening to anticipate arena energy swings.</p>
-              </article>
-            </div>
+              <figcaption id="offense-synergy-caption" class="viz-card__caption">
+                Bubble positions merge scoring pace and defensive drag while size encodes assist
+                volume for all-time leaders.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Assist fireworks timeline</header>
+              <div class="viz-canvas">
+                <canvas data-chart="assist-fireworks" aria-describedby="assist-fireworks-caption"></canvas>
+              </div>
+              <figcaption id="assist-fireworks-caption" class="viz-card__caption">
+                Ribbon line charts the most prolific dime nights ever recorded and tags the arenas
+                that hosted them.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Margin avalanches</header>
+              <div class="viz-canvas">
+                <canvas data-chart="margin-surges" aria-describedby="margin-surges-caption"></canvas>
+              </div>
+              <figcaption id="margin-surges-caption" class="viz-card__caption">
+                Horizontal bars isolate the fiercest single-game blowouts, sorted by sheer point
+                separation.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Rest spectrum</header>
+              <div class="viz-canvas">
+                <canvas data-chart="rest-spectrum" aria-describedby="rest-spectrum-caption"></canvas>
+              </div>
+              <figcaption id="rest-spectrum-caption" class="viz-card__caption">
+                Polar slices map how often teams see zero to three-plus days between outings this
+                season.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Homestand endurance radar</header>
+              <div class="viz-canvas">
+                <canvas data-chart="homestand-radar" aria-describedby="homestand-radar-caption"></canvas>
+              </div>
+              <figcaption id="homestand-radar-caption" class="viz-card__caption">
+                Radar lob compares longest home and road swings for schedule grinders with extended
+                travel runs.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Monthly load river</header>
+              <div class="viz-canvas">
+                <canvas data-chart="monthly-volume" aria-describedby="monthly-volume-caption"></canvas>
+              </div>
+              <figcaption id="monthly-volume-caption" class="viz-card__caption">
+                Layered lines show how preseason heat gives way to regular-season torrents across the
+                calendar.
+              </figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Back-to-back gauntlet</header>
+              <div class="viz-canvas">
+                <canvas data-chart="back-to-back" aria-describedby="back-to-back-caption"></canvas>
+              </div>
+              <figcaption id="back-to-back-caption" class="viz-card__caption">
+                Column chart stacks the franchises carrying the heaviest double-night burdens.
+              </figcaption>
+            </figure>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- convert the teams page into a visualization-first layout with a metric ribbon and ten chart canvases
- expand the teams script to drive new franchise, schedule, and rest distribution charts from existing datasets
- add styling for the new metric tiles and grid layout so the visuals align with the site theme

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d88b674b9c83278275a9c5f3f3a732