### PR TITLE
Refactor history page with expanded visualizations

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -29,104 +29,182 @@
         <div class="hero">
           <span class="eyebrow">League Archive</span>
           <h1>Chronicle the eras that shaped today's game.</h1>
-          <p>
-            Plug into curated timelines, record books, and attendance milestones to turn archival datasets
-            into rich interactive retrospectives.
-          </p>
+          <div class="history-hero-metrics">
+            <article class="history-hero-metric history-hero-metric--primary">
+              <span class="history-hero-metric__label">Games logged</span>
+              <span class="history-hero-metric__value" data-history="total-games">--</span>
+              <span class="history-hero-metric__context">
+                <span data-history="first-game">--</span>
+                <span class="history-hero-metric__divider">to</span>
+                <span data-history="latest-game">--</span>
+              </span>
+            </article>
+            <article class="history-hero-metric">
+              <span class="history-hero-metric__label">Playoff catalog</span>
+              <span class="history-hero-metric__value" data-history="playoff-games">--</span>
+              <span class="history-hero-metric__context" data-history="playoff-share">--</span>
+            </article>
+            <article class="history-hero-metric">
+              <span class="history-hero-metric__label">Attendance record</span>
+              <span class="history-hero-metric__value history-hero-metric__value--compact" data-history="attendance-record">--</span>
+            </article>
+          </div>
         </div>
       </header>
 
       <main>
-        <section>
-          <h2>Era explorer</h2>
-          <p class="lead">
-            Trace the league's growth decade by decade and see how expansion bursts, archival coverage, and
-            postseason logs stack up across the NBA timeline.
-          </p>
-
-          <div class="summary-cards summary-cards--compact">
-            <article class="summary-card">
-              <strong>Archive breadth</strong>
-              <p>
-                <span data-history="total-games">--</span> games logged from
-                <span data-history="first-game">--</span> through <span data-history="latest-game">--</span>.
-              </p>
-            </article>
-            <article class="summary-card">
-              <strong>Postseason catalog</strong>
-              <p>
-                <span data-history="playoff-games">--</span> playoff contests, representing
-                <span data-history="playoff-share">--</span> of the archive.
-              </p>
-            </article>
-            <article class="summary-card">
-              <strong>Attendance record</strong>
-              <p data-history="attendance-record">--</p>
-            </article>
+        <section class="history-section">
+          <div class="history-section__header">
+            <h2>Timeline atlas</h2>
+            <div class="history-badges">
+              <span class="history-badge">
+                <span class="history-badge__label">Active franchises</span>
+                <span class="history-badge__value" data-history="franchise-count">--</span>
+              </span>
+              <span class="history-badge">
+                <span class="history-badge__label">Peak expansion</span>
+                <span class="history-badge__value">
+                  <span data-history="peak-expansion-decade">--</span>
+                  <span class="history-badge__divider">•</span>
+                  <span data-history="peak-expansion-total">--</span>
+                </span>
+              </span>
+            </div>
           </div>
 
-          <div class="grid-two">
+          <div class="history-mosaic history-mosaic--wide">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Games logged by decade</header>
               <div class="viz-canvas">
                 <canvas data-chart="games-by-decade" aria-describedby="games-by-decade-caption"></canvas>
               </div>
               <figcaption id="games-by-decade-caption" class="viz-card__caption">
-                A filled line plot surfaces how the volume of tracked matchups accelerated from the early BAA
-                seasons through the modern 2020s slate.
+                A filled spline highlights how the archive scales from the BAA launch through today's slate.
               </figcaption>
             </figure>
