### PR TITLE
Expand preseason previews with dual-team dashboards

### DIFF
--- a/public/previews/preseason-12400001.html
+++ b/public/previews/preseason-12400001.html
@@ -48,6 +48,44 @@
         color: var(--navy);
       }
 
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
       .chart-grid {
         display: grid;
         gap: clamp(1.1rem, 3vw, 1.8rem);
@@ -74,6 +112,11 @@
         margin: 0;
         font-size: 0.85rem;
         color: var(--text-subtle);
+      }
+
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
       }
 
       .preview-copy {
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
-        <main class="preview-shell">
+  <body data-preview-id="preseason-12400001">
+    <main class="preview-shell">
       <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes the coaching staffs want to log for their developmental priorities in Abu Dhabi.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for young wings</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaches’ emphasis areas (0-10 scale) for Boston and Denver wings fighting for rotation trust.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Breakdown of the roster groups: cleared for full minutes, monitored workloads, or limited to rehab work.</p>
-                </figure>
-              </div>
-            </section>
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="boston-celtics">
+            <header>
+              <h3>Boston Celtics data lab</h3>
+              <span class="meta">Bench acceleration focus</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="boston-celtics-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for Abu Dhabi reps, highlighting how Boston’s reserve wings scale up.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="boston-celtics-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for Boston’s developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="boston-celtics-shot-zones"></canvas>
+                <p>Where the Celtics expect their preseason attempts to come from compared to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="boston-celtics-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="boston-celtics-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Boston combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="denver-nuggets">
+            <header>
+              <h3>Denver Nuggets data lab</h3>
+              <span class="meta">Development runway</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="denver-nuggets-rotation"></canvas>
+                <p>Targeted minutes for Denver’s rising contributors as they search for the next wave of support players.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="denver-nuggets-skill-spider"></canvas>
+                <p>Skill priorities outlined by the staff against current camp readiness readings for the Nuggets.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="denver-nuggets-shot-zones"></canvas>
+                <p>Projected shot profile for Denver’s preseason lineups juxtaposed with a league-average distribution.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="denver-nuggets-tempo-curve"></canvas>
+                <p>How tempo drills and special-situation work have been balanced in camp before the Abu Dhabi showcase.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="denver-nuggets-synergy-matrix"></canvas>
+                <p>Pace and defensive sync scores for Denver combinations auditioning for higher-leverage minutes.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,133 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        celtics: "#007A33",
-        nuggets: "#0E2240",
-        accent: "#FDB927",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Jordan Walsh (BOS)",
-              "Baylor Scheierman (BOS)",
-              "Neemias Queta (BOS)",
-              "Julian Strawther (DEN)",
-              "Peyton Watson (DEN)",
-              "DaRon Holmes II (DEN)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [22, 20, 16, 21, 18, 17],
-                backgroundColor: [
-                  palette.celtics,
-                  palette.celtics,
-                  palette.celtics,
-                  palette.nuggets,
-                  palette.nuggets,
-                  palette.nuggets
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(15, 35, 64, 0.08)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["On-ball reps", "Spacing volume", "Defensive activity", "Playmaking", "Transition pace"],
-            datasets: [
-              {
-                label: "Jordan Walsh",
-                data: [7, 5, 9, 6, 8],
-                borderColor: palette.celtics,
-                backgroundColor: "rgba(0, 122, 51, 0.25)",
-                pointBackgroundColor: palette.celtics
-              },
-              {
-                label: "Baylor Scheierman",
-                data: [5, 9, 6, 7, 6],
-                borderColor: palette.accent,
-                backgroundColor: "rgba(253, 185, 39, 0.2)",
-                pointBackgroundColor: palette.accent
-              },
-              {
-                label: "Julian Strawther",
-                data: [6, 8, 7, 5, 7],
-                borderColor: palette.nuggets,
-                backgroundColor: "rgba(14, 34, 64, 0.25)",
-                pointBackgroundColor: palette.nuggets
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(15, 35, 64, 0.08)" },
-                angleLines: { color: "rgba(15, 35, 64, 0.08)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [9, 4, 2],
-                backgroundColor: [palette.celtics, palette.accent, palette.nuggets],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400003.html
+++ b/public/previews/preseason-12400003.html
@@ -48,6 +48,44 @@
         color: var(--navy);
       }
 
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
       .chart-grid {
         display: grid;
         gap: clamp(1.1rem, 3vw, 1.8rem);
@@ -74,6 +112,11 @@
         margin: 0;
         font-size: 0.85rem;
         color: var(--text-subtle);
+      }
+
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
       }
 
       .preview-copy {
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
-        <main class="preview-shell">
+  <body data-preview-id="preseason-12400003">
+    <main class="preview-shell">
       <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities in the Palm Desert opener.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for young guards/wings</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Emphasis areas (0-10 scale) for prospects chasing rotation trust under Finch and Redick.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Allocation of the travel roster between full go, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="minnesota-timberwolves">
+            <header>
+              <h3>Minnesota Timberwolves data lab</h3>
+              <span class="meta">Lineup elasticity</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="minnesota-timberwolves-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for Minnesota’s preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="minnesota-timberwolves-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for Minnesota’s developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="minnesota-timberwolves-shot-zones"></canvas>
+                <p>Where the Timberwolves expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="minnesota-timberwolves-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo work versus special-situation installs heading into Palm Desert.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="minnesota-timberwolves-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Minnesota groupings vying for expanded trust.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="los-angeles-lakers">
+            <header>
+              <h3>Los Angeles Lakers data lab</h3>
+              <span class="meta">Rhythm calibration</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="los-angeles-lakers-rotation"></canvas>
+                <p>Minute allocations mapped for the Lakers’ preseason lineups as Redick balances vets and youth.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="los-angeles-lakers-skill-spider"></canvas>
+                <p>Blueprint versus readiness metrics for the Lakers’ developmental points of emphasis this week.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="los-angeles-lakers-shot-zones"></canvas>
+                <p>How Los Angeles expects to space the floor in preseason action compared with a league-average mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="los-angeles-lakers-tempo-curve"></canvas>
+                <p>Tracking tempo sessions and special-situation installs as the Lakers implement new concepts.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="los-angeles-lakers-synergy-matrix"></canvas>
+                <p>Pace and coverage sync readings for Los Angeles combinations expected to share key minutes.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        lakers: "#552583",
-        sunshine: "#FDB927",
-        wolves: "#0C2340",
-        accent: "#78BE20",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Dalton Knecht (LAL)",
-              "Bronny James (LAL)",
-              "Rui Hachimura (LAL)",
-              "Rob Dillingham (MIN)",
-              "Leonard Miller (MIN)",
-              "Josh Minott (MIN)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [21, 18, 16, 22, 19, 15],
-                backgroundColor: [
-                  palette.lakers,
-                  palette.sunshine,
-                  palette.lakers,
-                  palette.wolves,
-                  palette.accent,
-                  palette.wolves
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(12, 35, 64, 0.1)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Pick-and-roll craft", "Catch-and-shoot", "Defensive versatility", "Playmaking", "Transition pace"],
-            datasets: [
-              {
-                label: "Dalton Knecht",
-                data: [6, 9, 5, 6, 7],
-                borderColor: palette.sunshine,
-                backgroundColor: "rgba(253, 185, 39, 0.22)",
-                pointBackgroundColor: palette.sunshine
-              },
-              {
-                label: "Bronny James",
-                data: [5, 7, 8, 6, 7],
-                borderColor: palette.lakers,
-                backgroundColor: "rgba(85, 37, 131, 0.25)",
-                pointBackgroundColor: palette.lakers
-              },
-              {
-                label: "Rob Dillingham",
-                data: [8, 6, 5, 7, 9],
-                borderColor: palette.accent,
-                backgroundColor: "rgba(120, 190, 32, 0.25)",
-                pointBackgroundColor: palette.accent
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(12, 35, 64, 0.1)" },
-                angleLines: { color: "rgba(12, 35, 64, 0.1)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [10, 5, 1],
-                backgroundColor: [palette.accent, palette.lakers, palette.wolves],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400004.html
+++ b/public/previews/preseason-12400004.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400004">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Expected minutes earmarked for developmental players during the Honolulu opener.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for rotation candidates</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for wings and forwards battling for October minutes.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster distribution across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="golden-state-warriors">
+            <header>
+              <h3>Golden State Warriors data lab</h3>
+              <span class="meta">Transition stress test</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="golden-state-warriors-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Golden State Warriors preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="golden-state-warriors-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Golden State Warriors developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="golden-state-warriors-shot-zones"></canvas>
+                <p>Where the Golden State Warriors expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="golden-state-warriors-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="golden-state-warriors-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Golden State Warriors combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="los-angeles-clippers">
+            <header>
+              <h3>Los Angeles Clippers data lab</h3>
+              <span class="meta">Half-court refinement</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="los-angeles-clippers-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Los Angeles Clippers preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="los-angeles-clippers-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Los Angeles Clippers developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="los-angeles-clippers-shot-zones"></canvas>
+                <p>Where the Los Angeles Clippers expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="los-angeles-clippers-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="los-angeles-clippers-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Los Angeles Clippers combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        warriors: "#1D428A",
-        gold: "#FFC72C",
-        clippers: "#ED174C",
-        wave: "#006BB6",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Jonathan Kuminga (GSW)",
-              "Moses Moody (GSW)",
-              "Quinten Post (GSW)",
-              "Kobe Brown (LAC)",
-              "Bones Hyland (LAC)",
-              "Jordan Miller (LAC)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [23, 20, 15, 19, 18, 16],
-                backgroundColor: [
-                  palette.warriors,
-                  palette.gold,
-                  palette.warriors,
-                  palette.clippers,
-                  palette.wave,
-                  palette.clippers
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(29, 66, 138, 0.1)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Rim pressure", "Catch-and-shoot", "Switch defense", "Playmaking", "Rebounding"],
-            datasets: [
-              {
-                label: "Jonathan Kuminga",
-                data: [8, 6, 7, 6, 7],
-                borderColor: palette.warriors,
-                backgroundColor: "rgba(29, 66, 138, 0.22)",
-                pointBackgroundColor: palette.warriors
-              },
-              {
-                label: "Moses Moody",
-                data: [6, 9, 6, 5, 6],
-                borderColor: palette.gold,
-                backgroundColor: "rgba(255, 199, 44, 0.22)",
-                pointBackgroundColor: palette.gold
-              },
-              {
-                label: "Kobe Brown",
-                data: [7, 6, 8, 5, 8],
-                borderColor: palette.clippers,
-                backgroundColor: "rgba(237, 23, 76, 0.22)",
-                pointBackgroundColor: palette.clippers
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(29, 66, 138, 0.1)" },
-                angleLines: { color: "rgba(29, 66, 138, 0.1)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [11, 4, 2],
-                backgroundColor: [palette.warriors, palette.clippers, palette.wave],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400006.html
+++ b/public/previews/preseason-12400006.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400006">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities during Charlotte’s opener.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for guards/wings</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for emerging perimeter players on each roster.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="new-york-knicks">
+            <header>
+              <h3>New York Knicks data lab</h3>
+              <span class="meta">Pressure defense matrix</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="new-york-knicks-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the New York Knicks preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="new-york-knicks-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the New York Knicks developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="new-york-knicks-shot-zones"></canvas>
+                <p>Where the New York Knicks expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="new-york-knicks-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="new-york-knicks-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for New York Knicks combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="charlotte-hornets">
+            <header>
+              <h3>Charlotte Hornets data lab</h3>
+              <span class="meta">Spacing experiment</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="charlotte-hornets-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Charlotte Hornets preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="charlotte-hornets-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Charlotte Hornets developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="charlotte-hornets-shot-zones"></canvas>
+                <p>Where the Charlotte Hornets expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="charlotte-hornets-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="charlotte-hornets-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Charlotte Hornets combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        knicks: "#006BB6",
-        orange: "#F58426",
-        hornets: "#1D1160",
-        teal: "#00788C",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Miles McBride (NYK)",
-              "Tyler Kolek (NYK)",
-              "Precious Achiuwa (NYK)",
-              "Tidjane Salaun (CHA)",
-              "Nick Smith Jr. (CHA)",
-              "Mark Williams (CHA)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [22, 18, 16, 21, 19, 17],
-                backgroundColor: [
-                  palette.knicks,
-                  palette.orange,
-                  palette.knicks,
-                  palette.hornets,
-                  palette.teal,
-                  palette.hornets
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(0, 107, 182, 0.12)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Pick-and-roll craft", "Catch-and-shoot", "Point-of-attack defense", "Playmaking", "Tempo push"],
-            datasets: [
-              {
-                label: "Miles McBride",
-                data: [7, 6, 9, 6, 7],
-                borderColor: palette.knicks,
-                backgroundColor: "rgba(0, 107, 182, 0.25)",
-                pointBackgroundColor: palette.knicks
-              },
-              {
-                label: "Tyler Kolek",
-                data: [6, 8, 6, 8, 6],
-                borderColor: palette.orange,
-                backgroundColor: "rgba(245, 132, 38, 0.25)",
-                pointBackgroundColor: palette.orange
-              },
-              {
-                label: "Tidjane Salaun",
-                data: [5, 7, 7, 5, 8],
-                borderColor: palette.hornets,
-                backgroundColor: "rgba(29, 17, 96, 0.25)",
-                pointBackgroundColor: palette.hornets
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(29, 17, 96, 0.12)" },
-                angleLines: { color: "rgba(29, 17, 96, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [10, 4, 2],
-                backgroundColor: [palette.knicks, palette.hornets, palette.teal],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400007.html
+++ b/public/previews/preseason-12400007.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400007">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities during Toronto’s opener.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for developmental core</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for young players Toronto and Washington are spotlighting.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="washington-wizards">
+            <header>
+              <h3>Washington Wizards data lab</h3>
+              <span class="meta">Tempo ignition</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="washington-wizards-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Washington Wizards preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="washington-wizards-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Washington Wizards developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="washington-wizards-shot-zones"></canvas>
+                <p>Where the Washington Wizards expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="washington-wizards-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="washington-wizards-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Washington Wizards combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="toronto-raptors">
+            <header>
+              <h3>Toronto Raptors data lab</h3>
+              <span class="meta">Switchability lab</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="toronto-raptors-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Toronto Raptors preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="toronto-raptors-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Toronto Raptors developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="toronto-raptors-shot-zones"></canvas>
+                <p>Where the Toronto Raptors expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="toronto-raptors-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="toronto-raptors-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Toronto Raptors combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        wizards: "#002B5C",
-        red: "#E31837",
-        raptors: "#CE1141",
-        black: "#1E1E1E",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Alex Sarr (WAS)",
-              "Bilal Coulibaly (WAS)",
-              "Bub Carrington (WAS)",
-              "Immanuel Quickley (TOR)",
-              "Jamal Shead (TOR)",
-              "Jonathan Mogbo (TOR)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [21, 20, 18, 20, 17, 16],
-                backgroundColor: [
-                  palette.wizards,
-                  palette.red,
-                  palette.wizards,
-                  palette.raptors,
-                  palette.black,
-                  palette.raptors
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(0, 43, 92, 0.1)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Rim protection", "Switch mobility", "Playmaking", "Shooting", "Tempo pressure"],
-            datasets: [
-              {
-                label: "Alex Sarr",
-                data: [9, 8, 6, 5, 7],
-                borderColor: palette.wizards,
-                backgroundColor: "rgba(0, 43, 92, 0.25)",
-                pointBackgroundColor: palette.wizards
-              },
-              {
-                label: "Bilal Coulibaly",
-                data: [7, 9, 6, 6, 8],
-                borderColor: palette.red,
-                backgroundColor: "rgba(227, 24, 55, 0.22)",
-                pointBackgroundColor: palette.red
-              },
-              {
-                label: "Immanuel Quickley",
-                data: [5, 6, 8, 9, 7],
-                borderColor: palette.raptors,
-                backgroundColor: "rgba(206, 17, 65, 0.22)",
-                pointBackgroundColor: palette.raptors
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(206, 17, 65, 0.12)" },
-                angleLines: { color: "rgba(206, 17, 65, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [11, 4, 1],
-                backgroundColor: [palette.raptors, palette.red, palette.black],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400008.html
+++ b/public/previews/preseason-12400008.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400008">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities during Detroit’s opener.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for guard/wing development</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for players trying to secure rotation roles this fall.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="milwaukee-bucks">
+            <header>
+              <h3>Milwaukee Bucks data lab</h3>
+              <span class="meta">Perimeter containment</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="milwaukee-bucks-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Milwaukee Bucks preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="milwaukee-bucks-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Milwaukee Bucks developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="milwaukee-bucks-shot-zones"></canvas>
+                <p>Where the Milwaukee Bucks expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="milwaukee-bucks-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="milwaukee-bucks-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Milwaukee Bucks combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="detroit-pistons">
+            <header>
+              <h3>Detroit Pistons data lab</h3>
+              <span class="meta">Young core ignition</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="detroit-pistons-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Detroit Pistons preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="detroit-pistons-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Detroit Pistons developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="detroit-pistons-shot-zones"></canvas>
+                <p>Where the Detroit Pistons expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="detroit-pistons-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="detroit-pistons-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Detroit Pistons combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        bucks: "#00471B",
-        cream: "#EEE1C6",
-        pistonsRed: "#C8102E",
-        pistonsBlue: "#006BB6",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Andre Jackson Jr. (MIL)",
-              "MarJon Beauchamp (MIL)",
-              "Delon Wright (MIL)",
-              "Jaden Ivey (DET)",
-              "Ausar Thompson (DET)",
-              "Marcus Sasser (DET)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [21, 19, 17, 22, 20, 16],
-                backgroundColor: [
-                  palette.bucks,
-                  palette.cream,
-                  palette.bucks,
-                  palette.pistonsRed,
-                  palette.pistonsBlue,
-                  palette.pistonsRed
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(0, 71, 27, 0.1)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Point-of-attack defense", "Catch-and-shoot", "Secondary playmaking", "Transition pace", "Rebounding"],
-            datasets: [
-              {
-                label: "Andre Jackson Jr.",
-                data: [9, 5, 6, 8, 7],
-                borderColor: palette.bucks,
-                backgroundColor: "rgba(0, 71, 27, 0.25)",
-                pointBackgroundColor: palette.bucks
-              },
-              {
-                label: "MarJon Beauchamp",
-                data: [7, 7, 5, 7, 6],
-                borderColor: palette.cream,
-                backgroundColor: "rgba(238, 225, 198, 0.3)",
-                pointBackgroundColor: palette.cream
-              },
-              {
-                label: "Ausar Thompson",
-                data: [8, 6, 6, 9, 8],
-                borderColor: palette.pistonsBlue,
-                backgroundColor: "rgba(0, 107, 182, 0.25)",
-                pointBackgroundColor: palette.pistonsBlue
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(0, 71, 27, 0.12)" },
-                angleLines: { color: "rgba(0, 71, 27, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [12, 3, 1],
-                backgroundColor: [palette.pistonsBlue, palette.bucks, palette.cream],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400010.html
+++ b/public/previews/preseason-12400010.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400010">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities during the New Orleans opener.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for ball-handlers</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for guards and wings tasked with creation duties.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="orlando-magic">
+            <header>
+              <h3>Orlando Magic data lab</h3>
+              <span class="meta">Size and skill blend</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="orlando-magic-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Orlando Magic preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="orlando-magic-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Orlando Magic developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="orlando-magic-shot-zones"></canvas>
+                <p>Where the Orlando Magic expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="orlando-magic-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="orlando-magic-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Orlando Magic combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="new-orleans-pelicans">
+            <header>
+              <h3>New Orleans Pelicans data lab</h3>
+              <span class="meta">Physicality gauge</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="new-orleans-pelicans-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the New Orleans Pelicans preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="new-orleans-pelicans-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the New Orleans Pelicans developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="new-orleans-pelicans-shot-zones"></canvas>
+                <p>Where the New Orleans Pelicans expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="new-orleans-pelicans-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="new-orleans-pelicans-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for New Orleans Pelicans combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        magic: "#0077C0",
-        silver: "#C4CED4",
-        pels: "#0C2340",
-        gold: "#85714D",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Anthony Black (ORL)",
-              "Jett Howard (ORL)",
-              "Tristan da Silva (ORL)",
-              "Dyson Daniels (NOP)",
-              "Trey Murphy III (NOP)",
-              "Yves Missi (NOP)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [22, 18, 16, 21, 19, 17],
-                backgroundColor: [
-                  palette.magic,
-                  palette.silver,
-                  palette.magic,
-                  palette.pels,
-                  palette.gold,
-                  palette.pels
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(0, 119, 192, 0.12)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Pick-and-roll craft", "Catch-and-shoot", "Defensive playmaking", "Tempo push", "Half-court creation"],
-            datasets: [
-              {
-                label: "Anthony Black",
-                data: [7, 6, 8, 7, 6],
-                borderColor: palette.magic,
-                backgroundColor: "rgba(0, 119, 192, 0.25)",
-                pointBackgroundColor: palette.magic
-              },
-              {
-                label: "Jett Howard",
-                data: [5, 9, 6, 6, 5],
-                borderColor: palette.silver,
-                backgroundColor: "rgba(196, 206, 212, 0.3)",
-                pointBackgroundColor: palette.silver
-              },
-              {
-                label: "Dyson Daniels",
-                data: [7, 6, 8, 7, 7],
-                borderColor: palette.pels,
-                backgroundColor: "rgba(12, 35, 64, 0.25)",
-                pointBackgroundColor: palette.pels
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(12, 35, 64, 0.12)" },
-                angleLines: { color: "rgba(12, 35, 64, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [11, 4, 2],
-                backgroundColor: [palette.pels, palette.magic, palette.gold],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400012.html
+++ b/public/previews/preseason-12400012.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400012">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities in Dallas.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for rotation hopefuls</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for players battling for rotation spots.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="memphis-grizzlies">
+            <header>
+              <h3>Memphis Grizzlies data lab</h3>
+              <span class="meta">Athletic depth push</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="memphis-grizzlies-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Memphis Grizzlies preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="memphis-grizzlies-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Memphis Grizzlies developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="memphis-grizzlies-shot-zones"></canvas>
+                <p>Where the Memphis Grizzlies expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="memphis-grizzlies-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="memphis-grizzlies-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Memphis Grizzlies combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="dallas-mavericks">
+            <header>
+              <h3>Dallas Mavericks data lab</h3>
+              <span class="meta">Dual-star balance</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="dallas-mavericks-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Dallas Mavericks preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="dallas-mavericks-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Dallas Mavericks developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="dallas-mavericks-shot-zones"></canvas>
+                <p>Where the Dallas Mavericks expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="dallas-mavericks-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="dallas-mavericks-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Dallas Mavericks combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        grizzlies: "#12173F",
-        slate: "#5D76A9",
-        mavs: "#0053BC",
-        frost: "#B8C4CA",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "GG Jackson II (MEM)",
-              "Zach Edey (MEM)",
-              "De'Anthony Melton (MEM)",
-              "Josh Green (DAL)",
-              "O-Max Prosper (DAL)",
-              "AJ Johnson (DAL)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [22, 18, 17, 20, 18, 16],
-                backgroundColor: [
-                  palette.grizzlies,
-                  palette.slate,
-                  palette.grizzlies,
-                  palette.mavs,
-                  palette.frost,
-                  palette.mavs
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(18, 23, 63, 0.1)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Rim protection", "Perimeter defense", "Playmaking", "Shooting", "Transition"],
-            datasets: [
-              {
-                label: "Zach Edey",
-                data: [8, 5, 4, 6, 5],
-                borderColor: palette.slate,
-                backgroundColor: "rgba(93, 118, 169, 0.25)",
-                pointBackgroundColor: palette.slate
-              },
-              {
-                label: "Josh Green",
-                data: [6, 8, 6, 7, 8],
-                borderColor: palette.mavs,
-                backgroundColor: "rgba(0, 83, 188, 0.25)",
-                pointBackgroundColor: palette.mavs
-              },
-              {
-                label: "GG Jackson II",
-                data: [5, 6, 5, 8, 7],
-                borderColor: palette.grizzlies,
-                backgroundColor: "rgba(18, 23, 63, 0.25)",
-                pointBackgroundColor: palette.grizzlies
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(18, 23, 63, 0.12)" },
-                angleLines: { color: "rgba(18, 23, 63, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [10, 5, 2],
-                backgroundColor: [palette.mavs, palette.grizzlies, palette.frost],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400013.html
+++ b/public/previews/preseason-12400013.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400013">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities in San Antonio.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for ball-handlers</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for guards and wings seeking rotation roles.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="oklahoma-city-thunder">
+            <header>
+              <h3>Oklahoma City Thunder data lab</h3>
+              <span class="meta">Frictionless pace</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="oklahoma-city-thunder-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Oklahoma City Thunder preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="oklahoma-city-thunder-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Oklahoma City Thunder developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="oklahoma-city-thunder-shot-zones"></canvas>
+                <p>Where the Oklahoma City Thunder expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="oklahoma-city-thunder-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="oklahoma-city-thunder-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Oklahoma City Thunder combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="san-antonio-spurs">
+            <header>
+              <h3>San Antonio Spurs data lab</h3>
+              <span class="meta">Length laboratory</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="san-antonio-spurs-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the San Antonio Spurs preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="san-antonio-spurs-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the San Antonio Spurs developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="san-antonio-spurs-shot-zones"></canvas>
+                <p>Where the San Antonio Spurs expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="san-antonio-spurs-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="san-antonio-spurs-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for San Antonio Spurs combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        thunder: "#007AC1",
-        sunrise: "#F05133",
-        spurs: "#C4CED4",
-        charcoal: "#1C1C1C",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Cason Wallace (OKC)",
-              "Alex Caruso (OKC)",
-              "Bobi Klintman (OKC)",
-              "Stephon Castle (SAS)",
-              "Malaki Branham (SAS)",
-              "Victor Wembanyama (SAS)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [20, 18, 16, 21, 18, 15],
-                backgroundColor: [
-                  palette.thunder,
-                  palette.sunrise,
-                  palette.thunder,
-                  palette.spurs,
-                  palette.charcoal,
-                  palette.spurs
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(0, 122, 193, 0.12)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Point-of-attack defense", "Playmaking", "Catch-and-shoot", "Transition pace", "Screen navigation"],
-            datasets: [
-              {
-                label: "Cason Wallace",
-                data: [9, 6, 7, 8, 8],
-                borderColor: palette.thunder,
-                backgroundColor: "rgba(0, 122, 193, 0.25)",
-                pointBackgroundColor: palette.thunder
-              },
-              {
-                label: "Alex Caruso",
-                data: [10, 6, 7, 7, 9],
-                borderColor: palette.sunrise,
-                backgroundColor: "rgba(240, 81, 51, 0.25)",
-                pointBackgroundColor: palette.sunrise
-              },
-              {
-                label: "Stephon Castle",
-                data: [7, 8, 6, 7, 7],
-                borderColor: palette.spurs,
-                backgroundColor: "rgba(196, 206, 212, 0.25)",
-                pointBackgroundColor: palette.spurs
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(196, 206, 212, 0.12)" },
-                angleLines: { color: "rgba(196, 206, 212, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [11, 4, 1],
-                backgroundColor: [palette.thunder, palette.spurs, palette.charcoal],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400016.html
+++ b/public/previews/preseason-12400016.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400016">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities in Cleveland.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for perimeter pieces</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for guards and wings chasing rotation certainty.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="chicago-bulls">
+            <header>
+              <h3>Chicago Bulls data lab</h3>
+              <span class="meta">Half-court variability</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="chicago-bulls-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Chicago Bulls preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="chicago-bulls-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Chicago Bulls developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="chicago-bulls-shot-zones"></canvas>
+                <p>Where the Chicago Bulls expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="chicago-bulls-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="chicago-bulls-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Chicago Bulls combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="cleveland-cavaliers">
+            <header>
+              <h3>Cleveland Cavaliers data lab</h3>
+              <span class="meta">Defensive shell sync</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="cleveland-cavaliers-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Cleveland Cavaliers preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="cleveland-cavaliers-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Cleveland Cavaliers developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="cleveland-cavaliers-shot-zones"></canvas>
+                <p>Where the Cleveland Cavaliers expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="cleveland-cavaliers-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="cleveland-cavaliers-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Cleveland Cavaliers combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        bulls: "#CE1141",
-        black: "#000000",
-        cavs: "#6F263D",
-        gold: "#FDBB30",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Josh Giddey (CHI)",
-              "Coby White (CHI)",
-              "Terrence Shannon Jr. (CHI)",
-              "Caris LeVert (CLE)",
-              "Jaylon Tyson (CLE)",
-              "Emoni Bates (CLE)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [21, 20, 16, 20, 18, 17],
-                backgroundColor: [
-                  palette.bulls,
-                  palette.black,
-                  palette.bulls,
-                  palette.cavs,
-                  palette.gold,
-                  palette.cavs
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(206, 17, 65, 0.12)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Playmaking", "Catch-and-shoot", "Defensive versatility", "Transition pace", "Physicality"],
-            datasets: [
-              {
-                label: "Josh Giddey",
-                data: [9, 6, 6, 7, 6],
-                borderColor: palette.bulls,
-                backgroundColor: "rgba(206, 17, 65, 0.25)",
-                pointBackgroundColor: palette.bulls
-              },
-              {
-                label: "Coby White",
-                data: [6, 8, 5, 7, 6],
-                borderColor: palette.black,
-                backgroundColor: "rgba(0, 0, 0, 0.2)",
-                pointBackgroundColor: palette.black
-              },
-              {
-                label: "Jaylon Tyson",
-                data: [6, 7, 7, 6, 7],
-                borderColor: palette.cavs,
-                backgroundColor: "rgba(111, 38, 61, 0.25)",
-                pointBackgroundColor: palette.cavs
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(111, 38, 61, 0.12)" },
-                angleLines: { color: "rgba(111, 38, 61, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [10, 5, 2],
-                backgroundColor: [palette.cavs, palette.bulls, palette.gold],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/previews/preseason-12400018.html
+++ b/public/previews/preseason-12400018.html
@@ -47,6 +47,44 @@
         font-size: clamp(1.4rem, 4vw, 1.9rem);
         color: var(--navy);
       }
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(17, 86, 214, 0.7);
+      }
+
 
       .chart-grid {
         display: grid;
@@ -75,6 +113,11 @@
         font-size: 0.85rem;
         color: var(--text-subtle);
       }
+      .chart-card canvas {
+        width: 100%;
+        height: clamp(220px, 30vw, 270px);
+      }
+
 
       .preview-copy {
         grid-area: preview;
@@ -148,29 +191,82 @@
       }
     </style>
     <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
   </head>
-  <body>
+  <body data-preview-id="preseason-12400018">
         <main class="preview-shell">
-      <section class="visuals">
-              <h2>Preseason scouting dashboard</h2>
-              <div class="chart-grid">
-                <figure class="chart-card">
-                  <h3>Projected evaluation minutes</h3>
-                  <canvas id="rotationChart"></canvas>
-                  <p>Estimated minutes earmarked for developmental priorities in Atlanta.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Skill focus for wings/forwards</h3>
-                  <canvas id="developmentChart"></canvas>
-                  <p>Coaching emphasis (0-10 scale) for versatile forwards in this matchup.</p>
-                </figure>
-                <figure class="chart-card">
-                  <h3>Availability snapshot</h3>
-                  <canvas id="healthChart"></canvas>
-                  <p>Roster allocation across full-go groups, monitored workloads, and rehab assignments.</p>
-                </figure>
-              </div>
-            </section>
+            <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="indiana-pacers">
+            <header>
+              <h3>Indiana Pacers data lab</h3>
+              <span class="meta">Throttle mapping</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="indiana-pacers-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Indiana Pacers preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="indiana-pacers-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Indiana Pacers developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="indiana-pacers-shot-zones"></canvas>
+                <p>Where the Indiana Pacers expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="indiana-pacers-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="indiana-pacers-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Indiana Pacers combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="atlanta-hawks">
+            <header>
+              <h3>Atlanta Hawks data lab</h3>
+              <span class="meta">Pace-and-space tune-up</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="atlanta-hawks-rotation"></canvas>
+                <p>Minute allocations the staff wants to log for the Atlanta Hawks preseason reps, highlighting priority combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="atlanta-hawks-skill-spider"></canvas>
+                <p>Comparison between the coaching blueprint and current readiness for the Atlanta Hawks developmental priorities.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="atlanta-hawks-shot-zones"></canvas>
+                <p>Where the Atlanta Hawks expect preseason attempts to originate relative to a league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="atlanta-hawks-tempo-curve"></canvas>
+                <p>Five-session chronicle of tempo sessions versus special-situation installs leading into the opener.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="atlanta-hawks-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Atlanta Hawks combinations expected to share long stretches.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <article class="preview-copy">
         <header>
@@ -200,134 +296,5 @@
             </footer>
     </main>
 
-    <script defer>
-      const palette = {
-        pacers: "#002D62",
-        gold: "#FDBB30",
-        hawks: "#C8102E",
-        ink: "#000000",
-        neutral: "#7f8ea3"
-      };
-
-      window.addEventListener("DOMContentLoaded", () => {
-        const rotationCtx = document.getElementById("rotationChart");
-        const developmentCtx = document.getElementById("developmentChart");
-        const healthCtx = document.getElementById("healthChart");
-
-        new Chart(rotationCtx, {
-          type: "bar",
-          data: {
-            labels: [
-              "Andrew Nembhard (IND)",
-              "Ben Sheppard (IND)",
-              "Jarace Walker (IND)",
-              "Zaccharie Risacher (ATL)",
-              "Kobe Bufkin (ATL)",
-              "AJ Griffin (ATL)"
-            ],
-            datasets: [
-              {
-                label: "Target minutes",
-                data: [21, 18, 17, 22, 18, 16],
-                backgroundColor: [
-                  palette.pacers,
-                  palette.gold,
-                  palette.pacers,
-                  palette.hawks,
-                  palette.ink,
-                  palette.hawks
-                ],
-                borderRadius: 6
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              y: {
-                beginAtZero: true,
-                max: 24,
-                ticks: { stepSize: 4, color: palette.neutral },
-                grid: { color: "rgba(0, 45, 98, 0.12)" }
-              },
-              x: {
-                ticks: { color: palette.neutral },
-                grid: { display: false }
-              }
-            },
-            plugins: {
-              legend: { display: false }
-            }
-          }
-        });
-
-        new Chart(developmentCtx, {
-          type: "radar",
-          data: {
-            labels: ["Catch-and-shoot", "Defensive versatility", "Playmaking", "Transition pace", "Physicality"],
-            datasets: [
-              {
-                label: "Jarace Walker",
-                data: [6, 8, 6, 7, 8],
-                borderColor: palette.pacers,
-                backgroundColor: "rgba(0, 45, 98, 0.25)",
-                pointBackgroundColor: palette.pacers
-              },
-              {
-                label: "Zaccharie Risacher",
-                data: [7, 7, 5, 8, 6],
-                borderColor: palette.hawks,
-                backgroundColor: "rgba(200, 16, 46, 0.25)",
-                pointBackgroundColor: palette.hawks
-              },
-              {
-                label: "AJ Griffin",
-                data: [8, 6, 5, 6, 5],
-                borderColor: palette.ink,
-                backgroundColor: "rgba(0, 0, 0, 0.2)",
-                pointBackgroundColor: palette.ink
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            scales: {
-              r: {
-                suggestedMin: 0,
-                suggestedMax: 10,
-                ticks: { display: false },
-                grid: { color: "rgba(200, 16, 46, 0.12)" },
-                angleLines: { color: "rgba(200, 16, 46, 0.12)" },
-                pointLabels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-
-        new Chart(healthCtx, {
-          type: "doughnut",
-          data: {
-            labels: ["Cleared for full run", "Monitored workload", "Rehab group"],
-            datasets: [
-              {
-                data: [11, 4, 1],
-                backgroundColor: [palette.pacers, palette.hawks, palette.gold],
-                borderWidth: 0
-              }
-            ]
-          },
-          options: {
-            responsive: true,
-            cutout: "62%",
-            plugins: {
-              legend: {
-                position: "bottom",
-                labels: { color: palette.neutral }
-              }
-            }
-          }
-        });
-      });
-    </script>
   </body>
 </html>

--- a/public/scripts/preseason-dashboards.js
+++ b/public/scripts/preseason-dashboards.js
@@ -1,0 +1,1415 @@
+/*
+ * Preseason dashboard data for each preview page.
+ * Populates 10 visualizations (5 per team) using Chart.js.
+ */
+
+window.preseasonDashboards = {
+  "preseason-12400001": {
+    teams: [
+      {
+        name: "Boston Celtics",
+        slug: "boston-celtics",
+        colors: {
+          primary: "#007A33",
+          secondary: "#2C5234",
+          tertiary: "#CBA135"
+        },
+        rotation: {
+          labels: [
+            "Jordan Walsh",
+            "Baylor Scheierman",
+            "Payton Pritchard",
+            "Neemias Queta",
+            "Oshae Brissett"
+          ],
+          data: [24, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 9, 6, 8],
+          readiness: [6, 8, 8, 7, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 12, 10, 22, 28],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 74, 77, 72, 70],
+          specials: [22, 28, 34, 36, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Walsh + Pritchard", x: 102, y: 78, r: 14 },
+            { label: "Scheierman + Hauser", x: 96, y: 84, r: 12 },
+            { label: "Queta anchor units", x: 90, y: 72, r: 11 },
+            { label: "Brissett switch looks", x: 106, y: 80, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Denver Nuggets",
+        slug: "denver-nuggets",
+        colors: {
+          primary: "#0E2240",
+          secondary: "#8B2131",
+          tertiary: "#FDB927"
+        },
+        rotation: {
+          labels: [
+            "Julian Strawther",
+            "Peyton Watson",
+            "DaRon Holmes II",
+            "Christian Braun",
+            "Zeke Nnaji"
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 6, 8, 6, 7],
+          readiness: [6, 7, 7, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 11, 15, 20, 30],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [64, 69, 72, 70, 68],
+          specials: [18, 24, 30, 32, 26]
+        },
+        synergy: {
+          points: [
+            { label: "Strawther + Murray reps", x: 98, y: 82, r: 13 },
+            { label: "Watson + Braun wings", x: 94, y: 86, r: 12 },
+            { label: "Holmes + Jokic hub", x: 90, y: 78, r: 11 },
+            { label: "Nnaji bench rim", x: 96, y: 74, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400003": {
+    teams: [
+      {
+        name: "Minnesota Timberwolves",
+        slug: "minnesota-timberwolves",
+        colors: {
+          primary: "#0C2340",
+          secondary: "#236192",
+          tertiary: "#9EA2A2"
+        },
+        rotation: {
+          labels: [
+            "Naz Reid",
+            "Nickeil Alexander-Walker",
+            "Josh Minott",
+            "Leonard Miller",
+            "Troy Brown Jr."
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 6, 8, 5, 7],
+          readiness: [6, 7, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 13, 12, 20, 29],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 72, 75, 70, 68],
+          specials: [20, 26, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Reid + Towns stretch", x: 100, y: 80, r: 13 },
+            { label: "NAW + McDaniels traps", x: 96, y: 88, r: 12 },
+            { label: "Minott slashing wing", x: 98, y: 76, r: 11 },
+            { label: "Miller jumbo fours", x: 92, y: 74, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Los Angeles Lakers",
+        slug: "los-angeles-lakers",
+        colors: {
+          primary: "#552583",
+          secondary: "#FDB927",
+          tertiary: "#000000"
+        },
+        rotation: {
+          labels: [
+            "Austin Reaves",
+            "D'Angelo Russell",
+            "Rui Hachimura",
+            "Max Christie",
+            "Jaxson Hayes"
+          ],
+          data: [20, 18, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 6, 7, 6],
+          readiness: [7, 8, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [25, 15, 14, 20, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [64, 70, 72, 68, 67],
+          specials: [22, 28, 34, 32, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Reaves + Davis drags", x: 94, y: 88, r: 13 },
+            { label: "Russell + Rui pops", x: 98, y: 78, r: 12 },
+            { label: "Christie wing stopper", x: 96, y: 82, r: 11 },
+            { label: "Hayes rim pressure", x: 100, y: 74, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400004": {
+    teams: [
+      {
+        name: "Golden State Warriors",
+        slug: "golden-state-warriors",
+        colors: {
+          primary: "#1D428A",
+          secondary: "#FFC72C",
+          tertiary: "#26282A"
+        },
+        rotation: {
+          labels: [
+            "Jonathan Kuminga",
+            "Moses Moody",
+            "Brandin Podziemski",
+            "Trayce Jackson-Davis",
+            "Gui Santos"
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 7, 6, 6],
+          readiness: [7, 8, 7, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 12, 14, 26, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 78, 72, 71],
+          specials: [18, 24, 30, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Kuminga downhill", x: 104, y: 82, r: 14 },
+            { label: "Moody 3&D", x: 100, y: 86, r: 12 },
+            { label: "Podziemski connectors", x: 96, y: 80, r: 11 },
+            { label: "TJD roll game", x: 98, y: 78, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Los Angeles Clippers",
+        slug: "los-angeles-clippers",
+        colors: {
+          primary: "#C8102E",
+          secondary: "#1D428A",
+          tertiary: "#000000"
+        },
+        rotation: {
+          labels: [
+            "Terance Mann",
+            "Amir Coffey",
+            "Kobe Brown",
+            "Bones Hyland",
+            "Moussa Diabate"
+          ],
+          data: [20, 18, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 6, 6, 7],
+          readiness: [7, 8, 7, 6, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [22, 14, 18, 20, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 72, 69, 68],
+          specials: [18, 24, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Mann drive game", x: 96, y: 84, r: 13 },
+            { label: "Hyland pace", x: 102, y: 78, r: 12 },
+            { label: "Brown spacing", x: 94, y: 80, r: 11 },
+            { label: "Diabate rim seals", x: 90, y: 76, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400006": {
+    teams: [
+      {
+        name: "New York Knicks",
+        slug: "new-york-knicks",
+        colors: {
+          primary: "#006BB6",
+          secondary: "#F58426",
+          tertiary: "#BEC0C2"
+        },
+        rotation: {
+          labels: [
+            "Miles McBride",
+            "Donte DiVincenzo",
+            "Josh Hart",
+            "Precious Achiuwa",
+            "Jericho Sims"
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 8, 7, 6, 6],
+          readiness: [7, 8, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [25, 14, 15, 18, 28],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 73, 76, 72, 70],
+          specials: [24, 30, 34, 36, 32]
+        },
+        synergy: {
+          points: [
+            { label: "McBride + Achiuwa traps", x: 100, y: 86, r: 13 },
+            { label: "DiVincenzo motion", x: 98, y: 82, r: 12 },
+            { label: "Hart connective", x: 94, y: 84, r: 11 },
+            { label: "Sims rim protection", x: 90, y: 80, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Charlotte Hornets",
+        slug: "charlotte-hornets",
+        colors: {
+          primary: "#1D1160",
+          secondary: "#00788C",
+          tertiary: "#A1A1A4"
+        },
+        rotation: {
+          labels: [
+            "Brandon Miller",
+            "LaMelo Ball",
+            "Grant Williams",
+            "Nick Smith Jr.",
+            "JT Thor"
+          ],
+          data: [24, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 6, 8, 7],
+          readiness: [7, 7, 6, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [27, 12, 13, 22, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 75, 72, 71],
+          specials: [20, 26, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Ball + Miller creation", x: 104, y: 80, r: 14 },
+            { label: "Grant Williams switches", x: 94, y: 82, r: 12 },
+            { label: "Nick Smith pace", x: 102, y: 74, r: 11 },
+            { label: "Thor weak-side length", x: 96, y: 78, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400007": {
+    teams: [
+      {
+        name: "Washington Wizards",
+        slug: "washington-wizards",
+        colors: {
+          primary: "#002B5C",
+          secondary: "#E31837",
+          tertiary: "#C4CED4"
+        },
+        rotation: {
+          labels: [
+            "Bilal Coulibaly",
+            "Jordan Poole",
+            "Corey Kispert",
+            "Deni Avdija",
+            "Patrick Baldwin Jr."
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 8, 6, 7, 7],
+          readiness: [6, 7, 6, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 11, 15, 20, 28],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 76, 72, 70],
+          specials: [22, 28, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Coulibaly wingspan", x: 102, y: 84, r: 14 },
+            { label: "Poole pace groups", x: 106, y: 74, r: 13 },
+            { label: "Kispert movement", x: 98, y: 80, r: 11 },
+            { label: "Avdija initiator", x: 94, y: 82, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Toronto Raptors",
+        slug: "toronto-raptors",
+        colors: {
+          primary: "#BA0C2F",
+          secondary: "#000000",
+          tertiary: "#A1A1A4"
+        },
+        rotation: {
+          labels: [
+            "Scottie Barnes",
+            "RJ Barrett",
+            "Immanuel Quickley",
+            "Gradey Dick",
+            "Jakob Poeltl"
+          ],
+          data: [24, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 8, 7, 6],
+          readiness: [7, 7, 8, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 12, 14, 22, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 70, 69],
+          specials: [24, 30, 34, 36, 32]
+        },
+        synergy: {
+          points: [
+            { label: "Barnes point forward", x: 98, y: 86, r: 14 },
+            { label: "Quickley pace", x: 102, y: 80, r: 12 },
+            { label: "Barrett downhill", x: 100, y: 78, r: 11 },
+            { label: "Poeltl hub", x: 94, y: 84, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400008": {
+    teams: [
+      {
+        name: "Milwaukee Bucks",
+        slug: "milwaukee-bucks",
+        colors: {
+          primary: "#00471B",
+          secondary: "#EEE1C6",
+          tertiary: "#0077C0"
+        },
+        rotation: {
+          labels: [
+            "MarJon Beauchamp",
+            "AJ Green",
+            "Andre Jackson Jr.",
+            "Pat Connaughton",
+            "Bobby Portis"
+          ],
+          data: [22, 18, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 8, 7, 6, 6],
+          readiness: [6, 7, 8, 6, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 10, 14, 24, 28],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 74, 70, 68],
+          specials: [20, 26, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Beauchamp pressure", x: 98, y: 84, r: 13 },
+            { label: "Jackson Jr. disruption", x: 100, y: 88, r: 12 },
+            { label: "Green spacing", x: 92, y: 80, r: 11 },
+            { label: "Portis punch", x: 94, y: 82, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Detroit Pistons",
+        slug: "detroit-pistons",
+        colors: {
+          primary: "#C8102E",
+          secondary: "#1D428A",
+          tertiary: "#00274C"
+        },
+        rotation: {
+          labels: [
+            "Jaden Ivey",
+            "Ausar Thompson",
+            "Marcus Sasser",
+            "Jalen Duren",
+            "Isaiah Stewart"
+          ],
+          data: [22, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 8, 6, 7],
+          readiness: [7, 7, 8, 6, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [30, 12, 14, 20, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 76, 72, 70],
+          specials: [24, 30, 34, 36, 32]
+        },
+        synergy: {
+          points: [
+            { label: "Ivey downhill", x: 106, y: 78, r: 14 },
+            { label: "Ausar havoc", x: 100, y: 86, r: 13 },
+            { label: "Sasser control", x: 96, y: 80, r: 11 },
+            { label: "Duren lob game", x: 104, y: 82, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400010": {
+    teams: [
+      {
+        name: "Orlando Magic",
+        slug: "orlando-magic",
+        colors: {
+          primary: "#0077C0",
+          secondary: "#C4CED4",
+          tertiary: "#000000"
+        },
+        rotation: {
+          labels: [
+            "Paolo Banchero",
+            "Franz Wagner",
+            "Jalen Suggs",
+            "Anthony Black",
+            "Wendell Carter Jr."
+          ],
+          data: [22, 20, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 8, 7, 6],
+          readiness: [7, 7, 8, 7, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [30, 12, 14, 18, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 70, 69],
+          specials: [22, 28, 34, 36, 32]
+        },
+        synergy: {
+          points: [
+            { label: "Banchero hub", x: 98, y: 86, r: 14 },
+            { label: "Suggs pressure", x: 102, y: 88, r: 12 },
+            { label: "Wagner connector", x: 96, y: 84, r: 12 },
+            { label: "Black guard length", x: 100, y: 80, r: 11 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "New Orleans Pelicans",
+        slug: "new-orleans-pelicans",
+        colors: {
+          primary: "#0C2340",
+          secondary: "#85714D",
+          tertiary: "#C8102E"
+        },
+        rotation: {
+          labels: [
+            "Zion Williamson",
+            "Brandon Ingram",
+            "Trey Murphy III",
+            "Dyson Daniels",
+            "Larry Nance Jr."
+          ],
+          data: [20, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 7, 7, 7, 6],
+          readiness: [8, 7, 7, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [34, 14, 16, 18, 18],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 72, 68, 67],
+          specials: [24, 28, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Zion downhill", x: 108, y: 76, r: 15 },
+            { label: "Ingram midrange", x: 96, y: 84, r: 12 },
+            { label: "Murphy spacers", x: 98, y: 80, r: 11 },
+            { label: "Daniels defense", x: 94, y: 88, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400012": {
+    teams: [
+      {
+        name: "Memphis Grizzlies",
+        slug: "memphis-grizzlies",
+        colors: {
+          primary: "#5D76A9",
+          secondary: "#12173F",
+          tertiary: "#F5B112"
+        },
+        rotation: {
+          labels: [
+            "Desmond Bane",
+            "Ziaire Williams",
+            "GG Jackson",
+            "Santi Aldama",
+            "Brandon Clarke"
+          ],
+          data: [20, 18, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 7, 6, 7],
+          readiness: [7, 7, 8, 6, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 13, 15, 20, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 76, 72, 70],
+          specials: [20, 26, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Bane off-ball", x: 98, y: 84, r: 13 },
+            { label: "GG Jackson usage", x: 102, y: 76, r: 12 },
+            { label: "Aldama stretch", x: 96, y: 80, r: 11 },
+            { label: "Clarke rim runs", x: 104, y: 82, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Dallas Mavericks",
+        slug: "dallas-mavericks",
+        colors: {
+          primary: "#00538C",
+          secondary: "#002B5E",
+          tertiary: "#B8C4CA"
+        },
+        rotation: {
+          labels: [
+            "Luka Dončić",
+            "Kyrie Irving",
+            "Josh Green",
+            "Dereck Lively II",
+            "Olivier-Maxence Prosper"
+          ],
+          data: [18, 18, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 7, 6, 9, 7],
+          readiness: [8, 7, 6, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 12, 18, 22, 22],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [64, 70, 72, 68, 66],
+          specials: [24, 28, 34, 32, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Dončić orchestrator", x: 90, y: 88, r: 15 },
+            { label: "Irving pace", x: 96, y: 82, r: 13 },
+            { label: "Green defensive wing", x: 98, y: 84, r: 11 },
+            { label: "Lively rim roll", x: 100, y: 78, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400013": {
+    teams: [
+      {
+        name: "Oklahoma City Thunder",
+        slug: "oklahoma-city-thunder",
+        colors: {
+          primary: "#007AC1",
+          secondary: "#EF3B24",
+          tertiary: "#002D62"
+        },
+        rotation: {
+          labels: [
+            "Shai Gilgeous-Alexander",
+            "Jalen Williams",
+            "Chet Holmgren",
+            "Josh Giddey",
+            "Cason Wallace"
+          ],
+          data: [18, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 7, 8, 8, 7],
+          readiness: [8, 7, 8, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [32, 12, 12, 20, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [72, 76, 78, 74, 72],
+          specials: [22, 28, 32, 36, 30]
+        },
+        synergy: {
+          points: [
+            { label: "SGA isolation", x: 100, y: 90, r: 15 },
+            { label: "J-Dub secondary", x: 102, y: 84, r: 13 },
+            { label: "Holmgren rim protect", x: 96, y: 92, r: 14 },
+            { label: "Wallace pressure", x: 104, y: 82, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "San Antonio Spurs",
+        slug: "san-antonio-spurs",
+        colors: {
+          primary: "#000000",
+          secondary: "#C4CED4",
+          tertiary: "#8D9093"
+        },
+        rotation: {
+          labels: [
+            "Victor Wembanyama",
+            "Devin Vassell",
+            "Jeremy Sochan",
+            "Tre Jones",
+            "Malaki Branham"
+          ],
+          data: [20, 20, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 9, 7, 6],
+          readiness: [8, 7, 8, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [30, 14, 18, 18, 20],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 72, 68, 67],
+          specials: [20, 26, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Wemby rim deterrence", x: 92, y: 96, r: 15 },
+            { label: "Vassell spacing", x: 100, y: 84, r: 12 },
+            { label: "Sochan playmaking", x: 96, y: 82, r: 11 },
+            { label: "Jones tempo", x: 102, y: 80, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400016": {
+    teams: [
+      {
+        name: "Chicago Bulls",
+        slug: "chicago-bulls",
+        colors: {
+          primary: "#CE1141",
+          secondary: "#000000",
+          tertiary: "#747474"
+        },
+        rotation: {
+          labels: [
+            "Coby White",
+            "Ayo Dosunmu",
+            "Patrick Williams",
+            "Julian Phillips",
+            "Dalen Terry"
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 7, 6, 7],
+          readiness: [7, 7, 8, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 12, 16, 22, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 72, 68, 67],
+          specials: [20, 26, 30, 32, 28]
+        },
+        synergy: {
+          points: [
+            { label: "White pace", x: 100, y: 82, r: 13 },
+            { label: "Williams spacing", x: 96, y: 84, r: 12 },
+            { label: "Dosunmu on-ball", x: 98, y: 78, r: 11 },
+            { label: "Phillips length", x: 94, y: 80, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Cleveland Cavaliers",
+        slug: "cleveland-cavaliers",
+        colors: {
+          primary: "#860038",
+          secondary: "#041E42",
+          tertiary: "#FDBB30"
+        },
+        rotation: {
+          labels: [
+            "Donovan Mitchell",
+            "Darius Garland",
+            "Caris LeVert",
+            "Evan Mobley",
+            "Georges Niang"
+          ],
+          data: [20, 18, 18, 20, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 8, 7, 8, 7],
+          readiness: [8, 8, 7, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 14, 16, 20, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 70, 69],
+          specials: [22, 28, 34, 36, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Mitchell downhill", x: 102, y: 84, r: 14 },
+            { label: "Garland orchestration", x: 96, y: 88, r: 13 },
+            { label: "Mobley rim shield", x: 90, y: 94, r: 14 },
+            { label: "Niang spacing", x: 94, y: 82, r: 11 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400018": {
+    teams: [
+      {
+        name: "Indiana Pacers",
+        slug: "indiana-pacers",
+        colors: {
+          primary: "#002D62",
+          secondary: "#FDBB30",
+          tertiary: "#BEC0C2"
+        },
+        rotation: {
+          labels: [
+            "Tyrese Haliburton",
+            "Bennedict Mathurin",
+            "Andrew Nembhard",
+            "Obi Toppin",
+            "Jarace Walker"
+          ],
+          data: [20, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 8, 7, 9, 8],
+          readiness: [8, 8, 7, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 12, 12, 24, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [72, 76, 78, 74, 72],
+          specials: [24, 30, 36, 38, 34]
+        },
+        synergy: {
+          points: [
+            { label: "Haliburton orchestration", x: 98, y: 90, r: 14 },
+            { label: "Mathurin scoring", x: 104, y: 82, r: 13 },
+            { label: "Nembhard control", x: 96, y: 84, r: 11 },
+            { label: "Toppin rim pressure", x: 108, y: 78, r: 12 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Atlanta Hawks",
+        slug: "atlanta-hawks",
+        colors: {
+          primary: "#E03A3E",
+          secondary: "#C1D32F",
+          tertiary: "#26282A"
+        },
+        rotation: {
+          labels: [
+            "Trae Young",
+            "Dejounte Murray",
+            "Jalen Johnson",
+            "Bogdan Bogdanovic",
+            "Onyeka Okongwu"
+          ],
+          data: [20, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 7, 6, 9, 8],
+          readiness: [8, 7, 6, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 14, 14, 26, 22],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 76, 72, 70],
+          specials: [22, 28, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Young + Murray dual", x: 102, y: 84, r: 14 },
+            { label: "Johnson slashing", x: 104, y: 80, r: 12 },
+            { label: "Bogdanovic spacing", x: 98, y: 78, r: 11 },
+            { label: "Okongwu rim deterrence", x: 96, y: 86, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  }
+};

--- a/public/scripts/preseason-preview.js
+++ b/public/scripts/preseason-preview.js
@@ -1,0 +1,253 @@
+(function () {
+  const pageId = document.body?.dataset?.previewId;
+  const registry = window.preseasonDashboards;
+
+  if (!pageId || !registry || !registry[pageId]) {
+    return;
+  }
+
+  const { teams } = registry[pageId];
+  const gridColor = "rgba(18, 42, 68, 0.16)";
+  const tickColor = "rgba(12, 34, 56, 0.66)";
+  const labelColor = "rgba(12, 22, 34, 0.78)";
+
+  Chart.defaults.font.family = "'Barlow', 'Inter', system-ui, sans-serif";
+  Chart.defaults.color = labelColor;
+
+  function hexToRgba(hex, alpha) {
+    const clean = hex.replace('#', '');
+    const bigint = parseInt(clean, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  teams.forEach((team) => {
+    const { slug, colors, rotation, skill, shotProfile, tempo, synergy, name } = team;
+
+    const rotationCtx = document.getElementById(`${slug}-rotation`);
+    const skillCtx = document.getElementById(`${slug}-skill-spider`);
+    const shotCtx = document.getElementById(`${slug}-shot-zones`);
+    const tempoCtx = document.getElementById(`${slug}-tempo-curve`);
+    const synergyCtx = document.getElementById(`${slug}-synergy-matrix`);
+
+    if (rotationCtx) {
+      new Chart(rotationCtx, {
+        type: 'bar',
+        data: {
+          labels: rotation.labels,
+          datasets: [
+            {
+              label: 'Target minutes',
+              data: rotation.data,
+              backgroundColor: rotation.data.map((value, index) =>
+                index === 0 ? hexToRgba(colors.primary, 0.9) : hexToRgba(colors.primary, 0.7)
+              ),
+              borderColor: colors.primary,
+              borderWidth: 1,
+              borderRadius: 9,
+              hoverBackgroundColor: hexToRgba(colors.secondary, 0.75)
+            }
+          ]
+        },
+        options: {
+          indexAxis: 'y',
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              grid: { color: gridColor },
+              ticks: { color: tickColor, stepSize: 4 }
+            },
+            y: {
+              grid: { display: false },
+              ticks: { color: tickColor }
+            }
+          },
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: (context) => `${context.raw} minute plan`
+              }
+            }
+          }
+        }
+      });
+    }
+
+    if (skillCtx) {
+      new Chart(skillCtx, {
+        type: 'radar',
+        data: {
+          labels: skill.labels,
+          datasets: [
+            {
+              label: 'Coaching blueprint',
+              data: skill.training,
+              borderColor: colors.primary,
+              backgroundColor: hexToRgba(colors.primary, 0.25),
+              pointBackgroundColor: colors.primary,
+              pointBorderColor: '#ffffff'
+            },
+            {
+              label: 'Current readiness',
+              data: skill.readiness,
+              borderColor: colors.tertiary,
+              backgroundColor: hexToRgba(colors.tertiary || '#7f8ea3', 0.3),
+              pointBackgroundColor: colors.tertiary,
+              pointBorderColor: '#ffffff'
+            }
+          ]
+        },
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            r: {
+              suggestedMin: 0,
+              suggestedMax: 10,
+              angleLines: { color: gridColor },
+              grid: { color: gridColor },
+              pointLabels: { color: tickColor },
+              ticks: { display: false }
+            }
+          }
+        }
+      });
+    }
+
+    if (shotCtx) {
+      new Chart(shotCtx, {
+        type: 'bar',
+        data: {
+          labels: shotProfile.labels,
+          datasets: [
+            {
+              label: name,
+              data: shotProfile.team,
+              backgroundColor: hexToRgba(colors.primary, 0.75),
+              borderColor: colors.primary,
+              borderWidth: 1,
+              borderRadius: 8
+            },
+            {
+              label: 'League baseline',
+              data: shotProfile.league,
+              backgroundColor: 'rgba(18, 42, 68, 0.18)',
+              borderColor: 'rgba(18, 42, 68, 0.4)',
+              borderWidth: 1,
+              borderRadius: 8
+            }
+          ]
+        },
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              stacked: false,
+              grid: { display: false },
+              ticks: { color: tickColor }
+            },
+            y: {
+              grid: { color: gridColor },
+              ticks: { color: tickColor, callback: (value) => `${value}%` }
+            }
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                label: (context) => `${context.dataset.label}: ${context.raw}% of attempts`
+              }
+            }
+          }
+        }
+      });
+    }
+
+    if (tempoCtx) {
+      new Chart(tempoCtx, {
+        type: 'line',
+        data: {
+          labels: tempo.labels,
+          datasets: [
+            {
+              label: 'Tempo sessions',
+              data: tempo.tempo,
+              borderColor: colors.primary,
+              backgroundColor: hexToRgba(colors.primary, 0.2),
+              fill: true,
+              tension: 0.35,
+              pointRadius: 4,
+              pointBackgroundColor: colors.primary
+            },
+            {
+              label: 'Special situation installs',
+              data: tempo.specials,
+              borderColor: colors.secondary,
+              backgroundColor: hexToRgba(colors.secondary || colors.primary, 0.2),
+              fill: true,
+              tension: 0.35,
+              pointRadius: 4,
+              pointBackgroundColor: colors.secondary || colors.primary
+            }
+          ]
+        },
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              grid: { display: false },
+              ticks: { color: tickColor }
+            },
+            y: {
+              grid: { color: gridColor },
+              ticks: { color: tickColor }
+            }
+          }
+        }
+      });
+    }
+
+    if (synergyCtx) {
+      new Chart(synergyCtx, {
+        type: 'bubble',
+        data: {
+          datasets: [
+            {
+              label: `${name} pairings`,
+              data: synergy.points.map((point) => ({ x: point.x, y: point.y, r: point.r })),
+              backgroundColor: synergy.points.map((_, index) =>
+                index === 0 ? hexToRgba(colors.primary, 0.65) : hexToRgba(colors.secondary || colors.primary, 0.55)
+              ),
+              borderColor: colors.primary,
+              borderWidth: 1
+            }
+          ]
+        },
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            x: {
+              title: { display: true, text: synergy.xLabel, color: tickColor },
+              grid: { color: gridColor },
+              ticks: { color: tickColor }
+            },
+            y: {
+              title: { display: true, text: synergy.yLabel, color: tickColor },
+              grid: { color: gridColor },
+              ticks: { color: tickColor }
+            }
+          },
+          plugins: {
+            tooltip: {
+              callbacks: {
+                title: (items) => items[0]?.raw ? `${items[0].raw.x} pace / ${items[0].raw.y} sync` : '',
+                label: (context) => synergy.points[context.dataIndex]?.label || ''
+              }
+            }
+          }
+        }
+      });
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add a shared data set of preseason metrics for every preview matchup and centralize chart rendering logic
- replace each preseason preview page with twin team panels that host five charts apiece plus shared styling updates
- remove legacy inline Chart.js blocks in favor of the new reusable dashboard scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d88c0345388327aa467b2f3557433d