### PR TITLE
Reorder GOAT Index to prioritize leaderboard

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -84,31 +84,6 @@
       </header>
 
       <main>
-        <section id="goat-method" class="goat-methodology">
-          <div class="section-header">
-            <h2>How the General Overall Attribute Total is built</h2>
-          </div>
-          <div class="goat-methodology__layout">
-            <figure class="viz-card" data-chart-wrapper>
-              <header class="viz-card__title">Weight blueprint</header>
-              <div class="viz-canvas">
-                <canvas data-chart="goat-weight-donut" aria-label="GOAT component weighting"></canvas>
-              </div>
-              <figcaption class="viz-card__caption">Component weight, expressed in percentage of the total GOAT equation.</figcaption>
-            </figure>
-            <div class="goat-methodology__grid" data-weight-list>
-              <article class="goat-weight-card">
-                <header>
-                  <span class="goat-weight-label">Loading components…</span>
-                  <span class="goat-weight-chip">—</span>
-                </header>
-                <div class="goat-weight-meter" aria-hidden="true"><span style="width: 0%"></span></div>
-                <p class="goat-weight-copy">The weighting profile is on its way.</p>
-              </article>
-            </div>
-          </div>
-        </section>
-
         <section id="goat-board" class="goat-leaderboard">
           <div class="section-header">
             <h2>Pantheon leaderboard</h2>
@@ -149,6 +124,30 @@
           </div>
         </section>
 
+        <section id="goat-method" class="goat-methodology">
+          <div class="section-header">
+            <h2>How the General Overall Attribute Total is built</h2>
+          </div>
+          <div class="goat-methodology__layout">
+            <figure class="viz-card" data-chart-wrapper>
+              <header class="viz-card__title">Weight blueprint</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-weight-donut" aria-label="GOAT component weighting"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Component weight, expressed in percentage of the total GOAT equation.</figcaption>
+            </figure>
+            <div class="goat-methodology__grid" data-weight-list>
+              <article class="goat-weight-card">
+                <header>
+                  <span class="goat-weight-label">Loading components…</span>
+                  <span class="goat-weight-chip">—</span>
+                </header>
+                <div class="goat-weight-meter" aria-hidden="true"><span style="width: 0%"></span></div>
+                <p class="goat-weight-copy">The weighting profile is on its way.</p>
+              </article>
+            </div>
+          </div>
+        </section>
         <section class="goat-visuals">
           <div class="section-header">
             <h2>Pantheon lab</h2>


### PR DESCRIPTION
## Summary
- move the Pantheon leaderboard section above the methodology content on the GOAT Index page

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d89281aa788327a18cd26400d54411