-            <div class="subsection">
-              <h3>Expansion timeline</h3>
-              <p>
-                The franchise ledger now counts <span data-history="franchise-count">--</span> active NBA clubs. The
-                busiest era was the <span data-history="peak-expansion-decade">--</span>, which added
-                <span data-history="peak-expansion-total">--</span> teams.
-              </p>
-              <ol class="timeline" data-history="expansion-timeline"></ol>
-            </div>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Season logging velocity</header>
+              <div class="viz-canvas">
+                <canvas data-chart="season-velocity" data-chart-ratio="0.62" aria-describedby="season-velocity-caption"></canvas>
+              </div>
+              <figcaption id="season-velocity-caption" class="viz-card__caption">
+                Each season's captured games stream across the decades to show spikes in schedule density.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Cumulative archive build</header>
+              <div class="viz-canvas">
+                <canvas data-chart="cumulative-games" data-chart-ratio="0.62" aria-describedby="cumulative-games-caption"></canvas>
+              </div>
+              <figcaption id="cumulative-games-caption" class="viz-card__caption">
+                An ascending ribbon quantifies how quickly total logged contests approach the modern era.</figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Expansion fingerprint</header>
+              <div class="viz-canvas">
+                <canvas data-chart="franchise-radar" data-chart-ratio="0.75" aria-describedby="franchise-radar-caption"></canvas>
+              </div>
+              <figcaption id="franchise-radar-caption" class="viz-card__caption">
+                A radial map compares franchise arrivals by decade to spotlight expansion surges.</figcaption>
+            </figure>
           </div>
+
+          <aside class="timeline-panel">
+            <h3>Expansion timeline</h3>
+            <ol class="timeline" data-history="expansion-timeline"></ol>
+          </aside>
         </section>
 
-        <section>
-          <h2>Playoff retrospectives</h2>
-          <p class="lead">
-            Compare the split between regular-season grinds and postseason epics, then dive into the biggest
-            blowouts and packed houses ever captured in the game logs.
-          </p>
+        <section class="history-section">
+          <div class="history-section__header">
+            <h2>Competitive reactor</h2>
+          </div>
 
-          <div class="grid-two">
+          <div class="history-mosaic">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Game type distribution</header>
               <div class="viz-canvas">
                 <canvas data-chart="game-type-share" aria-describedby="game-type-share-caption"></canvas>
               </div>
               <figcaption id="game-type-share-caption" class="viz-card__caption">
-                Doughnut segments show how regular season, playoffs, play-in tournaments, and showcase games
-                populate the historical record.
-              </figcaption>
+                A doughnut orbit contrasts regular season volume with postseason, play-in, and showcase slates.</figcaption>
             </figure>
+
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Largest victory margins</header>
               <div class="viz-canvas">
                 <canvas data-chart="largest-margins" aria-describedby="largest-margins-caption"></canvas>
               </div>
               <figcaption id="largest-margins-caption" class="viz-card__caption">
-                Horizontal bars spotlight the most lopsided scorelines on file, giving historians quick access
-                to blowout context.
+                Horizontal bars spotlight the most lopsided scorelines on file with total-point context overlays.</figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Scoring bursts scatterfield</header>
+              <div class="viz-canvas">
+                <canvas data-chart="scoring-bursts" aria-describedby="scoring-bursts-caption"></canvas>
+              </div>
+              <figcaption id="scoring-bursts-caption" class="viz-card__caption">
+                Bubble sizes encode attendance while plotting each 350+ point shootout by year and total points.</figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Margin vs. total matrix</header>
+              <div class="viz-canvas">
+                <canvas data-chart="margin-vs-total" aria-describedby="margin-vs-total-caption"></canvas>
+              </div>
+              <figcaption id="margin-vs-total-caption" class="viz-card__caption">
+                A scatter plot fuses blowout size and scoring output to surface extreme result combinations.</figcaption>
+            </figure>
+          </div>
+        </section>
+
+        <section class="history-section">
+          <div class="history-section__header">
+            <h2>Attendance observatory</h2>
+          </div>
+
+          <div class="history-mosaic history-mosaic--triptych">
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Attendance orbit</header>
+              <div class="viz-canvas">
+                <canvas data-chart="attendance-orbit" data-chart-ratio="0.8" aria-describedby="attendance-orbit-caption"></canvas>
+              </div>
+              <figcaption id="attendance-orbit-caption" class="viz-card__caption">
+                Polar wedges scale arena turnouts with a badge for the all-time record night.</figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Record scoreline stack</header>
+              <div class="viz-canvas">
+                <canvas data-chart="record-sparkline" aria-describedby="record-sparkline-caption"></canvas>
+              </div>
+              <figcaption id="record-sparkline-caption" class="viz-card__caption">
+                A vertical stack ranks the archive's highest combined totals with era-coded gradients.</figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Archive coverage gauge</header>
+              <div class="viz-canvas">
+                <canvas data-chart="archive-coverage" data-chart-ratio="0.8" aria-describedby="archive-coverage-caption"></canvas>
+              </div>
+              <figcaption id="archive-coverage-caption" class="viz-card__caption">
+                A dual-ring gauge tracks refresh cadence, seasons indexed, and total coverage span across
+                <span data-history="season-count">--</span> seasons (<span data-history="season-range">--</span>) with the
+                latest ingest on <span data-history="archive-updated">--</span>.
               </figcaption>
             </figure>
           </div>
 
