### PR TITLE
Refactor insights lab into visualization dashboard

### DIFF
--- a/public/insights.html
+++ b/public/insights.html
@@ -26,88 +26,169 @@
             <a href="about.html">About</a>
           </nav>
         </div>
-        <div class="hero">
-          <span class="eyebrow">R&amp;D</span>
-          <h1>Prototype, test, and launch new NBA analytics experiences.</h1>
-          <p>
-            The Insights Lab is the sandbox for everything experimental—from early wireframes to
-            fully instrumented data stories. Every visualization begins here.
-          </p>
+        <div class="hero hero--lab">
+          <div class="hero__intro">
+            <span class="eyebrow">Insights Lab Observatory</span>
+            <h1>Immersive analytics prototypes in active rotation</h1>
+          </div>
+          <dl class="hero-metrics hero-metrics--lab">
+            <div class="hero-metrics__item">
+              <dt>Active experiments</dt>
+              <dd data-metric="experiments">--</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Avg. launch readiness</dt>
+              <dd data-metric="readiness">--</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Collaboration nodes</dt>
+              <dd data-metric="collaboration">--</dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Next sync countdown</dt>
+              <dd data-metric="sync">--</dd>
+            </div>
+          </dl>
         </div>
       </header>
 
-      <main>
-        <section>
-          <h2>Changelog</h2>
-          <p class="lead">
-            Keep track of weekly experiments, pipeline upgrades, and deployed visualizations. This log
-            will sync with release notes once automation is in place.
-          </p>
-          <div class="changelog" data-changelog aria-live="polite">
-            <p class="changelog__placeholder">Loading weekly experiments…</p>
-          </div>
-        </section>
-
-        <section>
-          <h2>Phase 3 — Storytelling release</h2>
-          <p class="lead">
-            Follow guided walkthroughs that pair headline metrics with the editorial context needed to
-            brief stakeholders on what changed and why it matters.
-          </p>
-          <div class="story-walkthrough" data-storyboard>
-            <aside class="story-walkthrough__sidebar">
-              <div class="story-meta" data-story-meta>
-                <p class="story-meta__placeholder">Loading release details…</p>
+      <main class="lab-content">
+        <section class="lab-grid">
+          <article class="lab-module lab-module--wide" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Release velocity constellations</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Highlights per sprint</span>
+                <span class="lab-chip lab-chip--accent" data-metric="velocity">--</span>
               </div>
-              <div class="release-tracker" data-release-tracker aria-live="polite">
-                <p class="release-tracker__placeholder">Loading release checklist…</p>
-              </div>
-              <nav
-                class="story-steps"
-                data-story-nav
-                role="tablist"
-                aria-label="Narrative walkthroughs"
-              ></nav>
-            </aside>
-            <article
-              class="story-panel"
-              data-story-content
-              aria-live="polite"
-            >
-              <p class="story-panel__placeholder">Loading narrative walkthroughs…</p>
-            </article>
-          </div>
-        </section>
-
-        <section>
-          <h2>Experiment backlog</h2>
-          <div class="card-grid" data-experiments aria-live="polite">
-            <article class="card card--placeholder">Loading lab experiments…</article>
-          </div>
-        </section>
-
-        <section>
-          <h2>Collaboration corner</h2>
-          <div class="grid-two">
-            <div class="chart-placeholder">Embed Loom walkthroughs and design prototypes here</div>
-            <div class="subsection">
-              <h3>How to contribute</h3>
-              <p>
-                Fork the repo, explore sample data inside the <code>public/data</code> directory, and
-                submit proposals for new modules. The lab champions iterative feedback and co-creation
-                across analysts, designers, and engineers.
-              </p>
-              <div class="badge-list" data-collaboration-tags></div>
-              <div class="collaboration-details" data-collaboration aria-live="polite">
-                <p class="collaboration-details__placeholder">Coordinating upcoming sync details…</p>
-              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="release-velocity" data-chart-ratio="0.55"></canvas>
             </div>
-          </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Status orbit</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Stage energy</span>
+                <span class="lab-chip lab-chip--accent" data-metric="status">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="status-orbit" data-chart-ratio="0.8"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Readiness radar</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Checklist peaks</span>
+                <span class="lab-chip lab-chip--accent" data-metric="readiness-max">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="readiness-radar" data-chart-ratio="0.85"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Launch gauge</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Average completion</span>
+                <span class="lab-chip lab-chip--accent" data-metric="readiness-avg">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="readiness-gauge" data-chart-ratio="1"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module lab-module--tall" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Experiment swarm</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Momentum map</span>
+                <span class="lab-chip lab-chip--accent" data-metric="experiment-horizon">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="experiment-swarm" data-chart-ratio="0.75"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module lab-module--tall" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Progression ladder</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Deepest stage</span>
+                <span class="lab-chip lab-chip--accent" data-metric="experiment-progress">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="experiment-ladder" data-chart-ratio="0.8"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Objective ribbon</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Cumulative briefs</span>
+                <span class="lab-chip lab-chip--accent" data-metric="objective-total">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="objective-ribbon" data-chart-ratio="0.6"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Agenda orbit</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Focus weight</span>
+                <span class="lab-chip lab-chip--accent" data-metric="agenda-span">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="agenda-orbit" data-chart-ratio="1"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Channel lattice</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Signal density</span>
+                <span class="lab-chip lab-chip--accent" data-metric="channel-count">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas viz-canvas--grid">
+              <canvas id="channel-grid" data-chart-ratio="0.75"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Contributor bloom</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Lead bandwidth</span>
+                <span class="lab-chip lab-chip--accent" data-metric="contributor-count">--</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="contributor-radial" data-chart-ratio="0.85"></canvas>
+            </div>
+          </article>
         </section>
       </main>
 
       <footer class="page-footer">Ideas incubated here will power the next wave of NBA experiences.</footer>
     </div>
+    <script src="vendor/chart.umd.js" defer></script>
     <script type="module" src="scripts/insights.js"></script>
   </body>
 </html>

--- a/public/scripts/insights.js
+++ b/public/scripts/insights.js
@@ -1,542 +1,970 @@
-import { helpers } from './hub-charts.js';
+import { registerCharts, helpers } from './hub-charts.js';
 
-const DATA_URL = 'data/storytelling_walkthroughs.json';
-const LAB_DATA_URL = 'data/insights_lab.json';
-const PANEL_ID = 'story-panel';
+const DATA_URL = 'data/insights_lab.json';
 
