### PR TITLE
Filter USA from international talent chart

### DIFF
--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -223,7 +223,9 @@ registerCharts([
     element: document.querySelector('[data-chart="country-spectrum"]'),
     source: 'data/players_overview.json',
     async createConfig(data) {
-      const countries = helpers.rankAndSlice(Array.isArray(data?.countries) ? data.countries : [], 7, (item) => item.players);
+      const allCountries = Array.isArray(data?.countries) ? data.countries : [];
+      const international = allCountries.filter((entry) => (entry?.country || '').toLowerCase() !== 'usa');
+      const countries = helpers.rankAndSlice(international, 7, (item) => item.players);
       if (!countries.length) return null;
 
       return {


### PR DESCRIPTION
## Summary
- exclude United States data from the international talent spectrum chart so the remaining countries are visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89590e808832782f49dc1a381c112