### PR TITLE
Refactor GOAT index with immersive visualizations

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -30,10 +30,41 @@
           <div class="hero__intro">
             <span class="eyebrow">GOAT Index Debut</span>
             <h1>The all-time race through the General Overall Attribute Total.</h1>
-            <p class="hero__lede">
-              GOAT blends peak impact, stage dominance, longevity, versatility, and cultural capital into a single rating so we
-              can map the pantheon and spotlight who is charging up the mountain next.
-            </p>
+            <div class="hero__metrics" role="list">
+              <article class="hero-metric" role="listitem">
+                <header class="hero-metric__header">
+                  <span class="hero-metric__label">Pantheon saturation</span>
+                  <span class="hero-metric__value" data-hero-saturation-value>—</span>
+                </header>
+                <div class="viz-card viz-card--compact" data-chart-wrapper>
+                  <div class="viz-canvas">
+                    <canvas data-chart="goat-saturation-gauge" data-chart-ratio="0.7" aria-label="Average GOAT score gauge"></canvas>
+                  </div>
+                </div>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <header class="hero-metric__header">
+                  <span class="hero-metric__label">Active dynasty share</span>
+                  <span class="hero-metric__value" data-hero-active-value>—</span>
+                </header>
+                <div class="viz-card viz-card--compact" data-chart-wrapper>
+                  <div class="viz-canvas">
+                    <canvas data-chart="goat-active-gauge" data-chart-ratio="0.7" aria-label="Active players gauge"></canvas>
+                  </div>
+                </div>
+              </article>
+              <article class="hero-metric" role="listitem">
+                <header class="hero-metric__header">
+                  <span class="hero-metric__label">Orbit jumpers</span>
+                  <span class="hero-metric__value" data-hero-orbit-value>—</span>
+                </header>
+                <div class="viz-card viz-card--compact" data-chart-wrapper>
+                  <div class="viz-canvas">
+                    <canvas data-chart="goat-multi-franchise-gauge" data-chart-ratio="0.7" aria-label="Multi-franchise gauge"></canvas>
+                  </div>
+                </div>
+              </article>
+            </div>
             <div class="cta-group" role="group" aria-label="Primary actions">
               <a class="cta cta--primary" href="#goat-board">See the leaderboard</a>
               <a class="cta cta--ghost" href="#goat-method">Understand the formula</a>
@@ -56,28 +87,31 @@
         <section id="goat-method" class="goat-methodology">
           <div class="section-header">
             <h2>How the General Overall Attribute Total is built</h2>
-            <p class="lead">
-              Inspired by the lessons of PER, EPM, and championship equity models, the GOAT Index weights five dimensions that
-              explain how players bend winning across eras.
-            </p>
           </div>
-          <div class="goat-methodology__grid" data-weight-list>
-            <article class="goat-weight-card">
-              <header>
-                <span class="goat-weight-label">Loading components…</span>
-              </header>
-              <p class="goat-weight-copy">The weighting profile is on its way.</p>
-            </article>
+          <div class="goat-methodology__layout">
+            <figure class="viz-card" data-chart-wrapper>
+              <header class="viz-card__title">Weight blueprint</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-weight-donut" aria-label="GOAT component weighting"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Component weight, expressed in percentage of the total GOAT equation.</figcaption>
+            </figure>
+            <div class="goat-methodology__grid" data-weight-list>
+              <article class="goat-weight-card">
+                <header>
+                  <span class="goat-weight-label">Loading components…</span>
+                  <span class="goat-weight-chip">—</span>
+                </header>
+                <div class="goat-weight-meter" aria-hidden="true"><span style="width: 0%"></span></div>
+                <p class="goat-weight-copy">The weighting profile is on its way.</p>
+              </article>
+            </div>
           </div>
         </section>
 
         <section id="goat-board" class="goat-leaderboard">
           <div class="section-header">
             <h2>Pantheon leaderboard</h2>
-            <p class="lead">
-              Rankings refresh monthly using rolling play-by-play impact data, postseason equity share, and cultural resonance
-              signals.
-            </p>
           </div>
           <div class="goat-leaderboard__layout">
             <div class="goat-table-wrapper">
@@ -117,30 +151,79 @@
 
         <section class="goat-visuals">
           <div class="section-header">
-            <h2>Score distribution</h2>
-            <p class="lead">A barline view shows how tightly packed the modern pantheon has become.</p>
+            <h2>Pantheon lab</h2>
           </div>