-function formatDate(value) {
-  if (!value) return null;
+const STAGE_WEIGHTS = {
+  released: 4.6,
+  'in progress': 3.4,
+  qa: 3.1,
+  discovery: 2.4,
+  planned: 1.8,
+};
+
+const STATUS_COLORS = {
+  released: '#1156d6',
+  'in progress': '#1f7bff',
+  qa: '#f4b53f',
+  discovery: '#ef3d5b',
+  planned: '#8e9eff',
+};
+
+const MONTH_INDEX = {
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
+};
+
+function stageWeight(status) {
+  if (!status) {
+    return 1.5;
+  }
+  const key = status.toLowerCase().trim();
+  return STAGE_WEIGHTS[key] ?? 2;
+}
+
+function statusColor(status) {
+  if (!status) {
+    return '#1156d6';
+  }
+  const key = status.toLowerCase().trim();
+  return STATUS_COLORS[key] ?? '#1f7bff';
+}
+
+function parseLabDate(value) {
+  if (!value) {
+    return null;
+  }
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function formatDateTime(value) {
-  if (!value) return null;
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return value;
+function parseTimeline(value) {
+  if (!value) {
+    return null;
   }
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
-  }).format(date);
+  const match = value.match(/\b(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+(\d{1,2})/i);
+  if (!match) {
+    return null;
+  }
+  const monthKey = match[1].slice(0, 3).toLowerCase();
+  const day = Number.parseInt(match[2], 10);
+  if (!Number.isFinite(day)) {
+    return null;
+  }
+  const now = new Date();
+  const monthIndex = MONTH_INDEX[monthKey];
+  if (!Number.isInteger(monthIndex)) {
+    return null;
+  }
+  const year = now.getMonth() > monthIndex ? now.getFullYear() + 1 : now.getFullYear();
+  const parsed = new Date(Date.UTC(year, monthIndex, day));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
-function formatMetric(entry) {
-  if (!entry) return null;
-  const { value, unit } = entry;
-  if (typeof value === 'number') {
-    const digits = Number.isInteger(value) ? 0 : 1;
-    const formatted = helpers.formatNumber(value, digits);
-    return unit ? `${formatted} ${unit}` : formatted;
-  }
-  if (typeof value === 'string') {
-    return unit ? `${value} ${unit}` : value;
-  }
-  return unit || '';
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
 }
 
-function clearChildren(node) {
-  if (!node) return;
-  while (node.firstChild) {
-    node.removeChild(node.firstChild);
+function sum(collection, accessor) {
+  if (!Array.isArray(collection) || !collection.length) {
+    return 0;
   }
+  return collection.reduce((total, item, index) => total + (accessor(item, index) || 0), 0);
 }
 
-function createElement(tag, className, textContent) {
-  const element = document.createElement(tag);
-  if (className) {
-    element.className = className;
-  }
-  if (typeof textContent === 'string') {
-    element.textContent = textContent;
-  }
-  return element;
-}
-
-function createStatusBadge(label) {
-  const badge = createElement('span', 'status-badge', label || 'Planned');
-  const status = (label || 'planned').toLowerCase().replace(/[^a-z0-9]+/g, '-');
-  badge.dataset.status = status;
-  return badge;
-}
-
-function renderChangelog(container, entries) {
-  if (!container) return;
-  clearChildren(container);
-
-  const items = Array.isArray(entries) ? entries.filter(Boolean) : [];
-  if (!items.length) {
-    container.appendChild(
-      createElement(
-        'p',
-        'changelog__placeholder',
-        'Changelog updates will appear once the next release ships.'
-      )
-    );
+function setMetric(key, value, fallback = '--') {
+  const target = document.querySelector(`[data-metric="${key}"]`);
+  if (!target) {
     return;
   }
+  const output = value === null || value === undefined || value === '' ? fallback : value;
+  target.textContent = output;
+}
 
-  const list = createElement('ul', 'changelog__list');
-  items
-    .slice()
-    .sort((a, b) => {
-      const dateA = a.date ? new Date(a.date).getTime() : Number.NEGATIVE_INFINITY;
-      const dateB = b.date ? new Date(b.date).getTime() : Number.NEGATIVE_INFINITY;
-      return dateB - dateA;
+function formatCountdown(nextSync) {
+  if (!nextSync) {
+    return 'Awaiting sync';
+  }
+  const now = new Date();
+  const diffMs = nextSync.getTime() - now.getTime();
+  if (diffMs <= 0) {
+    return 'Sync in progress';
+  }
+  const totalMinutes = Math.round(diffMs / 60000);
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes - days * 1440) / 60);
+  const minutes = Math.max(0, totalMinutes - days * 1440 - hours * 60);
+  const parts = [];
+  if (days) {
+    parts.push(`${days}d`);
+  }
+  if (hours) {
+    parts.push(`${hours}h`);
+  }
+  parts.push(`${minutes}m`);
+  return parts.slice(0, 3).join(' ');
+}
+
+function updateHero(data) {
+  const experiments = Array.isArray(data?.experiments) ? data.experiments.filter(Boolean) : [];
+  const checklist = Array.isArray(data?.releaseChecklist) ? data.releaseChecklist.filter(Boolean) : [];
+  const collaboration = data?.collaboration ?? {};
+  const collaborationBadges = Array.isArray(collaboration.badges) ? collaboration.badges.length : 0;
+  const collaborationChannels = Array.isArray(collaboration.channels) ? collaboration.channels.length : 0;
+  const collaborationContributors = Array.isArray(collaboration.contributors) ? collaboration.contributors.length : 0;
+  const totalCollaborationNodes = collaborationBadges + collaborationChannels + collaborationContributors;
+  const readinessAverage = checklist.length
+    ? sum(checklist, (item) => clamp(item.progress ?? 0, 0, 100)) / checklist.length
+    : null;
+
+  setMetric('experiments', `${helpers.formatNumber(experiments.length, 0)} live`);
+  setMetric(
+    'readiness',
+    readinessAverage === null ? 'Calibrating' : `${helpers.formatNumber(readinessAverage, 0)}% ready`
+  );
+  setMetric('collaboration', `${helpers.formatNumber(totalCollaborationNodes, 0)} links`);
+
+  const nextSync = collaboration.nextSync ? parseLabDate(collaboration.nextSync) : null;
+  setMetric('sync', formatCountdown(nextSync));
+}
+
+function updateModuleChips(data) {
+  const changelog = Array.isArray(data?.changelog) ? data.changelog.filter(Boolean) : [];
+  const experiments = Array.isArray(data?.experiments) ? data.experiments.filter(Boolean) : [];
+  const checklist = Array.isArray(data?.releaseChecklist) ? data.releaseChecklist.filter(Boolean) : [];
+  const collaboration = data?.collaboration ?? {};
+  const agendaItems = Array.isArray(collaboration.agenda) ? collaboration.agenda.filter(Boolean) : [];
+  const channels = Array.isArray(collaboration.channels) ? collaboration.channels.filter(Boolean) : [];
+  const contributors = Array.isArray(collaboration.contributors)
+    ? collaboration.contributors.filter(Boolean)
+    : [];
+
+  const highlightCounts = changelog.map((entry) =>
+    Array.isArray(entry.highlights) ? entry.highlights.filter(Boolean).length : 0
+  );
+  const velocityAverage = highlightCounts.length
+    ? sum(highlightCounts, (count) => count) / highlightCounts.length
+    : null;
+  setMetric('velocity', velocityAverage === null ? 'No launches yet' : `${helpers.formatNumber(velocityAverage, 1)} avg`);
+
+  const statusTotals = changelog.reduce((acc, entry) => {
+    const key = (entry.status || 'Planned').trim();
+    const base = acc.get(key) ?? 0;
+    const weight = stageWeight(entry.status);
+    const highlights = Array.isArray(entry.highlights) ? entry.highlights.length : 0;
+    acc.set(key, base + weight + highlights * 0.4);
+    return acc;
+  }, new Map());
+  const dominantStatus = Array.from(statusTotals.entries()).sort((a, b) => b[1] - a[1])[0];
+  setMetric('status', dominantStatus ? `${dominantStatus[0]} lead` : 'Awaiting cycles');
+
+  const readinessMax = checklist.slice().sort((a, b) => (b.progress ?? 0) - (a.progress ?? 0))[0];
+  setMetric(
+    'readiness-max',
+    readinessMax ? `${helpers.formatNumber(clamp(readinessMax.progress ?? 0, 0, 100), 0)}% · ${readinessMax.label}` : 'Checklist pending'
+  );
+
+  const readinessAverage = checklist.length
+    ? sum(checklist, (item) => clamp(item.progress ?? 0, 0, 100)) / checklist.length
+    : null;
+  setMetric(
+    'readiness-avg',
+    readinessAverage === null ? '0% avg' : `${helpers.formatNumber(readinessAverage, 0)}% avg`
+  );
+
+  const horizonDays = experiments
+    .map((experiment) => {
+      const timeline = parseTimeline(experiment.timeline);
+      if (!timeline) {
+        return null;
+      }
+      const diff = (timeline.getTime() - Date.now()) / 86400000;
+      return Number.isFinite(diff) ? diff : null;
     })
-    .forEach((entry) => {
-      const item = createElement('li', 'changelog__item');
+    .filter((value) => value !== null);
+  const soonestHorizon = horizonDays.length ? Math.min(...horizonDays) : null;
+  setMetric(
+    'experiment-horizon',
+    soonestHorizon === null ? 'No schedule set' : `${helpers.formatNumber(Math.max(0, soonestHorizon), 0)}d window`
+  );
 
-      const header = createElement('div', 'changelog__header');
-      if (entry.week) {
-        header.appendChild(createElement('span', 'changelog__week', entry.week));
-      }
-      if (entry.date) {
-        const dateLabel = createElement('time', 'changelog__date', formatDate(entry.date));
-        dateLabel.dateTime = entry.date;
-        header.appendChild(dateLabel);
-      }
-      if (entry.status) {
-        header.appendChild(createStatusBadge(entry.status));
-      }
-      item.appendChild(header);
+  const deepestStage = experiments
+    .map((experiment) => experiment.status)
+    .sort((a, b) => stageWeight(b) - stageWeight(a))[0];
+  setMetric('experiment-progress', deepestStage ? `${deepestStage} tier` : 'Stage TBD');
 
-      if (entry.summary) {
-        item.appendChild(createElement('p', 'changelog__summary', entry.summary));
-      }
+  const totalObjectives = sum(experiments, (experiment) =>
+    Array.isArray(experiment.objectives) ? experiment.objectives.filter(Boolean).length : 0
+  );
+  setMetric('objective-total', `${helpers.formatNumber(totalObjectives, 0)} objectives`);
 
-      const highlights = Array.isArray(entry.highlights) ? entry.highlights.filter(Boolean) : [];
-      if (highlights.length) {
-        const highlightList = createElement('ul', 'changelog__highlights');
-        highlights.forEach((highlight) => {
-          highlightList.appendChild(createElement('li', 'changelog__highlight', highlight));
-        });
-        item.appendChild(highlightList);
-      }
+  const agendaWeight = sum(agendaItems, (item) => item.length / 6);
+  setMetric('agenda-span', agendaItems.length ? `${helpers.formatNumber(agendaWeight, 0)} focus pts` : 'Agenda open');
 
-      if (entry.owner) {
-        const owner = createElement('p', 'changelog__owner');
-        owner.appendChild(createElement('span', 'changelog__owner-label', 'Owner'));
-        owner.appendChild(document.createTextNode(` · ${entry.owner}`));
-        item.appendChild(owner);
-      }
-
-      list.appendChild(item);
-    });
-
-  container.appendChild(list);
+  setMetric('channel-count', `${helpers.formatNumber(channels.length, 0)} channels`);
+  setMetric('contributor-count', `${helpers.formatNumber(contributors.length, 0)} leads`);
 }
 
-function renderExperiments(container, experiments) {
-  if (!container) return;
-  clearChildren(container);
-
-  const items = Array.isArray(experiments) ? experiments.filter(Boolean) : [];
-  if (!items.length) {
-    container.appendChild(
-      createElement('article', 'card card--placeholder', 'New experiment briefs will be posted soon.')
-    );
-    return;
+function createGradient(context, stops) {
+  const { chart } = context;
+  const { ctx, chartArea } = chart || {};
+  if (!ctx || !chartArea) {
+    return stops[0];
   }
-
-  items.forEach((experiment) => {
-    const card = createElement('article', 'card experiment-card');
-
-    const topRow = createElement('div', 'experiment-card__meta');
-    topRow.appendChild(createStatusBadge(experiment.status || 'Planned'));
-    if (experiment.owner) {
-      topRow.appendChild(createElement('span', 'experiment-card__owner', experiment.owner));
-    }
-    if (experiment.timeline) {
-      topRow.appendChild(createElement('span', 'experiment-card__timeline', experiment.timeline));
-    }
-    card.appendChild(topRow);
-
-    card.appendChild(
-      createElement('h3', 'experiment-card__title', experiment.title || 'Untitled experiment')
-    );
-
-    if (experiment.summary) {
-      card.appendChild(createElement('p', 'experiment-card__summary', experiment.summary));
-    }
-
-    const objectives = Array.isArray(experiment.objectives)
-      ? experiment.objectives.filter(Boolean)
-      : [];
-    if (objectives.length) {
-      const objectivesList = createElement('ul', 'experiment-card__objectives');
-      objectives.forEach((objective) => {
-        objectivesList.appendChild(createElement('li', null, objective));
-      });
-      card.appendChild(objectivesList);
-    }
-
-    const tags = Array.isArray(experiment.tags) ? experiment.tags.filter(Boolean) : [];
-    if (tags.length) {
-      const tagList = createElement('div', 'badge-list badge-list--compact');
-      tags.forEach((tag) => {
-        tagList.appendChild(createElement('span', 'badge', tag));
-      });
-      card.appendChild(tagList);
-    }
-
-    container.appendChild(card);
-  });
+  const gradient = ctx.createLinearGradient(chartArea.left, chartArea.bottom, chartArea.left, chartArea.top);
+  gradient.addColorStop(0, stops[0]);
+  gradient.addColorStop(1, stops[1] ?? stops[0]);
+  return gradient;
 }
 
-function renderCollaborationTags(container, badges) {
-  if (!container) return;
-  clearChildren(container);
-
-  const items = Array.isArray(badges) ? badges.filter(Boolean) : [];
-  if (!items.length) {
-    container.appendChild(createElement('span', 'badge badge--muted', 'Feedback welcome'));
-    return;
-  }
-
-  items.forEach((badge) => {
-    container.appendChild(createElement('span', 'badge', badge));
-  });
+function fallbackConfig(message) {
+  return {
+    type: 'doughnut',
+    data: {
+      labels: [''],
+      datasets: [
+        {
+          data: [1],
+          backgroundColor: ['rgba(17, 86, 214, 0.15)'],
+          borderWidth: 0,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: { enabled: false },
+        title: { display: true, text: message },
+      },
+    },
+  };
 }
 
-function renderCollaboration(container, details) {
-  if (!container) return;
-  clearChildren(container);
-
-  if (!details) {
-    container.appendChild(
-      createElement(
-        'p',
-        'collaboration-details__placeholder',
-        'Collaboration schedule will post once the next sprint is confirmed.'
-      )
-    );
-    return;
+function buildReleaseVelocityConfig(dataRef, helperRef) {
+  const changelog = Array.isArray(dataRef?.changelog) ? dataRef.changelog.filter(Boolean) : [];
+  if (!changelog.length) {
+    return fallbackConfig('Velocity data pending');
   }
+  const timeline = changelog
+    .map((entry, index) => {
+      const highlights = Array.isArray(entry.highlights) ? entry.highlights.filter(Boolean).length : 0;
+      const date = parseLabDate(entry.date);
+      const label =
+        entry.week ||
+        (date
+          ? new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(date)
+          : `Sprint ${index + 1}`);
+      return {
+        label,
+        highlights,
+        stage: stageWeight(entry.status),
+        timestamp: date ? date.getTime() : index,
+      };
+    })
+    .sort((a, b) => a.timestamp - b.timestamp);
 
-  if (details.nextSync) {
-    const next = createElement('p', 'collaboration-details__next');
-    const label = createElement('strong', null, 'Next sync');
-    next.appendChild(label);
-    const nextText = formatDateTime(details.nextSync);
-    const location = details.location ? ` · ${details.location}` : '';
-    next.appendChild(document.createTextNode(` · ${nextText}${location}`));
-    container.appendChild(next);
-  }
+  const labels = timeline.map((item) => item.label);
+  const highlightSeries = timeline.map((item) => item.highlights || 0);
+  const stageSeries = timeline.map((item) => item.stage * 10);
 
-  const agenda = Array.isArray(details.agenda) ? details.agenda.filter(Boolean) : [];
-  if (agenda.length) {
-    container.appendChild(createElement('p', 'collaboration-details__label', 'Agenda focus'));
-    const agendaList = createElement('ul', 'collaboration-details__agenda');
-    agenda.forEach((item) => {
-      agendaList.appendChild(createElement('li', null, item));
-    });
-    container.appendChild(agendaList);
-  }
-
-  const channels = Array.isArray(details.channels) ? details.channels.filter(Boolean) : [];
-  if (channels.length) {
-    container.appendChild(createElement('p', 'collaboration-details__label', 'Active channels'));
-    const channelList = createElement('dl', 'collaboration-details__channels');
-    channels.forEach((channel) => {
-      channelList.appendChild(createElement('dt', null, channel.label || 'Channel'));
-      channelList.appendChild(createElement('dd', null, channel.value || ''));
-    });
-    container.appendChild(channelList);
-  }
-
-  const contributors = Array.isArray(details.contributors) ? details.contributors.filter(Boolean) : [];
-  if (contributors.length) {
-    container.appendChild(createElement('p', 'collaboration-details__label', 'Contributor leads'));
-    const contributorList = createElement('ul', 'collaboration-details__contributors');
-    contributors.forEach((contributor) => {
-      const text = contributor.name
-        ? `${contributor.name}${contributor.focus ? ` — ${contributor.focus}` : ''}`
-        : contributor.focus || '';
-      contributorList.appendChild(createElement('li', null, text));
-    });
-    container.appendChild(contributorList);
-  }
+  return {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Highlights shipped',
+          data: highlightSeries,
+          fill: 'start',
+          tension: 0.42,
+          borderWidth: 2,
+          borderColor: '#1156d6',
+          backgroundColor: (context) =>
+            createGradient(context, ['rgba(17, 86, 214, 0.52)', 'rgba(17, 86, 214, 0.05)']),
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#1156d6',
+          pointBorderWidth: 2,
+          pointRadius: 4.5,
+          pointHoverRadius: 6,
+        },
+        {
+          label: 'Stage momentum',
+          data: stageSeries,
+          yAxisID: 'momentum',
+          borderColor: '#f4b53f',
+          borderWidth: 2,
+          borderDash: [6, 6],
+          tension: 0.35,
+          pointRadius: 0,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'Story highlights' },
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+        },
+        momentum: {
+          position: 'right',
+          beginAtZero: true,
+          grid: { drawOnChartArea: false },
+          ticks: {
+            callback: (value) => `${helperRef.formatNumber(value / 10, 1)}×`,
+          },
+          title: { display: true, text: 'Stage intensity' },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title(context) {
+              return `Sprint ${context[0]?.label ?? ''}`;
+            },
+            label(context) {
+              if (context.datasetIndex === 0) {
+                return `Highlights: ${helperRef.formatNumber(context.parsed.y, 0)}`;
+              }
+              return `Stage intensity: ${helperRef.formatNumber(context.parsed.y / 10, 1)}×`;
+            },
+          },
+        },
+      },
+    },
+  };
 }
 
-function renderReleaseChecklist(container, items) {
-  if (!container) return;
-  clearChildren(container);
+function buildStatusOrbitConfig(dataRef) {
+  const changelog = Array.isArray(dataRef?.changelog) ? dataRef.changelog.filter(Boolean) : [];
+  if (!changelog.length) {
+    return fallbackConfig('Statuses incoming');
+  }
+  const summary = changelog.reduce((acc, entry) => {
+    const label = entry.status || 'Planned';
+    const base = acc.get(label) ?? 0;
+    const highlights = Array.isArray(entry.highlights) ? entry.highlights.length : 0;
+    acc.set(label, base + stageWeight(entry.status) + highlights * 0.6);
+    return acc;
+  }, new Map());
 
-  const checklist = Array.isArray(items) ? items.filter(Boolean) : [];
+  const labels = Array.from(summary.keys());
+  const values = labels.map((label) => summary.get(label));
+  const palette = [
+    'rgba(17, 86, 214, 0.72)',
+    'rgba(31, 123, 255, 0.7)',
+    'rgba(239, 61, 91, 0.7)',
+    'rgba(244, 181, 63, 0.72)',
+    'rgba(11, 37, 69, 0.72)',
+  ];
+
+  return {
+    type: 'polarArea',
+    data: {
+      labels,
+      datasets: [
+        {
+          data: values,
+          backgroundColor: labels.map((_, index) => palette[index % palette.length]),
+          borderColor: 'rgba(255, 255, 255, 0.6)',
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        r: {
+          ticks: { display: false },
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+        },
+      },
+      plugins: {
+        legend: { position: 'bottom' },
+      },
+    },
+  };
+}
+
+function buildReadinessRadarConfig(dataRef) {
+  const checklist = Array.isArray(dataRef?.releaseChecklist)
+    ? dataRef.releaseChecklist.filter(Boolean)
+    : [];
   if (!checklist.length) {
-    container.appendChild(
-      createElement(
-        'p',
-        'release-tracker__placeholder',
-        'Add launch criteria to track readiness for the storytelling release.'
-      )
-    );
-    return;
+    return fallbackConfig('Checklist loading');
   }
+  const labels = checklist.map((item) => item.label || 'Milestone');
+  const progressValues = checklist.map((item) => clamp(item.progress ?? 0, 0, 100));
 
-  container.appendChild(createElement('p', 'release-tracker__title', 'Launch readiness'));
-
-  const list = createElement('ul', 'release-checklist');
-  checklist.forEach((item) => {
-    const value = typeof item.progress === 'number' ? Math.min(Math.max(item.progress, 0), 100) : 0;
-    const listItem = createElement('li', 'release-checklist__item');
-    listItem.appendChild(
-      createElement('span', 'release-checklist__label', item.label || 'Checklist item')
-    );
-
-    const progressWrapper = createElement('div', 'release-checklist__progress');
-    const progressBar = createElement('div', 'release-checklist__progress-bar');
-    progressBar.style.setProperty('--progress', `${value}%`);
-    progressBar.setAttribute('role', 'progressbar');
-    progressBar.setAttribute('aria-valuemin', '0');
-    progressBar.setAttribute('aria-valuemax', '100');
-    progressBar.setAttribute('aria-valuenow', String(value));
-    progressBar.setAttribute(
-      'aria-label',
-      `${item.label || 'Checklist item'} — ${helpers.formatNumber(value, 0)}%`
-    );
-    progressWrapper.appendChild(progressBar);
-    listItem.appendChild(progressWrapper);
-    listItem.appendChild(
-      createElement('span', 'release-checklist__progress-value', `${helpers.formatNumber(value, 0)}%`)
-    );
-    list.appendChild(listItem);
-  });
-
-  container.appendChild(list);
+  return {
+    type: 'radar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Readiness amplitude',
+          data: progressValues,
+          backgroundColor: 'rgba(17, 86, 214, 0.25)',
+          borderColor: '#1156d6',
+          pointBackgroundColor: '#f5f8ff',
+          pointBorderColor: '#1156d6',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        r: {
+          suggestedMin: 0,
+          suggestedMax: 100,
+          ticks: { display: false },
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+          angleLines: { color: 'rgba(17, 86, 214, 0.08)' },
+        },
+      },
+      plugins: { legend: { display: false } },
+    },
+  };
 }
 
-function renderMeta(target, release) {
-  if (!target) return;
-  clearChildren(target);
+function buildGaugeConfig(dataRef, helperRef) {
+  const checklist = Array.isArray(dataRef?.releaseChecklist)
+    ? dataRef.releaseChecklist.filter(Boolean)
+    : [];
+  const readinessAverage = checklist.length
+    ? sum(checklist, (item) => clamp(item.progress ?? 0, 0, 100)) / checklist.length
+    : 0;
+  const dataset = [clamp(readinessAverage, 0, 100), Math.max(0, 100 - readinessAverage)];
 
-  if (!release) {
-    target.appendChild(createElement('p', 'story-meta__placeholder', 'Release details unavailable.'));
-    return;
-  }
-
-  const badgeLabel = release.version || release.phase || 'Release';
-  const badge = createElement('span', 'story-meta__badge', badgeLabel);
-
-  const phase = release.phase ? createElement('p', 'story-meta__phase', release.phase) : null;
-  const updated = formatDate(release.updated);
-  const metaList = createElement('div', 'story-meta__details');
-
-  if (phase) {
-    metaList.appendChild(phase);
-  }
-  if (updated) {
-    metaList.appendChild(createElement('p', 'story-meta__updated', `Updated ${updated}`));
-  }
-  if (release.summary) {
-    metaList.appendChild(createElement('p', 'story-meta__summary', release.summary));
-  }
-
-  target.appendChild(badge);
-  target.appendChild(metaList);
-}
-
-function renderStoryPanel(container, story, index) {
-  if (!container || !story) return;
-  clearChildren(container);
-
-  container.id = PANEL_ID;
-  container.setAttribute('role', 'tabpanel');
-  container.setAttribute('tabindex', '0');
-
-  const header = createElement('header', 'story-step__header');
-  header.appendChild(createElement('p', 'story-step__lede', story.lede || ''));
-  header.appendChild(createElement('h3', 'story-step__title', story.title || `Story ${index + 1}`));
-
-  const metricSection = createElement('section', 'story-step__metrics');
-  const primaryMetric = createElement('div', 'story-metric story-metric--primary');
-  primaryMetric.appendChild(createElement('span', 'story-metric__label', story.metric?.label || 'Headline metric'));
-  primaryMetric.appendChild(createElement('strong', 'story-metric__value', formatMetric(story.metric) || ''));
-  if (story.metric?.context) {
-    primaryMetric.appendChild(createElement('span', 'story-metric__context', story.metric.context));
-  }
-  metricSection.appendChild(primaryMetric);
-
-  const spotlights = Array.isArray(story.spotlights) ? story.spotlights : [];
-  if (spotlights.length) {
-    const list = createElement('ul', 'story-spotlights');
-    spotlights.forEach((spotlight) => {
-      const item = createElement('li', 'story-spotlight');
-      item.appendChild(createElement('span', 'story-spotlight__label', spotlight.label || ''));
-      item.appendChild(createElement('span', 'story-spotlight__value', formatMetric(spotlight) || ''));
-      if (spotlight.context) {
-        item.appendChild(createElement('span', 'story-spotlight__context', spotlight.context));
+  const gaugeLabel = {
+    id: 'labGaugeLabel',
+    afterDraw(chart) {
+      const { ctx } = chart;
+      const meta = chart.getDatasetMeta(0);
+      const center = meta?.data?.[0];
+      if (!center) {
+        return;
       }
-      list.appendChild(item);
-    });
-    metricSection.appendChild(list);
-  }
+      ctx.save();
+      ctx.fillStyle = '#0b2545';
+      ctx.font = '600 1.6rem "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(`${helperRef.formatNumber(readinessAverage, 0)}%`, center.x, center.y - 6);
+      ctx.font = '500 0.75rem "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+      ctx.fillStyle = 'rgba(11, 37, 69, 0.65)';
+      ctx.fillText('ready', center.x, center.y + 14);
+      ctx.restore();
+    },
+  };
 
-  const editorial = Array.isArray(story.editorial) ? story.editorial : [];
-  const copy = createElement('div', 'story-step__body');
-  if (editorial.length) {
-    editorial.forEach((paragraph) => {
-      copy.appendChild(createElement('p', null, paragraph));
-    });
-  }
-
-  if (Array.isArray(story.sources) && story.sources.length) {
-    const sources = createElement('div', 'story-sources');
-    sources.appendChild(createElement('span', 'story-sources__label', 'Data sources:'));
-    story.sources.forEach((source) => {
-      sources.appendChild(createElement('code', 'story-sources__tag', source));
-    });
-    copy.appendChild(sources);
-  }
-
-  container.appendChild(header);
-  container.appendChild(metricSection);
-  container.appendChild(copy);
+  return {
+    type: 'doughnut',
+    data: {
+      labels: ['Ready', 'In motion'],
+      datasets: [
+        {
+          data: dataset,
+          backgroundColor: ['#1156d6', 'rgba(17, 86, 214, 0.12)'],
+          borderWidth: 0,
+          hoverBackgroundColor: ['#0b2545', 'rgba(17, 86, 214, 0.18)'],
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      cutout: '70%',
+      rotation: -110,
+      circumference: 220,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              return `${context.label}: ${helperRef.formatNumber(context.parsed, 0)}%`;
+            },
+          },
+        },
+      },
+    },
+    plugins: [gaugeLabel],
+  };
 }
 
-function setupStorytelling(board, data) {
-  const nav = board.querySelector('[data-story-nav]');
-  const content = board.querySelector('[data-story-content]');
-  const meta = board.querySelector('[data-story-meta]');
-  renderMeta(meta, data?.release);
-
-  const stories = Array.isArray(data?.stories) ? data.stories.filter(Boolean) : [];
-  if (!stories.length) {
-    clearChildren(content);
-    content.appendChild(createElement('p', 'story-panel__placeholder', 'Narrative walkthroughs are on the way.'));
-    return;
+function buildExperimentSwarmConfig(dataRef) {
+  const experiments = Array.isArray(dataRef?.experiments) ? dataRef.experiments.filter(Boolean) : [];
+  if (!experiments.length) {
+    return fallbackConfig('Experiments warming up');
   }
-
-  const buttons = [];
-  clearChildren(nav);
-  stories.forEach((story, index) => {
-    const button = createElement('button', 'story-step__trigger');
-    button.type = 'button';
-    const tabId = `story-tab-${story.id || index}`;
-    const panelId = PANEL_ID;
-    button.id = tabId;
-    button.setAttribute('role', 'tab');
-    button.setAttribute('aria-controls', panelId);
-    button.setAttribute('tabindex', index === 0 ? '0' : '-1');
-    button.innerHTML = `
-      <span class="story-step__index">${String(index + 1).padStart(2, '0')}</span>
-      <span class="story-step__summary">
-        <strong>${story.title || `Story ${index + 1}`}</strong>
-        <span>${story.metric?.label || story.lede || ''}</span>
-      </span>
-    `;
-    button.addEventListener('click', () => activate(index));
-    nav.appendChild(button);
-    buttons.push(button);
+  const now = Date.now();
+  const points = experiments.map((experiment, index) => {
+    const objectives = Array.isArray(experiment.objectives) ? experiment.objectives.filter(Boolean).length : 0;
+    const stage = stageWeight(experiment.status);
+    const timeline = parseTimeline(experiment.timeline);
+    const daysUntil = timeline ? (timeline.getTime() - now) / 86400000 : (index + 1) * 6;
+    const normalizedDays = clamp(daysUntil, -14, 40);
+    return {
+      x: stage * 24 + index * 6,
+      y: (objectives || 1) * 14 + stage * 3,
+      r: clamp(28 - normalizedDays, 12, 32),
+      status: experiment.status || 'Planned',
+      owner: experiment.owner || 'Unassigned',
+      title: experiment.title || `Experiment ${index + 1}`,
+      timeline: experiment.timeline || 'Timeline TBD',
+      background: statusColor(experiment.status),
+    };
   });
 
-  nav.addEventListener('keydown', (event) => {
-    if (!['ArrowRight', 'ArrowLeft'].includes(event.key)) {
-      return;
-    }
-    event.preventDefault();
-    const current = buttons.findIndex((button) => button.classList.contains('is-active'));
-    const startingIndex = current === -1 ? 0 : current;
-    const direction = event.key === 'ArrowRight' ? 1 : -1;
-    const nextIndex = (startingIndex + direction + stories.length) % stories.length;
-    buttons[nextIndex].focus();
-    activate(nextIndex);
-  });
-
-  function activate(index) {
-    const story = stories[index];
-    if (!story) {
-      return;
-    }
-    buttons.forEach((button, buttonIndex) => {
-      const isActive = buttonIndex === index;
-      button.classList.toggle('is-active', isActive);
-      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
-      button.setAttribute('tabindex', isActive ? '0' : '-1');
-    });
-    renderStoryPanel(content, story, index);
-    const activeButton = buttons[index];
-    if (activeButton) {
-      content.setAttribute('aria-labelledby', activeButton.id);
-    }
-  }
-
-  activate(0);
+  return {
+    type: 'bubble',
+    data: {
+      datasets: [
+        {
+          label: 'Lab experiments',
+          data: points,
+          backgroundColor: points.map((point) => point.background),
+          borderColor: 'rgba(255, 255, 255, 0.6)',
+          borderWidth: 1.4,
+          hoverBorderWidth: 2.4,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          title: { display: true, text: 'Stage momentum' },
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+        },
+        y: {
+          title: { display: true, text: 'Objective stack' },
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title(context) {
+              return context[0]?.raw?.title ?? '';
+            },
+            label(context) {
+              const raw = context.raw || {};
+              return [
+                `Status: ${raw.status}`,
+                `Owner: ${raw.owner}`,
+                `Timeline: ${raw.timeline}`,
+                `Signal radius: ${helpers.formatNumber(raw.r, 0)}`,
+              ];
+            },
+          },
+        },
+      },
+    },
+  };
 }
 
-async function initStorytelling() {
-  const board = document.querySelector('[data-storyboard]');
-  if (!board) {
-    return;
+function buildExperimentLadderConfig(dataRef, helperRef) {
+  const experiments = Array.isArray(dataRef?.experiments) ? dataRef.experiments.filter(Boolean) : [];
+  if (!experiments.length) {
+    return fallbackConfig('Ladder forming');
   }
+  const labels = experiments.map((experiment, index) => experiment.title || `Experiment ${index + 1}`);
+  const depths = experiments.map((experiment) => stageWeight(experiment.status) * 25);
+  const colors = experiments.map((experiment) => statusColor(experiment.status));
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Stage depth',
+          data: depths,
+          backgroundColor: colors,
+          borderRadius: 14,
+          borderSkipped: false,
+        },
+      ],
+    },
+    options: {
+      indexAxis: 'y',
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          display: false,
+          grid: { display: false },
+        },
+        y: {
+          ticks: {
+            callback: (value, index) => labels[index] ?? value,
+          },
+          grid: { color: 'rgba(17, 86, 214, 0.05)' },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              const stage = experiments[context.dataIndex]?.status || 'Stage';
+              return `${stage}: ${helperRef.formatNumber(context.parsed.x / 25, 1)} tiers`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildObjectiveRibbonConfig(dataRef, helperRef) {
+  const experiments = Array.isArray(dataRef?.experiments) ? dataRef.experiments.filter(Boolean) : [];
+  if (!experiments.length) {
+    return fallbackConfig('Objective ribbon pending');
+  }
+  const sequence = experiments
+    .map((experiment, index) => ({
+      experiment,
+      index,
+      timeline: parseTimeline(experiment.timeline) || index,
+    }))
+    .sort((a, b) => {
+      const aTime = a.timeline instanceof Date ? a.timeline.getTime() : a.timeline;
+      const bTime = b.timeline instanceof Date ? b.timeline.getTime() : b.timeline;
+      return aTime - bTime;
+    });
+
+  let running = 0;
+  const labels = [];
+  const cumulative = [];
+  const stageLift = [];
+
+  sequence.forEach(({ experiment }, order) => {
+    const objectives = Array.isArray(experiment.objectives) ? experiment.objectives.filter(Boolean).length : 0;
+    running += objectives;
+    labels.push(experiment.title || `Experiment ${order + 1}`);
+    cumulative.push(running);
+    stageLift.push(stageWeight(experiment.status) * 10);
+  });
+
+  return {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Cumulative objectives',
+          data: cumulative,
+          fill: 'start',
+          tension: 0.42,
+          borderColor: '#ef3d5b',
+          backgroundColor: (context) =>
+            createGradient(context, ['rgba(239, 61, 91, 0.34)', 'rgba(239, 61, 91, 0.04)']),
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#ef3d5b',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+        {
+          label: 'Stage lift',
+          data: stageLift,
+          yAxisID: 'lift',
+          borderColor: '#1f7bff',
+          borderDash: [8, 6],
+          borderWidth: 2,
+          pointRadius: 0,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'Objectives aggregated' },
+          grid: { color: 'rgba(239, 61, 91, 0.1)' },
+        },
+        lift: {
+          position: 'right',
+          beginAtZero: true,
+          grid: { drawOnChartArea: false },
+          ticks: {
+            callback: (value) => `${helperRef.formatNumber(value / 10, 1)}×`,
+          },
+          title: { display: true, text: 'Stage lift' },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              if (context.datasetIndex === 0) {
+                return `Cumulative objectives: ${helperRef.formatNumber(context.parsed.y, 0)}`;
+              }
+              return `Stage lift: ${helperRef.formatNumber(context.parsed.y / 10, 1)}×`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildAgendaOrbitConfig(dataRef) {
+  const agenda = Array.isArray(dataRef?.collaboration?.agenda)
+    ? dataRef.collaboration.agenda.filter(Boolean)
+    : [];
+  if (!agenda.length) {
+    return fallbackConfig('Agenda orbit loading');
+  }
+  const weights = agenda.map((item) => Math.max(2, item.length / 14));
+
+  return {
+    type: 'doughnut',
+    data: {
+      labels: agenda,
+      datasets: [
+        {
+          data: weights,
+          backgroundColor: agenda.map((_, index) =>
+            `hsl(${(index / agenda.length) * 220 + 200}, 76%, 62%)`
+          ),
+          borderColor: 'rgba(255, 255, 255, 0.65)',
+          borderWidth: 1.2,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      cutout: '58%',
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              return `${context.label}: ${helpers.formatNumber(context.parsed, 1)} weight`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildChannelGridConfig(dataRef) {
+  const channels = Array.isArray(dataRef?.collaboration?.channels)
+    ? dataRef.collaboration.channels.filter(Boolean)
+    : [];
+  const badges = Array.isArray(dataRef?.collaboration?.badges)
+    ? dataRef.collaboration.badges.filter(Boolean)
+    : [];
+  if (!channels.length || !badges.length) {
+    return fallbackConfig('Channel lattice calibrating');
+  }
+  const labels = channels.map((channel) => channel.label || 'Channel');
+  const palette = ['#1156d6', '#1f7bff', '#ef3d5b', '#f4b53f', '#0b2545'];
+  const datasets = badges.map((badge, index) => ({
+    label: badge,
+    data: channels.map((channel) => {
+      const base = (channel.value || '').length || 6;
+      return Math.round(base / 2 + badge.length);
+    }),
+    backgroundColor: palette[index % palette.length],
+    stack: 'signal-density',
+    borderRadius: 18,
+    borderSkipped: false,
+  }));
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets,
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          stacked: true,
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+        },
+        y: {
+          stacked: true,
+          beginAtZero: true,
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+          ticks: {
+            callback: (value) => helpers.formatNumber(value, 0),
+          },
+        },
+      },
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              return `${context.dataset.label}: ${helpers.formatNumber(context.parsed.y, 0)} signal units`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildContributorBloomConfig(dataRef) {
+  const contributors = Array.isArray(dataRef?.collaboration?.contributors)
+    ? dataRef.collaboration.contributors.filter(Boolean)
+    : [];
+  if (!contributors.length) {
+    return fallbackConfig('Contributor bloom forming');
+  }
+  const count = contributors.length;
+  const baseRadius = 64;
+  const points = contributors.map((contributor, index) => {
+    const angle = (Math.PI * 2 * index) / count;
+    const focusStrength = (contributor.focus || '').length / 2 + 18;
+    const radius = baseRadius + focusStrength;
+    return {
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius,
+      label: contributor.name || `Contributor ${index + 1}`,
+      focus: contributor.focus || 'Focus TBD',
+    };
+  });
+  points.push(points[0]);
+
+  return {
+    type: 'scatter',
+    data: {
+      datasets: [
+        {
+          label: 'Collaboration halo',
+          data: points,
+          showLine: true,
+          fill: true,
+          tension: 0.35,
+          backgroundColor: 'rgba(17, 86, 214, 0.18)',
+          borderColor: 'rgba(239, 61, 91, 0.65)',
+          borderWidth: 2,
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#1156d6',
+          pointBorderWidth: 2,
+          pointRadius: 5,
+          pointHoverRadius: 7,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        x: { display: false, min: -160, max: 160 },
+        y: { display: false, min: -160, max: 160 },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title(context) {
+              return context[0]?.raw?.label ?? '';
+            },
+            label(context) {
+              return context.raw?.focus ? [context.raw.focus] : ['Focus TBD'];
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function registerLabCharts(dataRef) {
+  registerCharts([
+    {
+      element: '#release-velocity',
+      createConfig: (_, helperRef) => buildReleaseVelocityConfig(dataRef, helperRef),
+    },
+    {
+      element: '#status-orbit',
+      createConfig: () => buildStatusOrbitConfig(dataRef),
+    },
+    {
+      element: '#readiness-radar',
+      createConfig: () => buildReadinessRadarConfig(dataRef),
+    },
+    {
+      element: '#readiness-gauge',
+      createConfig: (_, helperRef) => buildGaugeConfig(dataRef, helperRef),
+    },
+    {
+      element: '#experiment-swarm',
+      createConfig: () => buildExperimentSwarmConfig(dataRef),
+    },
+    {
+      element: '#experiment-ladder',
+      createConfig: (_, helperRef) => buildExperimentLadderConfig(dataRef, helperRef),
+    },
+    {
+      element: '#objective-ribbon',
+      createConfig: (_, helperRef) => buildObjectiveRibbonConfig(dataRef, helperRef),
+    },
+    {
+      element: '#agenda-orbit',
+      createConfig: () => buildAgendaOrbitConfig(dataRef),
+    },
+    {
+      element: '#channel-grid',
+      createConfig: () => buildChannelGridConfig(dataRef),
+    },
+    {
+      element: '#contributor-radial',
+      createConfig: () => buildContributorBloomConfig(dataRef),
+    },
+  ]);
+}
+
+async function hydrateLab() {
   try {
     const response = await fetch(DATA_URL);
     if (!response.ok) {
-      throw new Error(`Failed to fetch storytelling data: ${response.status}`);
+      throw new Error(`Failed to fetch lab data: ${response.status}`);
     }
     const data = await response.json();
-    setupStorytelling(board, data);
+    updateHero(data);
+    updateModuleChips(data);
+    registerLabCharts(data);
   } catch (error) {
-    console.error('Storytelling release failed to load', error);
-    const meta = board.querySelector('[data-story-meta]');
-    const content = board.querySelector('[data-story-content]');
-    renderMeta(meta, null);
-    if (content) {
-      clearChildren(content);
-      content.appendChild(
-        createElement(
-          'p',
-          'story-panel__placeholder',
-          'We could not load the narrative walkthroughs. Refresh to try again.'
-        )
-      );
-    }
+    console.error('Failed to hydrate insights lab', error);
   }
 }
 
-async function initLabData() {
-  const changelog = document.querySelector('[data-changelog]');
-  const experiments = document.querySelector('[data-experiments]');
-  const collaboration = document.querySelector('[data-collaboration]');
-  const collaborationTags = document.querySelector('[data-collaboration-tags]');
-  const releaseTracker = document.querySelector('[data-release-tracker]');
-
-  if (!changelog && !experiments && !collaboration && !collaborationTags && !releaseTracker) {
-    return;
-  }
-
-  try {
-    const response = await fetch(LAB_DATA_URL);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch insights lab data: ${response.status}`);
-    }
-    const data = await response.json();
-    renderChangelog(changelog, data?.changelog);
-    renderExperiments(experiments, data?.experiments);
-    renderCollaboration(collaboration, data?.collaboration);
-    renderCollaborationTags(collaborationTags, data?.collaboration?.badges);
-    renderReleaseChecklist(releaseTracker, data?.releaseChecklist);
-  } catch (error) {
-    console.error('Insights Lab data failed to load', error);
-    renderChangelog(changelog, null);
-    renderExperiments(experiments, null);
-    renderCollaboration(collaboration, null);
-    renderCollaborationTags(collaborationTags, null);
-    renderReleaseChecklist(releaseTracker, null);
-  }
-}
-
-initStorytelling();
-initLabData();
+hydrateLab();

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -644,6 +644,47 @@ a:hover, a:focus { color: var(--sky); }
   justify-content: center;
 }
 
+.hero--lab {
+  padding: clamp(2.4rem, 5vw, 3.2rem) clamp(1.6rem, 4vw, 2.4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    radial-gradient(120% 120% at 18% 12%, rgba(17, 86, 214, 0.32), transparent 62%),
+    radial-gradient(130% 130% at 82% 8%, rgba(239, 61, 91, 0.25), transparent 66%),
+    linear-gradient(155deg, rgba(17, 86, 214, 0.15), rgba(244, 181, 63, 0.12)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: 0 26px 48px rgba(11, 37, 69, 0.2);
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2.2rem);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero--lab::after {
+  content: '';
+  position: absolute;
+  inset: auto -18% -48% 55%;
+  height: clamp(260px, 38vw, 340px);
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(31, 123, 255, 0.22), transparent 70%);
+  opacity: 0.7;
+}
+
+.hero--lab > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero--lab .hero__intro {
+  margin: 0;
+  text-align: left;
+  gap: 0.75rem;
+}
+
+.hero--lab h1 {
+  margin: 0;
+}
+
 .power-board {
   width: min(100%, 840px);
   display: grid;
@@ -852,6 +893,34 @@ a:hover, a:focus { color: var(--sky); }
 }
 .hero-metrics dd { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
 
+.hero-metrics--lab {
+  margin: 0;
+  width: 100%;
+  padding: clamp(1.1rem, 2.4vw, 1.6rem);
+  gap: clamp(0.9rem, 2vw, 1.3rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  background:
+    linear-gradient(145deg, rgba(17, 86, 214, 0.12), rgba(31, 123, 255, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 65%, rgba(242, 246, 255, 0.92) 35%);
+}
+
+.hero-metrics--lab .hero-metrics__item {
+  padding: 0.35rem 0.2rem;
+}
+
+.hero-metrics--lab dd {
+  font-size: clamp(1.35rem, 2.8vw, 1.75rem);
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.hero-metrics--lab dd small {
+  display: block;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-subtle);
+}
+
 .hero-panels {
   margin: 2rem auto 0;
   display: grid;
@@ -1018,6 +1087,156 @@ main { display: grid; gap: 1.75rem; }
 section {
   background: var(--surface); border-radius: var(--radius-lg);
   padding: 1.4rem clamp(1.25rem, 3.5vw, 2.1rem); box-shadow: var(--shadow-soft); border: 1px solid var(--border);
+}
+
+.lab-content {
+  display: block;
+  margin-top: clamp(2.4rem, 5vw, 3.4rem);
+}
+
+.lab-content > .lab-grid {
+  padding: 0;
+  border: 0;
+  box-shadow: none;
+  background: transparent;
+}
+
+.lab-grid {
+  display: grid;
+  gap: clamp(1.35rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-auto-rows: minmax(260px, auto);
+}
+
+.lab-module {
+  position: relative;
+  display: grid;
+  gap: clamp(0.85rem, 2vw, 1.4rem);
+  padding: clamp(1.1rem, 2.6vw, 1.7rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    radial-gradient(160% 140% at 8% 6%, rgba(17, 86, 214, 0.2), transparent 60%),
+    radial-gradient(150% 150% at 92% -8%, rgba(244, 181, 63, 0.22), transparent 64%),
+    linear-gradient(150deg, rgba(17, 86, 214, 0.08), rgba(31, 123, 255, 0.06)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 74%, rgba(242, 246, 255, 0.92) 26%);
+  box-shadow: 0 18px 32px rgba(11, 37, 69, 0.16);
+  overflow: hidden;
+}
+
+.lab-module::after {
+  content: '';
+  position: absolute;
+  inset: auto -35% -60% 45%;
+  height: clamp(220px, 32vw, 300px);
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(17, 86, 214, 0.16), transparent 72%);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.lab-module > * {
+  position: relative;
+  z-index: 1;
+}
+
+.lab-module--wide {
+  grid-column: span 2;
+}
+
+.lab-module--tall {
+  grid-row: span 2;
+}
+
+.lab-module__header {
+  display: grid;
+  gap: 0.65rem;
+  align-content: start;
+}
+
+.lab-module__header h2 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2.6vw, 1.55rem);
+  letter-spacing: -0.01em;
+}
+
+.lab-module__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.lab-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--royal);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
+}
+
+.lab-chip--accent {
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.95), rgba(239, 61, 91, 0.8));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(17, 86, 214, 0.35);
+}
+
+.viz-canvas {
+  position: relative;
+  border-radius: var(--radius-md);
+  padding: clamp(0.6rem, 1.8vw, 0.9rem);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.12), rgba(31, 123, 255, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.92) 30%);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  min-height: 220px;
+  display: flex;
+  align-items: stretch;
+}
+
+.lab-module--tall .viz-canvas {
+  min-height: clamp(300px, 42vw, 380px);
+}
+
+.viz-canvas::before {
+  content: '';
+  position: absolute;
+  inset: 12% 18% auto;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(17, 86, 214, 0.35), rgba(255, 255, 255, 0));
+  opacity: 0.9;
+}
+
+.viz-canvas canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.viz-canvas--grid {
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.12), rgba(17, 86, 214, 0.02)),
+    repeating-linear-gradient(0deg, rgba(17, 86, 214, 0.08), rgba(17, 86, 214, 0.08) 1px, transparent 1px, transparent 22px),
+    repeating-linear-gradient(90deg, rgba(17, 86, 214, 0.08), rgba(17, 86, 214, 0.08) 1px, transparent 1px, transparent 22px),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.92) 30%);
+}
+
+@media (max-width: 900px) {
+  .lab-module--wide {
+    grid-column: span 1;
+  }
+  .lab-module--tall {
+    grid-row: span 1;
+  }
+  .lab-module::after {
+    inset: auto -40% -70% 38%;
+  }
 }
 
 .spotlight-itinerary {


### PR DESCRIPTION
## Summary
- replace the Insights Lab page with a visualization-first layout that features ten experimental canvases and live hero metrics
- expand hub styles with bespoke lab modules, chips, and hero treatment to frame the new data stories
- rebuild the Insights Lab script to hydrate metrics and register the custom Chart.js dashboards from lab data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d88b12e2488327ba42284fb50053e1