-          <div class="card-grid">
-            <article class="card">
-              <h3>Scoreboard fireworks</h3>
-              <p>Highest combined point totals across the archive deliver instant storytelling starters.</p>
-              <ul class="list-grid list-grid--dense" data-history="record-games"></ul>
-            </article>
-            <article class="card">
-              <h3>Mega crowds</h3>
-              <p>Attendance giants that redefined what a sold-out arena looks like.</p>
+          <div class="history-matrix">
+            <figure class="history-table-card">
+              <header class="history-table-card__header">
+                <h3>Mega crowds ledger</h3>
+                <span class="history-table-card__meta" data-history="attendance-record">--</span>
+              </header>
               <div class="table-scroll">
                 <table class="history-table">
                   <thead>
@@ -139,25 +217,7 @@
                   <tbody data-history="attendance-body"></tbody>
                 </table>
               </div>
-            </article>
-            <article class="card">
-              <h3>Archive cadence</h3>
-              <p>Monitor refresh cycles and coverage windows for the historical ingest.</p>
-              <dl class="history-facts">
-                <div class="history-facts__row">
-                  <dt>Last refresh</dt>
-                  <dd data-history="archive-updated">--</dd>
-                </div>
-                <div class="history-facts__row">
-                  <dt>Seasons tracked</dt>
-                  <dd><span data-history="season-range">--</span> (<span data-history="season-count">--</span>)</dd>
-                </div>
-                <div class="history-facts__row">
-                  <dt>Coverage span</dt>
-                  <dd><span data-history="first-game">--</span> – <span data-history="latest-game">--</span></dd>
-                </div>
-              </dl>
-            </article>
+            </figure>
           </div>
         </section>
       </main>

