### PR TITLE
Add active player rankings feature to players page

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -38,6 +38,88 @@
       </header>
 
       <main class="players-lab">
+        <section class="players-rankings">
+          <div class="players-rankings__intro">
+            <h2>Who's the Man Right Now?</h2>
+            <p>
+              Using our GOAT ranking system of active players and production over the last three
+              seasons, here's how we stack the game's current apex performers.
+            </p>
+          </div>
+          <ol class="players-rankings__list">
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">1</span>
+              <div class="players-rankings__body">
+                <strong>Nikola Jokić — Nuggets</strong>
+                <span>Two MVPs and a title run fueled by an all-time efficiency blend of scoring and playmaking.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">2</span>
+              <div class="players-rankings__body">
+                <strong>Giannis Antetokounmpo — Bucks</strong>
+                <span>Still the league's most relentless downhill force, anchoring elite two-way metrics.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">3</span>
+              <div class="players-rankings__body">
+                <strong>Luka Dončić — Mavericks</strong>
+                <span>Carrying Dallas with historic usage, triple-double pace, and deep playoff shotmaking.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">4</span>
+              <div class="players-rankings__body">
+                <strong>Joel Embiid — 76ers</strong>
+                <span>The reigning scoring champ whose interior gravity warps defenses every trip.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">5</span>
+              <div class="players-rankings__body">
+                <strong>Shai Gilgeous-Alexander — Thunder</strong>
+                <span>Efficiency monster with elite drives, rim pressure, and clutch steal rates.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">6</span>
+              <div class="players-rankings__body">
+                <strong>Jayson Tatum — Celtics</strong>
+                <span>Versatile wing engine spearheading Boston's top-tier net ratings on both ends.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">7</span>
+              <div class="players-rankings__body">
+                <strong>Stephen Curry — Warriors</strong>
+                <span>The original gravity well, still bending defenses with pull-up threes and movement.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">8</span>
+              <div class="players-rankings__body">
+                <strong>Anthony Davis — Lakers</strong>
+                <span>Premier rim protector posting 25/12 lines while switching across schemes.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">9</span>
+              <div class="players-rankings__body">
+                <strong>Kevin Durant — Suns</strong>
+                <span>Still an elite shotmaker with 50/40/90 efficiency powering Phoenix's half-court sets.</span>
+              </div>
+            </li>
+            <li class="players-rankings__item">
+              <span class="players-rankings__rank">10</span>
+              <div class="players-rankings__body">
+                <strong>Devin Booker — Suns</strong>
+                <span>High-usage creator blending three-level scoring with a growing playmaking portfolio.</span>
+              </div>
+            </li>
+          </ol>
+        </section>
+
         <section class="players-lab__section">
           <header class="players-lab__section-header">
             <h2>Morphology lab</h2>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -3018,6 +3018,66 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 .players-lab { display: grid; gap: clamp(2.4rem, 5vw, 3.8rem); margin-bottom: 4rem; }
+.players-rankings {
+  display: grid;
+  gap: clamp(1.4rem, 3vw, 2rem);
+  padding: clamp(1.6rem, 3.4vw, 2.4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background:
+    linear-gradient(140deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.14)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.88) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: var(--shadow-soft);
+}
+.players-rankings__intro { display: grid; gap: 0.6rem; max-width: 640px; }
+.players-rankings__intro h2 { font-size: clamp(1.7rem, 3.2vw, 2.1rem); }
+.players-rankings__intro p {
+  margin: 0;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+.players-rankings__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: clamp(0.75rem, 2vw, 1.1rem);
+}
+.players-rankings__item {
+  display: grid;
+  gap: 0.85rem;
+  align-items: center;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: clamp(0.75rem, 1.8vw, 1rem) clamp(0.9rem, 2vw, 1.2rem);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.78) 65%, rgba(242, 246, 255, 0.88) 35%);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+.players-rankings__item:nth-child(-n + 3) {
+  border-color: color-mix(in srgb, var(--royal) 30%, transparent);
+  background: linear-gradient(150deg, rgba(17, 86, 214, 0.16), rgba(244, 181, 63, 0.12));
+}
+.players-rankings__rank {
+  display: grid;
+  place-items: center;
+  width: clamp(2.6rem, 4vw, 3rem);
+  height: clamp(2.6rem, 4vw, 3rem);
+  border-radius: 16px;
+  font-weight: 700;
+  font-size: clamp(1.4rem, 3.2vw, 1.8rem);
+  color: var(--surface);
+  background: linear-gradient(135deg, var(--royal), var(--sky));
+  box-shadow: 0 12px 20px rgba(17, 86, 214, 0.18);
+}
+.players-rankings__item:nth-child(-n + 3) .players-rankings__rank {
+  background: linear-gradient(135deg, var(--gold), #ffdd77);
+  color: var(--navy);
+  box-shadow: 0 12px 22px rgba(244, 181, 63, 0.32);
+}
+.players-rankings__body { display: grid; gap: 0.3rem; }
+.players-rankings__body strong { font-size: 1.05rem; color: var(--navy); }
+.players-rankings__body span { color: var(--text-subtle); font-size: 0.95rem; line-height: 1.55; }
 .players-lab__section { display: grid; gap: 1.5rem; }
 .players-lab__section-header { display: grid; gap: 0.6rem; max-width: 660px; }
 .players-lab__section-header h2 { margin: 0; font-size: clamp(1.6rem, 3vw, 1.9rem); }


### PR DESCRIPTION
## Summary
- add a "Who's the Man Right Now?" feature atop the players page with a top-10 active ranking
- style the rankings module to match the hub aesthetic and highlight the podium spots

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d89951d15c83279b71c1a87c3975eb