### PR TITLE
Simplify GOAT Index hero and reorder sections

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -28,87 +28,13 @@
         </div>
         <div class="hero hero--goat">
           <div class="hero__intro">
-            <span class="eyebrow">GOAT Index Debut</span>
-            <h1>The all-time race through the General Overall Attribute Total.</h1>
-            <div class="hero__metrics" role="list">
-              <article class="hero-metric" role="listitem">
-                <header class="hero-metric__header">
-                  <span class="hero-metric__label">Pantheon saturation</span>
-                  <span class="hero-metric__value" data-hero-saturation-value>—</span>
-                </header>
-                <div class="viz-card viz-card--compact" data-chart-wrapper>
-                  <div class="viz-canvas">
-                    <canvas data-chart="goat-saturation-gauge" data-chart-ratio="0.7" aria-label="Average GOAT score gauge"></canvas>
-                  </div>
-                </div>
-              </article>
-              <article class="hero-metric" role="listitem">
-                <header class="hero-metric__header">
-                  <span class="hero-metric__label">Active dynasty share</span>
-                  <span class="hero-metric__value" data-hero-active-value>—</span>
-                </header>
-                <div class="viz-card viz-card--compact" data-chart-wrapper>
-                  <div class="viz-canvas">
-                    <canvas data-chart="goat-active-gauge" data-chart-ratio="0.7" aria-label="Active players gauge"></canvas>
-                  </div>
-                </div>
-              </article>
-              <article class="hero-metric" role="listitem">
-                <header class="hero-metric__header">
-                  <span class="hero-metric__label">Orbit jumpers</span>
-                  <span class="hero-metric__value" data-hero-orbit-value>—</span>
-                </header>
-                <div class="viz-card viz-card--compact" data-chart-wrapper>
-                  <div class="viz-canvas">
-                    <canvas data-chart="goat-multi-franchise-gauge" data-chart-ratio="0.7" aria-label="Multi-franchise gauge"></canvas>
-                  </div>
-                </div>
-              </article>
-            </div>
-            <div class="cta-group" role="group" aria-label="Primary actions">
-              <a class="cta cta--primary" href="#goat-board">See the leaderboard</a>
-              <a class="cta cta--ghost" href="#goat-method">Understand the formula</a>
-            </div>
-          </div>
-          <div class="hero__visual" aria-hidden="true">
-            <div class="goat-hero-graphic">
-              <div class="goat-hero-planet"></div>
-              <div class="goat-hero-orbit"></div>
-              <div class="goat-hero-orbit goat-hero-orbit--delay"></div>
-              <div class="goat-hero-node goat-hero-node--primary"></div>
-              <div class="goat-hero-node goat-hero-node--secondary"></div>
-              <div class="goat-hero-node goat-hero-node--tertiary"></div>
-            </div>
+            <span class="eyebrow">GOAT INDEX</span>
+            <h1>General Overall Attribute Total.</h1>
           </div>
         </div>
       </header>
 
       <main>
-        <section id="goat-method" class="goat-methodology">
-          <div class="section-header">
-            <h2>How the General Overall Attribute Total is built</h2>
-          </div>
-          <div class="goat-methodology__layout">
-            <figure class="viz-card" data-chart-wrapper>
-              <header class="viz-card__title">Weight blueprint</header>
-              <div class="viz-canvas">
-                <canvas data-chart="goat-weight-donut" aria-label="GOAT component weighting"></canvas>
-              </div>
-              <figcaption class="viz-card__caption">Component weight, expressed in percentage of the total GOAT equation.</figcaption>
-            </figure>
-            <div class="goat-methodology__grid" data-weight-list>
-              <article class="goat-weight-card">
-                <header>
-                  <span class="goat-weight-label">Loading components…</span>
-                  <span class="goat-weight-chip">—</span>
-                </header>
-                <div class="goat-weight-meter" aria-hidden="true"><span style="width: 0%"></span></div>
-                <p class="goat-weight-copy">The weighting profile is on its way.</p>
-              </article>
-            </div>
-          </div>
-        </section>
-
         <section id="goat-board" class="goat-leaderboard">
           <div class="section-header">
             <h2>Pantheon leaderboard</h2>
@@ -146,6 +72,31 @@
               </div>
               <footer class="goat-detail__footer" data-goat-footer></footer>
             </aside>
+          </div>
+        </section>
+
+        <section id="goat-method" class="goat-methodology">
+          <div class="section-header">
+            <h2>How the General Overall Attribute Total is built</h2>
+          </div>
+          <div class="goat-methodology__layout">
+            <figure class="viz-card" data-chart-wrapper>
+              <header class="viz-card__title">Weight blueprint</header>
+              <div class="viz-canvas">
+                <canvas data-chart="goat-weight-donut" aria-label="GOAT component weighting"></canvas>
+              </div>
+              <figcaption class="viz-card__caption">Component weight, expressed in percentage of the total GOAT equation.</figcaption>
+            </figure>
+            <div class="goat-methodology__grid" data-weight-list>
+              <article class="goat-weight-card">
+                <header>
+                  <span class="goat-weight-label">Loading components…</span>
+                  <span class="goat-weight-chip">—</span>
+                </header>
+                <div class="goat-weight-meter" aria-hidden="true"><span style="width: 0%"></span></div>
+                <p class="goat-weight-copy">The weighting profile is on its way.</p>
+              </article>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- streamline the GOAT Index hero so it only shows the banner and page title
- move the leaderboard ahead of the methodology section to match the desired layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d893a8fa0c8327a75f97207112c448