### PR TITLE
Simplify GOAT index hero presentation

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -28,57 +28,8 @@
         </div>
         <div class="hero hero--goat">
           <div class="hero__intro">
-            <span class="eyebrow">GOAT Index Debut</span>
-            <h1>The all-time race through the General Overall Attribute Total.</h1>
-            <div class="hero__metrics" role="list">
-              <article class="hero-metric" role="listitem">
-                <header class="hero-metric__header">
-                  <span class="hero-metric__label">Pantheon saturation</span>
-                  <span class="hero-metric__value" data-hero-saturation-value>—</span>
-                </header>
-                <div class="viz-card viz-card--compact" data-chart-wrapper>
-                  <div class="viz-canvas">
-                    <canvas data-chart="goat-saturation-gauge" data-chart-ratio="0.7" aria-label="Average GOAT score gauge"></canvas>
-                  </div>
-                </div>
-              </article>
-              <article class="hero-metric" role="listitem">
-                <header class="hero-metric__header">
-                  <span class="hero-metric__label">Active dynasty share</span>
-                  <span class="hero-metric__value" data-hero-active-value>—</span>
-                </header>
-                <div class="viz-card viz-card--compact" data-chart-wrapper>
-                  <div class="viz-canvas">
-                    <canvas data-chart="goat-active-gauge" data-chart-ratio="0.7" aria-label="Active players gauge"></canvas>
-                  </div>
-                </div>
-              </article>
-              <article class="hero-metric" role="listitem">
-                <header class="hero-metric__header">
-                  <span class="hero-metric__label">Orbit jumpers</span>
-                  <span class="hero-metric__value" data-hero-orbit-value>—</span>
-                </header>
-                <div class="viz-card viz-card--compact" data-chart-wrapper>
-                  <div class="viz-canvas">
-                    <canvas data-chart="goat-multi-franchise-gauge" data-chart-ratio="0.7" aria-label="Multi-franchise gauge"></canvas>
-                  </div>
-                </div>
-              </article>
-            </div>
-            <div class="cta-group" role="group" aria-label="Primary actions">
-              <a class="cta cta--primary" href="#goat-board">See the leaderboard</a>
-              <a class="cta cta--ghost" href="#goat-method">Understand the formula</a>
-            </div>
-          </div>
-          <div class="hero__visual" aria-hidden="true">
-            <div class="goat-hero-graphic">
-              <div class="goat-hero-planet"></div>
-              <div class="goat-hero-orbit"></div>
-              <div class="goat-hero-orbit goat-hero-orbit--delay"></div>
-              <div class="goat-hero-node goat-hero-node--primary"></div>
-              <div class="goat-hero-node goat-hero-node--secondary"></div>
-              <div class="goat-hero-node goat-hero-node--tertiary"></div>
-            </div>
+            <span class="eyebrow">GOAT Index</span>
+            <h1>General Overall Attribute Total.</h1>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- streamline the GOAT landing hero to only display the title banner
- keep the leaderboard, methodology, and lab sections immediately following the heading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8948dcbd083278230cdec6722eb5f