-          <figure class="viz-card viz-card--inline" data-chart-wrapper>
-            <header class="viz-card__title">Top GOAT scores</header>
-            <div class="viz-canvas">
-              <canvas data-chart="goat-top-bar" aria-describedby="goat-chart-caption"></canvas>
-            </div>
-            <figcaption id="goat-chart-caption" class="viz-card__caption">
-              GOAT points aggregate weighted impact, stage, longevity, versatility, and cultural capital on a 0-100 scale.
-            </figcaption>
-          </figure>
-        </section>
-
-        <section class="goat-risers">
-          <div class="section-header">
-            <h2>Who is rising?</h2>
-            <p class="lead">Movement scores combine year-over-year GOAT deltas with projected sustainability markers.</p>
-          </div>
-          <div class="goat-risers__grid" data-goat-risers>
-            <article class="goat-riser-card">
-              <h3>Tracking signals…</h3>
-              <p>The next generation will surface here when the data loads.</p>
-            </article>
+          <div class="goat-visuals__grid">
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Top GOAT scores</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-top-bar" aria-label="Top GOAT scores"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Leading scores across the active pantheon cohort.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Component fingerprint</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-component-radar" aria-label="Component radar comparison"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Radar overlays for the top trio across the five GOAT pillars.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Impact vs longevity</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-impact-longevity" aria-label="Impact versus longevity scatter"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Scatter comparing prime impact scores against longevity credits.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Stage vs culture resonance</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-stage-culture" aria-label="Stage dominance and cultural capital bubble chart"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Bubble size tracks GOAT value while plotting stage dominance and cultural reach.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Twelve-month motion</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-delta-bars" aria-label="Twelve month GOAT delta chart"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Horizontal bars highlight players with the strongest year-over-year swings.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Pantheon decades</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-decade-curve" aria-label="Pantheon presence by debut decade"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Line slope reveals when legends first entered the league.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Franchise constellations</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-franchise-polar" aria-label="Franchise concentration polar chart"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Polar area map of teams with multiple GOAT contenders.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Versatility ribbons</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-versatility-stream" aria-label="Versatility distribution chart"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Smoothed density of versatility scores across the index.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Tier signal wheel</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-tier-wheel" aria-label="Tier share wheel"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Polar segmentation by current tier labels.</figcaption>
+            </figure>
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Era delta scatter</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-era-delta" aria-label="Era delta scatter"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Positioning of GOAT deltas relative to debut eras.</figcaption>
+            </figure>
           </div>
         </section>
       </main>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -1925,6 +1925,53 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   z-index: 1;
 }
 
+.hero__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-block: 1.8rem 2.2rem;
+}
+
+.hero-metric {
+  padding: 0.9rem 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(17, 86, 214, 0.08) 30%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero-metric__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.hero-metric__label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--navy);
+}
+
+.hero-metric__value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--royal);
+}
+
+.viz-card--compact {
+  padding: 0.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.viz-card--compact .viz-canvas {
+  min-height: 160px;
+}
+
 .goat-hero-graphic {
   position: relative;
   width: min(320px, 100%);
@@ -1975,6 +2022,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 .goat-methodology { display: grid; gap: 1.8rem; margin-block: 3rem; }
 
+.goat-methodology__layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(240px, 1fr) minmax(300px, 1.2fr);
+  align-items: stretch;
+}
+
 .goat-methodology__grid {
   display: grid;
   gap: 1rem;
@@ -1988,7 +2042,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(17, 86, 214, 0.08) 30%);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
   display: grid;
-  gap: 0.6rem;
+  gap: 0.7rem;
 }
 
 .goat-weight-card header {
@@ -2019,7 +2073,27 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   letter-spacing: 0.08em;
 }
 
-.goat-weight-copy { margin: 0; color: var(--text-subtle); font-size: 0.92rem; line-height: 1.6; }
+.goat-weight-copy {
+  margin: 0;
+  color: var(--text-subtle);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.goat-weight-meter {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 70%, rgba(255, 255, 255, 0.7) 30%);
+  overflow: hidden;
+}
+
+.goat-weight-meter span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.95));
+}
 
 .goat-leaderboard { display: grid; gap: 2rem; margin-block: 3rem; }
 
@@ -2164,32 +2238,30 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   text-transform: uppercase;
 }
 
-.goat-visuals { display: grid; gap: 1.8rem; margin-block: 3rem; }
-
-.goat-risers { display: grid; gap: 1.8rem; margin-block: 3rem; }
-
-.goat-risers__grid {
+.goat-visuals {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1.1rem;
+  gap: 1.8rem;
+  margin-block: 3rem;
 }
 
-.goat-riser-card {
-  padding: 1.1rem 1.2rem;
-  border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--royal) 12%, transparent);
-  background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(244, 181, 63, 0.12) 30%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+.goat-visuals__grid {
   display: grid;
-  gap: 0.6rem;
+  gap: 1.4rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-.goat-riser-card h3 { margin: 0; font-size: 1.1rem; color: var(--navy); }
-.goat-riser-meta { margin: 0; font-size: 0.85rem; letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-subtle); }
-.goat-riser-card p:last-child { margin: 0; color: var(--text-strong); font-size: 0.92rem; line-height: 1.6; }
+.viz-card--inline .viz-canvas {
+  min-height: 260px;
+}
 
 @media (max-width: 720px) {
   .hero--goat { text-align: center; }
+  .hero__metrics {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+  .goat-methodology__layout {
+    grid-template-columns: 1fr;
+  }
   .goat-detail__list { grid-template-columns: 1fr; }
 }
 .changelog__highlight::marker { color: var(--royal); }


### PR DESCRIPTION
## Summary
- redesign the GOAT index hero with metric gauges and remove text-only content in favor of data-first modules
- expand the page with a ten-chart visualization lab and updated weighting cards driven by new Chart.js logic
- refresh GOAT-specific styles to support the new layouts, gauges, and component meters

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d88b23218c8327ada01a7c46eacb75