--- a/public/scripts/history.js
+++ b/public/scripts/history.js
@@ -27,7 +27,7 @@ const summaryEls = {
   latestGame: document.querySelectorAll('[data-history="latest-game"]'),
   playoffGames: document.querySelector('[data-history="playoff-games"]'),
   playoffShare: document.querySelector('[data-history="playoff-share"]'),
-  attendanceRecord: document.querySelector('[data-history="attendance-record"]'),
+  attendanceRecord: document.querySelectorAll('[data-history="attendance-record"]'),
   franchiseCount: document.querySelector('[data-history="franchise-count"]'),
   peakExpansionDecade: document.querySelector('[data-history="peak-expansion-decade"]'),
   peakExpansionTotal: document.querySelector('[data-history="peak-expansion-total"]'),
@@ -102,7 +102,10 @@ function updateEraSummary(history) {
   if (topAttendance && summaryEls.attendanceRecord) {
     const opponent = formatMatchup(topAttendance);
     const recordDate = formatDate(topAttendance.date);
-    summaryEls.attendanceRecord.textContent = `${helpers.formatNumber(topAttendance.attendance, 0)} fans watched ${opponent} on ${recordDate}.`;
+    setText(
+      summaryEls.attendanceRecord,
+      `${helpers.formatNumber(topAttendance.attendance, 0)} fans watched ${opponent} on ${recordDate}.`,
+    );
   }
 }
 
@@ -399,6 +402,541 @@ registerCharts([
             },
             y: {
               grid: { display: false },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="season-velocity"]'),
+    source: 'data/historical_audit.json',
+    async createConfig(data, helpers) {
+      const seasons = Array.isArray(data?.games?.seasonBreakdown) ? data.games.seasonBreakdown : [];
+      if (!seasons.length) return null;
+      const labels = seasons.map(([season]) => season);
+      const values = seasons.map(([, games]) => games);
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Games logged',
+              data: values,
+              borderColor: palette.sky,
+              borderWidth: 2,
+              fill: true,
+              tension: 0.35,
+              pointRadius: 0,
+              backgroundColor(context) {
+                const { chart } = context;
+                const { ctx, chartArea } = chart;
+                if (!chartArea) return 'rgba(31, 123, 255, 0.22)';
+                const gradient = ctx.createLinearGradient(0, chartArea.top, 0, chartArea.bottom);
+                gradient.addColorStop(0, 'rgba(31, 123, 255, 0.3)');
+                gradient.addColorStop(1, 'rgba(31, 123, 255, 0)');
+                return gradient;
+              },
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${helpers.formatNumber(context.parsed.y, 0)} logged games`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.05)' },
+              ticks: {
+                maxTicksLimit: 8,
+              },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="cumulative-games"]'),
+    source: 'data/historical_audit.json',
+    async createConfig(data, helpers) {
+      const seasons = Array.isArray(data?.games?.seasonBreakdown) ? data.games.seasonBreakdown : [];
+      if (!seasons.length) return null;
+      const labels = seasons.map(([season]) => season);
+      const cumulative = [];
+      let running = 0;
+      seasons.forEach(([, games]) => {
+        running += games;
+        cumulative.push(running);
+      });
+
+      return {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Cumulative games',
+              data: cumulative,
+              borderColor: palette.royal,
+              borderWidth: 2,
+              fill: true,
+              pointRadius: 0,
+              tension: 0.25,
+              backgroundColor(context) {
+                const { chart } = context;
+                const { ctx, chartArea } = chart;
+                if (!chartArea) return 'rgba(17, 86, 214, 0.18)';
+                const gradient = ctx.createLinearGradient(chartArea.left, chartArea.top, chartArea.left, chartArea.bottom);
+                gradient.addColorStop(0, 'rgba(17, 86, 214, 0.26)');
+                gradient.addColorStop(1, 'rgba(17, 86, 214, 0)');
+                return gradient;
+              },
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${helpers.formatNumber(context.parsed.y, 0)} games indexed`;
+                },
+              },
+            },
+          },
+          scales: {
+            x: {
+              grid: { color: 'rgba(11, 37, 69, 0.05)' },
+              ticks: {
+                maxTicksLimit: 8,
+              },
+            },
+            y: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="franchise-radar"]'),
+    source: 'data/active_franchises.json',
+    async createConfig(data, helpers) {
+      const entries = Array.isArray(data?.decades) ? data.decades.filter((entry) => Number.isFinite(entry?.decade)) : [];
+      if (!entries.length) return null;
+      const labels = entries.map((entry) => `${entry.decade}s`);
+      const values = entries.map((entry) => entry.total ?? 0);
+
+      return {
+        type: 'radar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Franchise arrivals',
+              data: values,
+              backgroundColor: 'rgba(244, 181, 63, 0.28)',
+              borderColor: palette.gold,
+              borderWidth: 2,
+              pointBackgroundColor: palette.gold,
+              pointRadius: 3,
+            },
+          ],
+        },
+        options: {
+          elements: {
+            line: { borderJoinStyle: 'round' },
+          },
+          scales: {
+            r: {
+              angleLines: { color: 'rgba(11, 37, 69, 0.1)' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                showLabelBackdrop: false,
+                stepSize: 2,
+                callback: (value) => (value ? helpers.formatNumber(value, 0) : ''),
+              },
+              pointLabels: {
+                font: { size: 11 },
+              },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${helpers.formatNumber(context.parsed.r, 0)} franchises added`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="scoring-bursts"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data, helpers) {
+      const games = Array.isArray(data?.highestScoringGames) ? data.highestScoringGames : [];
+      if (!games.length) return null;
+      const ranked = helpers
+        .rankAndSlice(games, 10, (game) => game.totalPoints)
+        .sort((a, b) => {
+          const da = parseDate(a.date)?.getTime() ?? 0;
+          const db = parseDate(b.date)?.getTime() ?? 0;
+          return da - db;
+        });
+
+      const dataset = ranked.map((game) => {
+        const date = parseDate(game.date);
+        const yearValue = date ? date.getUTCFullYear() + date.getUTCMonth() / 12 : 0;
+        const attendance = Number(game.attendance) || 0;
+        return {
+          x: yearValue,
+          y: game.totalPoints,
+          r: Math.max(8, Math.sqrt(attendance) / 35),
+          meta: game,
+        };
+      });
+
+      return {
+        type: 'bubble',
+        data: {
+          datasets: [
+            {
+              label: 'Scoring eruptions',
+              data: dataset,
+              backgroundColor: 'rgba(239, 61, 91, 0.4)',
+              borderColor: palette.crimson,
+              borderWidth: 1.5,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { top: 8, right: 16, bottom: 8, left: 12 } },
+          scales: {
+            x: {
+              type: 'linear',
+              beginAtZero: false,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => Math.round(value),
+              },
+              title: {
+                display: true,
+                text: 'Year',
+              },
+            },
+            y: {
+              beginAtZero: false,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              title: {
+                display: true,
+                text: 'Total points',
+              },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                title(context) {
+                  const meta = context[0]?.raw?.meta;
+                  return meta ? formatDate(meta.date) : '';
+                },
+                label(context) {
+                  const meta = context.raw?.meta;
+                  if (!meta) return '';
+                  const matchup = formatMatchup(meta);
+                  const attendance = meta.attendance ? ` • ${helpers.formatNumber(meta.attendance, 0)} fans` : '';
+                  return `${matchup}: ${helpers.formatNumber(meta.totalPoints, 0)} points${attendance}`;
+                },
+              },
+            },
+            legend: { display: false },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="margin-vs-total"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data, helpers) {
+      const games = Array.isArray(data?.largestMargins) ? data.largestMargins : [];
+      if (!games.length) return null;
+      const ranked = helpers.rankAndSlice(games, 10, (game) => game.margin);
+      const dataset = ranked.map((game) => {
+        const attendance = Number(game.attendance) || 0;
+        return {
+          x: game.margin,
+          y: game.totalPoints,
+          r: Math.max(7, Math.sqrt(attendance) / 40),
+          meta: game,
+        };
+      });
+
+      return {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'Margin & scoring blend',
+              data: dataset,
+              backgroundColor: 'rgba(17, 86, 214, 0.3)',
+              borderColor: palette.royal,
+              borderWidth: 1.2,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: { top: 8, right: 14, bottom: 8, left: 12 } },
+          scales: {
+            x: {
+              title: { display: true, text: 'Margin of victory' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => `${value} pts`,
+              },
+            },
+            y: {
+              title: { display: true, text: 'Total points' },
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const meta = context.raw?.meta;
+                  if (!meta) return '';
+                  const matchup = formatMatchup(meta);
+                  const date = formatDate(meta.date);
+                  return `${matchup} • ${helpers.formatNumber(meta.margin, 0)}-point margin • ${helpers.formatNumber(meta.totalPoints, 0)} total points (${date})`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="attendance-orbit"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data, helpers) {
+      const rows = Array.isArray(data?.attendanceLeaders) ? data.attendanceLeaders : [];
+      if (!rows.length) return null;
+      const ranked = helpers.rankAndSlice(rows, 7, (game) => game.attendance).sort((a, b) => b.attendance - a.attendance);
+      const labels = ranked.map((game) => `${formatDate(game.date)} • ${formatMatchup(game)}`);
+      const values = ranked.map((game) => game.attendance ?? 0);
+      const colors = values.map((_, index) => {
+        if (index === 0) {
+          return palette.gold;
+        }
+        const alpha = Math.max(0.32, 0.7 - index * 0.07);
+        return `rgba(17, 86, 214, ${alpha})`;
+      });
+
+      return {
+        type: 'polarArea',
+        data: {
+          labels,
+          datasets: [
+            {
+              data: values,
+              backgroundColor: colors,
+              borderWidth: 1,
+              borderColor: 'rgba(255, 255, 255, 0.6)',
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          scales: {
+            r: {
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+          },
+          plugins: {
+            legend: { position: 'bottom' },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  return `${context.label}: ${helpers.formatNumber(context.parsed, 0)} fans`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="record-sparkline"]'),
+    source: 'data/historic_games.json',
+    async createConfig(data, helpers) {
+      const games = Array.isArray(data?.highestScoringGames) ? data.highestScoringGames : [];
+      if (!games.length) return null;
+      const ranked = helpers.rankAndSlice(games, 8, (game) => game.totalPoints).sort((a, b) => b.totalPoints - a.totalPoints);
+      const labels = ranked.map((game) => formatDate(game.date));
+      const values = ranked.map((game) => game.totalPoints);
+      const metadata = ranked.map((game) => ({
+        matchup: formatMatchup(game),
+        total: game.totalPoints,
+        margin: game.margin,
+      }));
+
+      return {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Combined points',
+              data: values,
+              backgroundColor(context) {
+                const index = context.dataIndex;
+                const base = 0.85 - index * 0.06;
+                return `rgba(239, 61, 91, ${Math.max(base, 0.35)})`;
+              },
+              meta: metadata,
+            },
+          ],
+        },
+        options: {
+          indexAxis: 'y',
+          layout: { padding: { top: 8, right: 16, bottom: 8, left: 12 } },
+          scales: {
+            x: {
+              beginAtZero: true,
+              grid: { color: 'rgba(11, 37, 69, 0.08)' },
+              ticks: {
+                callback: (value) => helpers.formatNumber(value, 0),
+              },
+            },
+            y: {
+              grid: { display: false },
+            },
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const meta = context.dataset.meta?.[context.dataIndex];
+                  if (!meta) return '';
+                  const margin = meta.margin ? ` • decided by ${helpers.formatNumber(meta.margin, 0)} points` : '';
+                  return `${meta.matchup}: ${helpers.formatNumber(meta.total, 0)} total points${margin}`;
+                },
+              },
+            },
+          },
+        },
+      };
+    },
+  },
+  {
+    element: document.querySelector('[data-chart="archive-coverage"]'),
+    source: 'data/historical_audit.json',
+    async createConfig(data, helpers) {
+      const seasons = Array.isArray(data?.games?.seasonBreakdown) ? data.games.seasonBreakdown : [];
+      if (!seasons.length) return null;
+      const parseSeason = (season) => {
+        const year = Number.parseInt(String(season).split('-')[0], 10);
+        return Number.isFinite(year) ? year : null;
+      };
+      const firstSeasonYear = parseSeason(seasons[0][0]);
+      const lastSeasonYear = parseSeason(seasons[seasons.length - 1][0]);
+      const coverageSpan =
+        Number.isFinite(firstSeasonYear) && Number.isFinite(lastSeasonYear)
+          ? lastSeasonYear - firstSeasonYear + 1
+          : seasons.length;
+      const seasonsTracked = seasons.length;
+      const coverageGap = Math.max(coverageSpan - seasonsTracked, 0);
+      const totalRows = Number(data?.games?.rowCount) || 0;
+      const invalidRows = Number(data?.games?.invalidDateCount) || 0;
+      const validRows = Math.max(totalRows - invalidRows, 0);
+
+      const coverageLabels = ['Tracked seasons', 'Estimated gap'];
+      const validityLabels = ['Validated rows', 'Flagged rows'];
+
+      return {
+        type: 'doughnut',
+        data: {
+          labels: coverageLabels,
+          datasets: [
+            {
+              label: 'Season coverage',
+              data: [seasonsTracked, coverageGap],
+              backgroundColor: [palette.royal, 'rgba(11, 37, 69, 0.12)'],
+              borderWidth: 0,
+              weight: 0.8,
+            },
+            {
+              label: 'Row validity',
+              data: [validRows, invalidRows],
+              backgroundColor: ['rgba(244, 181, 63, 0.8)', 'rgba(239, 61, 91, 0.65)'],
+              borderWidth: 0,
+              weight: 0.5,
+            },
+          ],
+        },
+        options: {
+          layout: { padding: 8 },
+          cutout: '58%',
+          plugins: {
+            legend: {
+              position: 'bottom',
+              labels: {
+                usePointStyle: true,
+              },
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  const datasetLabel = context.dataset.label;
+                  const labels = datasetLabel === 'Season coverage' ? coverageLabels : validityLabels;
+                  const label = labels[context.dataIndex] ?? datasetLabel;
+                  return `${label}: ${helpers.formatNumber(context.parsed, 0)}`;
+                },
+              },
             },
           },
         },

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -554,6 +554,94 @@ a:hover, a:focus { color: var(--sky); }
   gap: clamp(1.75rem, 3.8vw, 2.7rem);
 }
 
+.history-hero-metrics {
+  display: grid;
+  gap: clamp(1rem, 2.8vw, 1.4rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.history-hero-metric {
+  position: relative;
+  padding: 1.15rem 1.3rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    linear-gradient(140deg, rgba(17, 86, 214, 0.18), rgba(244, 181, 63, 0.12)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: 0 18px 32px rgba(11, 37, 69, 0.18);
+  display: grid;
+  gap: 0.5rem;
+  overflow: hidden;
+}
+
+.history-hero-metric::after {
+  content: '';
+  position: absolute;
+  inset: auto -35% -55% 55%;
+  height: 140px;
+  background: radial-gradient(circle at center, rgba(31, 123, 255, 0.22), transparent 70%);
+  opacity: 0.8;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.history-hero-metric--primary {
+  border-color: color-mix(in srgb, var(--royal) 28%, transparent);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.25), rgba(239, 61, 91, 0.18)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
+}
+
+.history-hero-metric--primary::after {
+  inset: auto 52% -48% -22%;
+  height: 160px;
+  background: radial-gradient(circle at center, rgba(244, 181, 63, 0.26), transparent 72%);
+  z-index: 0;
+}
+
+.history-hero-metric__label {
+  font-size: 0.82rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--navy) 70%, var(--text-subtle) 30%);
+  font-weight: 700;
+  position: relative;
+  z-index: 1;
+}
+
+.history-hero-metric__value {
+  font-size: clamp(1.85rem, 4vw, 2.35rem);
+  line-height: 1.1;
+  font-weight: 700;
+  color: var(--navy);
+  position: relative;
+  z-index: 1;
+}
+
+.history-hero-metric__value--compact {
+  font-size: clamp(1.1rem, 2.6vw, 1.3rem);
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.history-hero-metric__context {
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  align-items: baseline;
+  position: relative;
+  z-index: 1;
+}
+
+.history-hero-metric__divider {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: color-mix(in srgb, var(--royal) 70%, var(--navy) 30%);
+}
+
 .hero--about {
   padding: clamp(2rem, 5vw, 2.8rem) 0 clamp(1.8rem, 4vw, 2.4rem);
   gap: clamp(1.4rem, 3.5vw, 2.2rem);
@@ -2240,6 +2328,128 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .timeline__year { font-weight: 700; font-size: 1.05rem; color: var(--navy); }
 .timeline__count { font-weight: 600; font-size: 0.9rem; color: var(--royal); letter-spacing: 0.04em; text-transform: uppercase; }
 .timeline__detail { margin: 0; font-size: 0.92rem; color: var(--text-subtle); }
+
+.history-section {
+  margin-bottom: clamp(2.6rem, 6vw, 3.6rem);
+  display: grid;
+  gap: clamp(1.6rem, 3.5vw, 2.4rem);
+}
+
+.history-section__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.history-badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.history-badge {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(17, 86, 214, 0.1);
+  border: 1px solid color-mix(in srgb, var(--royal) 22%, transparent);
+  font-size: 0.85rem;
+  color: var(--royal);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.history-badge__label {
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--royal) 70%, var(--navy) 30%);
+}
+
+.history-badge__value {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.history-badge__divider {
+  color: color-mix(in srgb, var(--royal) 60%, var(--text-subtle) 40%);
+  font-size: 0.7rem;
+}
+
+.history-mosaic {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.history-mosaic--wide {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.history-mosaic--triptych {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.timeline-panel {
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+  background:
+    linear-gradient(155deg, rgba(17, 86, 214, 0.1), rgba(244, 181, 63, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.92) 30%);
+  padding: 1.4rem 1.6rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.timeline-panel h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.history-matrix {
+  margin-top: clamp(1.6rem, 3.5vw, 2.4rem);
+  display: grid;
+  gap: 1.4rem;
+}
+
+.history-table-card {
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(31, 123, 255, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: var(--shadow-soft);
+  padding: 1.35rem 1.5rem 1.4rem;
+  display: grid;
+  gap: 1.15rem;
+}
+
+.history-table-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.65rem;
+}
+
+.history-table-card__header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.history-table-card__meta {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-subtle);
+}
 
 /* Story walkthrough */
 .story-walkthrough {


### PR DESCRIPTION
## Summary
- rebuild the history landing page around a mosaic of eleven data visualizations and hero metrics tied to archive stats
- implement new Chart.js dashboards for seasonal velocity, cumulative growth, franchise expansion, scoring bursts, attendance orbit, record stacks, and archive coverage
- refresh styling for the hero, visualization grids, badges, and tables to match the immersive data visualization theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88b039cf48327bf5b6f674e40e348