### PR TITLE
Add preseason preview pages for remaining openers

### DIFF
--- a/public/previews/preseason-12400002.html
+++ b/public/previews/preseason-12400002.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: International Showcase at Utah Jazz</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(0, 71, 27, 0.1);
+        --visual-tint: rgba(0, 71, 27, 0.08);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(0, 71, 27, 0.04) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(0, 71, 27, 0.72);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(0, 71, 27, 0.72);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(0, 71, 27, 0.12);
+        color: #00471b;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400002">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="international-showcase">
+            <header>
+              <h3>International Showcase camp lab</h3>
+              <span class="meta">Traveling select team</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="international-showcase-rotation"></canvas>
+                <p>Projected minute curve for the global select roster as it tests spacing and pace adjustments on NBA floors.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="international-showcase-skill-spider"></canvas>
+                <p>Developmental emphasis versus current readiness for a roster balancing Euro-style movement with NBA tempo.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="international-showcase-shot-zones"></canvas>
+                <p>How the Showcase group expects to generate attempts compared with a typical NBA distribution.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="international-showcase-tempo-curve"></canvas>
+                <p>Chronicle of training tempo and special-situation installs as the tour stop transitions from Europe to Salt Lake City.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="international-showcase-synergy-matrix"></canvas>
+                <p>Pace and coverage sync readings for Showcase combinations eager to impress scouts.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="utah-jazz">
+            <header>
+              <h3>Utah Jazz data lab</h3>
+              <span class="meta">Lineup calibration</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="utah-jazz-rotation"></canvas>
+                <p>Minute allocations Will Hardy wants for Utah’s young guard/wing core as it opens the preseason.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="utah-jazz-skill-spider"></canvas>
+                <p>Blueprint versus readiness metrics for Jazz prospects learning to share initiator duties.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="utah-jazz-shot-zones"></canvas>
+                <p>Where Utah anticipates its preseason attempts to originate compared with the league baseline mix.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="utah-jazz-tempo-curve"></canvas>
+                <p>Five-session tempo tracker capturing how the Jazz blend conditioning runs with situational work.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="utah-jazz-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indices for Utah combinations pushing for early minutes.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-04T21:00:00+00:00">Friday, October 04, 2024 — 21:00 UTC</time>
+          <h1>International Showcase at Utah Jazz</h1>
+          <p><strong>Delta Center · Salt Lake City, UT</strong> · Preseason opener</p>
+          <p class="lead">Utah’s opening night doubles as a measuring stick for a global select squad that has been barnstorming North America in search of NBA reps.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>The traveling Showcase group has been emphasizing tempo the entire tour; Tremont Waters is steering two-guard looks that free Luke Travers to attack mismatches on the wing. Staffers want to see whether Bruno Caboclo and Khalifa Diop can anchor drop coverage without fouling once NBA officiating tightens.</p>
+          <p>For the Jazz, Keyonte George and rookie Cody Williams headline the developmental checklist. Utah is testing jumbo switch groups with Taylor Hendricks and Walker Kessler, while Brice Sensabaugh’s shooting gravity is being mapped against second-unit ball-handling duties.</p>
+          <p>Utah’s analytics group will also scrutinize transition organization—last season’s Achilles’ heel. Expect early minutes for Collin Sexton to set the pace before giving way to long looks at the Jazz’s wing depth.</p>
+          <ul>
+            <li>Can the Showcase roster keep turnover counts down against Utah’s length when the Jazz toggle between switch and drop?</li>
+            <li>How comfortable does Cody Williams look toggling between spot-up and on-ball reps within Utah’s second unit?</li>
+            <li>Does Walker Kessler’s rim deterrence hold up without unnecessary contests that lead to foul trouble?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of September 28.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400009.html
+++ b/public/previews/preseason-12400009.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: Phoenix Suns at Los Angeles Lakers</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(229, 96, 32, 0.12);
+        --visual-tint: rgba(229, 96, 32, 0.08);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(229, 96, 32, 0.04) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(229, 96, 32, 0.72);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(229, 96, 32, 0.78);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(229, 96, 32, 0.14);
+        color: #e56020;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400009">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="phoenix-suns">
+            <header>
+              <h3>Phoenix Suns data lab</h3>
+              <span class="meta">Bench recalibration</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="phoenix-suns-rotation"></canvas>
+                <p>Minute band the Suns want to hit for their revamped bench wings while Booker and Durant ramp up separately.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="phoenix-suns-skill-spider"></canvas>
+                <p>Blueprint versus readiness for Phoenix role players asked to toggle between spot-up spacing and secondary creation.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="phoenix-suns-shot-zones"></canvas>
+                <p>Expected shot mix for Phoenix in Palm Desert as the staff leans into more corner three volume.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="phoenix-suns-tempo-curve"></canvas>
+                <p>Tracking tempo sessions and special-situation work as the Suns emphasize early-clock threes.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="phoenix-suns-synergy-matrix"></canvas>
+                <p>Tempo/coverage sync readings for Suns reserve combinations searching for trust alongside the stars.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="los-angeles-lakers">
+            <header>
+              <h3>Los Angeles Lakers data lab</h3>
+              <span class="meta">Rhythm calibration</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="los-angeles-lakers-rotation"></canvas>
+                <p>Minute distribution JJ Redick wants for his guard-heavy bench as stars take light shifts in the desert.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="los-angeles-lakers-skill-spider"></canvas>
+                <p>Comparison between the Lakers’ developmental roadmap and the current readiness of their new-look reserve backcourt.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="los-angeles-lakers-shot-zones"></canvas>
+                <p>How Los Angeles plans to create shots with Dalton Knecht and Spencer Dinwiddie orchestrating second units.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="los-angeles-lakers-tempo-curve"></canvas>
+                <p>Tempo tracking for Redick’s motion offense installs during a condensed Palm Desert schedule.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="los-angeles-lakers-synergy-matrix"></canvas>
+                <p>Pace and coverage sync indices for Los Angeles pairings expected to flank James and Davis later in the week.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-06T21:30:00+00:00">Sunday, October 06, 2024 — 21:30 UTC</time>
+          <h1>Phoenix Suns at Los Angeles Lakers</h1>
+          <p><strong>Acrisure Arena · Palm Desert, CA</strong> · Preseason opener</p>
+          <p class="lead">The desert showcase delivers a first look at Frank Vogel’s second-unit tweaks against JJ Redick’s motion-heavy Lakers blueprint.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>Phoenix is treating this swing as a chemistry lab for the role players expected to spell Devin Booker and Kevin Durant. Grayson Allen, Royce O’Neale, and Bol Bol will play extended minutes to sharpen the Suns’ spacing and backline length—two priorities after last year’s postseason exit.</p>
+          <p>Los Angeles wants to stress-test Dalton Knecht and Bronny James in real NBA pace. Spencer Dinwiddie will orchestrate early lineups while LeBron James and Anthony Davis take short shifts aimed at rhythm, not volume. Expect a heavy diet of staggered actions designed to create automatic reads for Knecht on the move.</p>
+          <p>Both staffs have circled transition defense as the night’s deciding variable. The Lakers struggled to corral live-ball turnovers last season, and the Suns believe Saben Lee’s pace can tilt the court if Phoenix wins the turnover margin.</p>
+          <ul>
+            <li>Do the Suns’ reserve lineups generate corner three volume without sacrificing defensive rebounding?</li>
+            <li>How comfortable is Dalton Knecht defending Phoenix’s switch-hunting wings in space?</li>
+            <li>Can Bronny James steady the second unit’s tempo while sharing the floor with Dinwiddie?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of September 29.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400011.html
+++ b/public/previews/preseason-12400011.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: International Showcase at Philadelphia 76ers</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(0, 107, 182, 0.12);
+        --visual-tint: rgba(0, 107, 182, 0.08);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(0, 107, 182, 0.05) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(0, 107, 182, 0.75);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(0, 107, 182, 0.78);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(0, 107, 182, 0.16);
+        color: #006bb6;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400011">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="international-showcase">
+            <header>
+              <h3>International Showcase camp lab</h3>
+              <span class="meta">World tour reps</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="international-showcase-rotation"></canvas>
+                <p>Expected minute curve for the global squad as it adapts to NBA physicality on a quick-turn road swing.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="international-showcase-skill-spider"></canvas>
+                <p>Readiness versus emphasis for Showcase playmakers as they toggle between FIBA spacing and NBA tempo.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="international-showcase-shot-zones"></canvas>
+                <p>Projected shot selection for the tour roster compared with the NBA baseline mix they’re trying to mimic.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="international-showcase-tempo-curve"></canvas>
+                <p>Pace of recent tune-ups as the Showcase coaches install more half-court counters before facing the 76ers.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="international-showcase-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indicators for Showcase pairings hoping to earn G League or camp invites.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="philadelphia-76ers">
+            <header>
+              <h3>Philadelphia 76ers data lab</h3>
+              <span class="meta">Guard creation focus</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="philadelphia-76ers-rotation"></canvas>
+                <p>Minute targets Nick Nurse set for Tyrese Maxey and rookie Jared McCain as the backcourt hierarchy evolves.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="philadelphia-76ers-skill-spider"></canvas>
+                <p>Comparison between Philadelphia’s development goals and the current readiness grades of its guard-driven lineups.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="philadelphia-76ers-shot-zones"></canvas>
+                <p>How the 76ers expect to generate looks with Maxey pushing pace and wings filling lanes.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="philadelphia-76ers-tempo-curve"></canvas>
+                <p>Five-session tempo tracker highlighting the blend of transition reps and special-situation work for Philly.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="philadelphia-76ers-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync readings for 76ers combinations featuring Paul Reed in the short roll.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-07T19:00:00+00:00">Monday, October 07, 2024 — 19:00 UTC</time>
+          <h1>International Showcase at Philadelphia 76ers</h1>
+          <p><strong>Wells Fargo Center · Philadelphia, PA</strong> · Preseason opener</p>
+          <p class="lead">Philadelphia tips off against the barnstorming Showcase squad, offering early looks at Maxey’s expanded on-ball role and the rookie guard pipeline.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>The Showcase roster arrives in Philly after a weekend session in Canada, aiming to prove its pace-and-space concepts travel. Tremont Waters will see heavy usage against NBA length, and the staff wants to evaluate Nigel Hayes-Davis as a connective forward in pick-and-pop sets.</p>
+          <p>Nick Nurse is leaning into dual guard lineups—Tyrese Maxey and Jared McCain will split creation duties while Kelly Oubre Jr. and Ricky Council IV toggle between slashing and spot-up roles. Paul Reed anchors the backline as the 76ers test small-ball coverages without Joel Embiid.</p>
+          <p>Philadelphia’s video room is focused on transition organization and early-clock threes. Expect Maxey to push off rebounds, while the Showcase club counters with intricate set plays designed to expose rotations from younger 76ers defenders.</p>
+          <ul>
+            <li>Can the Showcase bigs keep Paul Reed off the offensive glass when Philadelphia plays five-out?</li>
+            <li>Does Jared McCain hold up defensively when targeted by the Showcase’s experienced guards?</li>
+            <li>How many minutes does Maxey log before Nurse shifts to extended looks for McCain and Ricky Council IV?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of September 30.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400014.html
+++ b/public/previews/preseason-12400014.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: Houston Rockets at Utah Jazz</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(0, 71, 27, 0.1);
+        --visual-tint: rgba(0, 71, 27, 0.08);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(0, 71, 27, 0.04) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(0, 71, 27, 0.72);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(0, 71, 27, 0.72);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(0, 71, 27, 0.12);
+        color: #00471b;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400014">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="houston-rockets">
+            <header>
+              <h3>Houston Rockets data lab</h3>
+              <span class="meta">Pace and pressure</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="houston-rockets-rotation"></canvas>
+                <p>Minute plan for Ime Udoka’s young core as Amen Thompson and Cam Whitmore audition for expanded roles.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="houston-rockets-skill-spider"></canvas>
+                <p>How Houston grades progress on creation, spacing, and defensive disruption during its first preseason trip.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="houston-rockets-shot-zones"></canvas>
+                <p>Expected shot profile for the Rockets with Jalen Green and Cam Whitmore pushing rim pressure.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="houston-rockets-tempo-curve"></canvas>
+                <p>Tracking tempo work as Houston emphasizes quick decisions and free throw creation before the regular season.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="houston-rockets-synergy-matrix"></canvas>
+                <p>Pace and coverage sync notes for Rockets pairings built around Thompson’s downhill playmaking.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="utah-jazz">
+            <header>
+              <h3>Utah Jazz data lab</h3>
+              <span class="meta">Wing experimentation</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="utah-jazz-rotation"></canvas>
+                <p>Minute distribution Will Hardy will monitor as the Jazz continue sorting through their wing hierarchy.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="utah-jazz-skill-spider"></canvas>
+                <p>Blueprint versus readiness for Utah’s core prospects balancing playmaking reps with defensive assignments.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="utah-jazz-shot-zones"></canvas>
+                <p>Where the Jazz want attempts to come from as Keyonte George and Taylor Hendricks share the floor.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="utah-jazz-tempo-curve"></canvas>
+                <p>Pace tracker showing Utah’s effort to mix structured half-court sets with opportunistic transition pushes.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="utah-jazz-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync readings for Jazz lineups featuring Walker Kessler as the anchor.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-07T21:00:00+00:00">Monday, October 07, 2024 — 21:00 UTC</time>
+          <h1>Houston Rockets at Utah Jazz</h1>
+          <p><strong>Delta Center · Salt Lake City, UT</strong> · Preseason opener</p>
+          <p class="lead">Houston’s youth movement gets a stiff test against a Jazz squad prioritizing wing experimentation and rim protection.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>The Rockets are sprinting through camp with Amen Thompson and Cam Whitmore pushing tempo. Udoka wants to see if that pace holds against Utah’s length, especially with Steven Adams providing screening and rebounding insurance for second units.</p>
+          <p>Utah counters with lineups built around Keyonte George and Cody Williams, two players tasked with making quick decisions against pressure. Taylor Hendricks and Walker Kessler will toggle between switching and drop coverage to test chemistry with smaller guards.</p>
+          <p>Both teams view this meeting as a physicality checkpoint. Houston is emphasizing defensive rebounding to ignite fast breaks, while the Jazz want crisper half-court spacing to open driving lanes for George and Sexton.</p>
+          <ul>
+            <li>Does Amen Thompson’s pace unlock easier buckets or lead to turnovers against Utah’s length?</li>
+            <li>How comfortable is Taylor Hendricks defending in space when matched with Cam Whitmore’s power drives?</li>
+            <li>Can the Rockets keep Walker Kessler off the offensive glass without over-committing help defenders?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of October 1.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400015.html
+++ b/public/previews/preseason-12400015.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: Miami Heat at Charlotte Hornets</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(0, 120, 140, 0.14);
+        --visual-tint: rgba(0, 120, 140, 0.1);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(0, 120, 140, 0.05) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(0, 120, 140, 0.74);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(0, 120, 140, 0.76);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(0, 120, 140, 0.16);
+        color: #00788c;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400015">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="miami-heat">
+            <header>
+              <h3>Miami Heat data lab</h3>
+              <span class="meta">Playmaking expansion</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="miami-heat-rotation"></canvas>
+                <p>Minute plan for Erik Spoelstra’s reserve creators as Tyler Herro and Nikola Jović shoulder more on-ball reps.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="miami-heat-skill-spider"></canvas>
+                <p>Blueprint versus readiness for Miami’s developmental targets, from Jaime Jaquez Jr. post work to Jović’s playmaking.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="miami-heat-shot-zones"></canvas>
+                <p>Where the Heat expect to attack as they experiment with more movement-based spacing in preseason.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="miami-heat-tempo-curve"></canvas>
+                <p>Chronicle of Miami’s camp sessions balancing zone drills with pace pushes around Herro.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="miami-heat-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync reads for Heat combinations featuring Jaquez and Jović as hybrid forwards.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="charlotte-hornets">
+            <header>
+              <h3>Charlotte Hornets data lab</h3>
+              <span class="meta">Tempo ignition</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="charlotte-hornets-rotation"></canvas>
+                <p>Minute allocations the Hornets want for LaMelo Ball, Brandon Miller, and the revamped supporting cast.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="charlotte-hornets-skill-spider"></canvas>
+                <p>Charlotte’s developmental priorities and current readiness grades for their pace-driven offense.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="charlotte-hornets-shot-zones"></canvas>
+                <p>How the Hornets aim to generate attempts as Miller and Ball toggle initiator duties.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="charlotte-hornets-tempo-curve"></canvas>
+                <p>Five-session tempo tracker showing the balance between transition reps and special-situation installs.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="charlotte-hornets-synergy-matrix"></canvas>
+                <p>Pace and coverage sync scores for Charlotte pairings as Steve Clifford tests switchability.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-08T19:00:00+00:00">Tuesday, October 08, 2024 — 19:00 UTC</time>
+          <h1>Miami Heat at Charlotte Hornets</h1>
+          <p><strong>Spectrum Center · Charlotte, NC</strong> · Preseason opener</p>
+          <p class="lead">Charlotte’s uptempo experiment meets Miami’s developmental reps as both staffs tinker with ball-handling hierarchies.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>The Heat are expanding Tyler Herro’s playmaking palette while letting Jaime Jaquez Jr. and Nikola Jović script more touches. Spoelstra wants to see how those two connect as frontcourt initiators with Thomas Bryant anchoring second-unit screens.</p>
+          <p>Charlotte, meanwhile, is prioritizing chemistry between LaMelo Ball and Brandon Miller. The Hornets will toggle between five-out spacing and double-big looks with Grant Williams to test versatility, while Nick Smith Jr. battles for backup guard reps.</p>
+          <p>Both teams view defensive communication as the differentiator. Miami will toggle between zone and man coverages, forcing the Hornets to read early shifts. Charlotte counters by pushing pace and testing Miami’s transition floor balance.</p>
+          <ul>
+            <li>How comfortable does Nikola Jović look initiating dribble-handoff sets alongside Herro?</li>
+            <li>Can Charlotte limit turnovers while playing at LaMelo’s preferred tempo against Miami pressure?</li>
+            <li>Does Jaime Jaquez Jr. continue to defend up a position when the Hornets deploy bigger lineups?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of October 1.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400019.html
+++ b/public/previews/preseason-12400019.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: Brooklyn Nets at Los Angeles Clippers</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(29, 66, 138, 0.12);
+        --visual-tint: rgba(29, 66, 138, 0.08);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(29, 66, 138, 0.04) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(29, 66, 138, 0.74);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(29, 66, 138, 0.78);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(29, 66, 138, 0.16);
+        color: #1d428a;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400019">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="brooklyn-nets">
+            <header>
+              <h3>Brooklyn Nets data lab</h3>
+              <span class="meta">Creation committee</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="brooklyn-nets-rotation"></canvas>
+                <p>Minute plan for Jacque Vaughn’s wing-heavy roster as Mikal Bridges and Cam Thomas toggle initiator reps.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="brooklyn-nets-skill-spider"></canvas>
+                <p>Progress versus emphasis for Nets ball-handlers as Dennis Schröder guides tempo for the second unit.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="brooklyn-nets-shot-zones"></canvas>
+                <p>Where Brooklyn wants to operate as it prioritizes corner threes and paint pressure in Oceanside.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="brooklyn-nets-tempo-curve"></canvas>
+                <p>Tempo tracker illustrating how the Nets mix pace pushes with set plays for Bridges.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="brooklyn-nets-synergy-matrix"></canvas>
+                <p>Pace and coverage sync readings for Nets pairings built around Bridges’ two-way pressure.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="los-angeles-clippers">
+            <header>
+              <h3>Los Angeles Clippers data lab</h3>
+              <span class="meta">Wing depth reps</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="los-angeles-clippers-rotation"></canvas>
+                <p>Minute allotment Tyronn Lue set for Terance Mann, Norman Powell, and Bones Hyland while the stars ramp slowly.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="los-angeles-clippers-skill-spider"></canvas>
+                <p>Readiness scores for Clippers reserves charged with providing creation and defensive length.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="los-angeles-clippers-shot-zones"></canvas>
+                <p>How Los Angeles plans to generate looks with second-unit spacing while Kawhi Leonard and Paul George take short shifts.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="los-angeles-clippers-tempo-curve"></canvas>
+                <p>Chronicle of tempo sessions as the Clippers emphasize quick decisions out of spread pick-and-roll.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="los-angeles-clippers-synergy-matrix"></canvas>
+                <p>Pace and coverage sync for wing combinations expected to flank Harden and Leonard later in preseason.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-08T22:30:00+00:00">Tuesday, October 08, 2024 — 22:30 UTC</time>
+          <h1>Brooklyn Nets at Los Angeles Clippers</h1>
+          <p><strong>Frontwave Arena · Oceanside, CA</strong> · Preseason opener</p>
+          <p class="lead">The Nets bring their wing-driven identity to the California coast while the Clippers spotlight bench playmakers in a new arena.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>Brooklyn is using this trip to gauge how Mikal Bridges handles increased usage alongside Dennis Schröder. Cam Thomas will see heavy scoring minutes while Noah Clowney and Day’Ron Sharpe battle for rotation leverage.</p>
+          <p>The Clippers are protecting the core veterans but want to see Terance Mann and Bones Hyland push pace. Norman Powell’s downhill attacks and Moussa Diabaté’s rim presence are focal points as Tyronn Lue maps second-unit spacing.</p>
+          <p>Defensive communication is the swing factor. Brooklyn’s staff wants sharper shell rotations after last year’s slippage, while the Clippers are stressing defensive rebounding to fuel early offense in Oceanside’s smaller venue.</p>
+          <ul>
+            <li>Does Bridges create efficiently when the Clippers send length at him in early traps?</li>
+            <li>Can the Nets keep Los Angeles off the glass when Zubac sits and Diabaté anchors the middle?</li>
+            <li>How do the Clippers’ pace pushes look with Powell and Hyland sharing the backcourt?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of October 2.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400023.html
+++ b/public/previews/preseason-12400023.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: Golden State Warriors at Sacramento Kings</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(90, 45, 129, 0.14);
+        --visual-tint: rgba(90, 45, 129, 0.1);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(90, 45, 129, 0.05) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(90, 45, 129, 0.76);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(90, 45, 129, 0.78);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(90, 45, 129, 0.18);
+        color: #5a2d81;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400023">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="golden-state-warriors">
+            <header>
+              <h3>Golden State Warriors data lab</h3>
+              <span class="meta">Continuity tweaks</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="golden-state-warriors-rotation"></canvas>
+                <p>Minute plan for Steve Kerr as he balances veteran rhythm with Jonathan Kuminga and Trayce Jackson-Davis reps.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="golden-state-warriors-skill-spider"></canvas>
+                <p>Blueprint versus readiness for Golden State’s blend of star creation and young connective pieces.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="golden-state-warriors-shot-zones"></canvas>
+                <p>Expected shot mix with Stephen Curry orchestrating dribble hand-offs alongside new spacing wrinkles.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="golden-state-warriors-tempo-curve"></canvas>
+                <p>Tempo tracker showing how the Warriors are ramping pace after emphasizing half-court precision in camp.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="golden-state-warriors-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync readings for Golden State groupings expected to share rotation minutes.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="sacramento-kings">
+            <header>
+              <h3>Sacramento Kings data lab</h3>
+              <span class="meta">Pace and space</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="sacramento-kings-rotation"></canvas>
+                <p>Minute allocations Mike Brown wants for the Kings’ core as they chase another league-leading offense.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="sacramento-kings-skill-spider"></canvas>
+                <p>Readiness versus emphasis for Sacramento’s dribble-handoff machine centered on Fox and Sabonis.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="sacramento-kings-shot-zones"></canvas>
+                <p>Where the Kings expect to attack as Keegan Murray takes on more shot creation duties.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="sacramento-kings-tempo-curve"></canvas>
+                <p>Five-session tempo tracker highlighting Sacramento’s push for top-five pace with disciplined spacing.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="sacramento-kings-synergy-matrix"></canvas>
+                <p>Pace and coverage sync indicators for Kings pairings featuring Malik Monk and Sasha Vezenkov.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-09T22:30:00+00:00">Wednesday, October 09, 2024 — 22:30 UTC</time>
+          <h1>Golden State Warriors at Sacramento Kings</h1>
+          <p><strong>Golden 1 Center · Sacramento, CA</strong> · Preseason opener</p>
+          <p class="lead">The Northern California rivalry previews playoff-level pace as both teams sharpen offensive timing for the fall.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>Golden State wants early looks at Jonathan Kuminga as a featured scorer beside Stephen Curry. Expect Brandin Podziemski to initiate second units while Trayce Jackson-Davis anchors screening actions.</p>
+          <p>Sacramento counters with De’Aaron Fox and Domantas Sabonis running familiar dribble-handoff actions, but Keegan Murray will experiment with more on-ball touches. Malik Monk’s bench spark remains a priority as the Kings monitor defensive growth.</p>
+          <p>Both staffs have circled defensive rebounding and transition control. The Warriors aim to keep the Kings out of early offense, while Sacramento wants to pressure Golden State’s bench bigs into foul trouble.</p>
+          <ul>
+            <li>How sharp does Golden State’s motion look with Curry and Kuminga sharing initiator reps?</li>
+            <li>Does Keegan Murray’s expanded role produce efficient shots against Golden State’s switching?</li>
+            <li>Can the Kings limit second-chance looks when Trayce Jackson-Davis and Kevon Looney patrol the glass?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of October 3.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/previews/preseason-12400035.html
+++ b/public/previews/preseason-12400035.html
@@ -1,0 +1,312 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preseason Preview: Portland Trail Blazers at Los Angeles Clippers</title>
+    <link rel="stylesheet" href="../styles/hub.css" />
+    <style>
+      :root {
+        --preview-tint: rgba(29, 66, 138, 0.12);
+        --visual-tint: rgba(29, 66, 138, 0.08);
+      }
+
+      body {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        padding: clamp(1.5rem, 4vw, 3rem);
+        background: color-mix(in srgb, var(--surface) 90%, rgba(29, 66, 138, 0.04) 10%);
+      }
+
+      .preview-shell {
+        width: min(1180px, 100%);
+        display: grid;
+        gap: clamp(1.5rem, 3vw, 2.5rem);
+        grid-template-areas: "visuals" "preview" "footer";
+        background: color-mix(in srgb, var(--surface) 75%, var(--preview-tint) 25%);
+        border-radius: var(--radius-xl);
+        border: 1px solid color-mix(in srgb, var(--royal) 15%, transparent);
+        box-shadow: var(--shadow-soft);
+        padding: clamp(1.75rem, 3vw, 2.5rem);
+      }
+
+      .visuals {
+        grid-area: visuals;
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.75rem);
+        background: color-mix(in srgb, var(--surface-alt) 72%, var(--visual-tint) 28%);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+        padding: clamp(1.5rem, 4vw, 2.75rem);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+      }
+
+      .visuals > h2 {
+        margin: 0;
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+        color: var(--navy);
+      }
+
+      .team-visuals {
+        display: grid;
+        gap: clamp(1.4rem, 3vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+
+      .team-panel {
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        border-radius: var(--radius-lg);
+        background: color-mix(in srgb, var(--surface-alt) 78%, var(--preview-tint) 22%);
+        border: 1px solid color-mix(in srgb, var(--border) 58%, transparent);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      }
+
+      .team-panel header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .team-panel h3 {
+        margin: 0;
+        font-size: clamp(1.15rem, 3vw, 1.45rem);
+        color: var(--navy);
+      }
+
+      .team-panel .meta {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-weight: 600;
+        color: rgba(29, 66, 138, 0.74);
+      }
+
+      .chart-grid {
+        display: grid;
+        gap: clamp(1.1rem, 3vw, 1.8rem);
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+
+      .chart-card {
+        background: color-mix(in srgb, var(--surface-alt) 82%, var(--preview-tint) 18%);
+        border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+        border-radius: var(--radius-lg);
+        padding: clamp(1.25rem, 3vw, 1.75rem);
+        display: grid;
+        gap: 0.75rem;
+        box-shadow: var(--shadow-subtle);
+      }
+
+      .chart-card h3 {
+        margin: 0;
+        font-size: clamp(1.05rem, 2vw, 1.2rem);
+        color: var(--navy);
+      }
+
+      .chart-card p {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .chart-card__canvas {
+        position: relative;
+        border-radius: var(--radius-md);
+        background: color-mix(in srgb, var(--surface-alt) 88%, var(--preview-tint) 12%);
+        border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+        min-height: clamp(220px, 30vw, 260px);
+        display: flex;
+        align-items: stretch;
+        overflow: hidden;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.48);
+      }
+
+      .chart-card__canvas canvas {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .preview-copy {
+        grid-area: preview;
+        display: grid;
+        gap: clamp(1rem, 2.5vw, 1.5rem);
+      }
+
+      .preview-copy header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-copy h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 3.5vw, 2.3rem);
+        color: var(--navy);
+      }
+
+      .preview-copy time {
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(29, 66, 138, 0.78);
+        font-size: 0.78rem;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.32rem 0.85rem;
+        border-radius: 999px;
+        background: rgba(29, 66, 138, 0.16);
+        color: #1d428a;
+        font-weight: 600;
+        text-transform: uppercase;
+        font-size: 0.68rem;
+        letter-spacing: 0.08em;
+        width: fit-content;
+      }
+
+      .story {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .story h2 {
+        margin: 0;
+        font-size: 1.15rem;
+        color: var(--navy);
+      }
+
+      .story ul {
+        margin: 0;
+        padding-left: 1.15rem;
+        color: var(--text-subtle);
+      }
+
+      footer {
+        grid-area: footer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+      }
+
+      footer a {
+        text-decoration: none;
+        font-weight: 600;
+      }
+    </style>
+    <script src="../vendor/chart.umd.js" defer></script>
+    <script src="../scripts/preseason-dashboards.js" defer></script>
+    <script src="../scripts/preseason-preview.js" defer></script>
+  </head>
+  <body data-preview-id="preseason-12400035">
+    <main class="preview-shell">
+      <section class="visuals">
+        <h2>Preseason scouting dashboard</h2>
+        <div class="team-visuals">
+          <div class="team-panel" data-team="portland-trail-blazers">
+            <header>
+              <h3>Portland Trail Blazers data lab</h3>
+              <span class="meta">Guard runway</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="portland-trail-blazers-rotation"></canvas>
+                <p>Minute curve Chauncey Billups plans for Scoot Henderson and Anfernee Simons as they share initiator duties.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="portland-trail-blazers-skill-spider"></canvas>
+                <p>Readiness versus developmental goals for Portland’s young core as Shaedon Sharpe and Jabari Walker expand roles.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="portland-trail-blazers-shot-zones"></canvas>
+                <p>Where the Blazers expect to create offense as Scoot drives paint touches and Duop Reath spaces to three.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="portland-trail-blazers-tempo-curve"></canvas>
+                <p>Pace tracker showing how Portland balances developmental reps with half-court execution.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="portland-trail-blazers-synergy-matrix"></canvas>
+                <p>Tempo and coverage sync indicators for Blazer combinations focused on playmaking growth.</p>
+              </figure>
+            </div>
+          </div>
+          <div class="team-panel" data-team="los-angeles-clippers">
+            <header>
+              <h3>Los Angeles Clippers data lab</h3>
+              <span class="meta">Star integration</span>
+            </header>
+            <div class="chart-grid">
+              <figure class="chart-card">
+                <h3>Rotation bandwidth</h3>
+                <canvas id="los-angeles-clippers-rotation"></canvas>
+                <p>Minute targets Tyronn Lue set for James Harden, Kawhi Leonard, and Paul George as they test new spacing combinations.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Skill scaffolding radar</h3>
+                <canvas id="los-angeles-clippers-skill-spider"></canvas>
+                <p>Readiness scores for Los Angeles’ top trio as they chase better ball movement and tempo resilience.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Shot diet vs. league</h3>
+                <canvas id="los-angeles-clippers-shot-zones"></canvas>
+                <p>How the Clippers expect to weaponize Harden-George pick-and-rolls and Leonard mid-post touches.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Practice tempo log</h3>
+                <canvas id="los-angeles-clippers-tempo-curve"></canvas>
+                <p>Tempo log from Seattle practices tracking how the Clippers toggle between half-court sets and transition pushes.</p>
+              </figure>
+              <figure class="chart-card">
+                <h3>Pairing synergy map</h3>
+                <canvas id="los-angeles-clippers-synergy-matrix"></canvas>
+                <p>Pace and coverage sync readings for Clippers lineups featuring Harden orchestrating with big wings.</p>
+              </figure>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <article class="preview-copy">
+        <header>
+          <span class="chip">Preseason preview</span>
+          <time datetime="2024-10-11T22:30:00+00:00">Friday, October 11, 2024 — 22:30 UTC</time>
+          <h1>Portland Trail Blazers at Los Angeles Clippers</h1>
+          <p><strong>Climate Pledge Arena · Seattle, WA</strong> · Preseason opener</p>
+          <p class="lead">Seattle’s preseason stage features Portland’s youth movement against a Clippers core intent on refining star synergy.</p>
+        </header>
+
+        <section class="story">
+          <h2>Why it matters in October</h2>
+          <p>Portland wants Scoot Henderson to run the show with Anfernee Simons spotting up more often. Shaedon Sharpe and Jabari Walker will test lineup versatility while Duop Reath stretches opposing bigs beyond the arc.</p>
+          <p>The Clippers expect to play their stars in short bursts, prioritizing new Harden-Leonard actions and Paul George’s off-ball movement. Kobe Brown and Ivica Zubac provide stability while Los Angeles measures conditioning.</p>
+          <p>Both sides are eyeing defensive habits. Portland needs better containment at the point of attack, while the Clippers are monitoring pick-and-roll coverage after adding more switchable forwards.</p>
+          <ul>
+            <li>Can Scoot Henderson control pace without being baited into turnovers by Los Angeles’ veterans?</li>
+            <li>How sharp do Harden and Leonard look running two-man actions after limited offseason reps together?</li>
+            <li>Does Portland’s young frontcourt hold up on the glass against Zubac and the Clippers’ size?</li>
+          </ul>
+        </section>
+      </article>
+
+      <footer>
+        <span>Data: team camp reports and internal tracking as of October 4.</span>
+        <a href="../index.html">← Back to preseason hub</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/public/scripts/preseason-dashboards.js
+++ b/public/scripts/preseason-dashboards.js
@@ -132,6 +132,134 @@ window.preseasonDashboards = {
       }
     ]
   },
+  "preseason-12400002": {
+    teams: [
+      {
+        name: "International Showcase",
+        slug: "international-showcase",
+        colors: {
+          primary: "#00529B",
+          secondary: "#F2A900",
+          tertiary: "#F5F5F5"
+        },
+        rotation: {
+          labels: [
+            "Tremont Waters",
+            "Luke Travers",
+            "Nigel Hayes-Davis",
+            "Bruno Caboclo",
+            "Khalifa Diop"
+          ],
+          data: [23, 21, 19, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 6, 7, 6, 8],
+          readiness: [6, 6, 7, 5, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 15, 17, 21, 21],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [71, 74, 76, 72, 70],
+          specials: [20, 26, 30, 32, 26]
+        },
+        synergy: {
+          points: [
+            { label: "Waters pace push", x: 104, y: 78, r: 13 },
+            { label: "Travers wing size", x: 96, y: 82, r: 12 },
+            { label: "Hayes-Davis switches", x: 98, y: 76, r: 11 },
+            { label: "Caboclo rim deterrence", x: 92, y: 80, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Utah Jazz",
+        slug: "utah-jazz",
+        colors: {
+          primary: "#002B5C",
+          secondary: "#00471B",
+          tertiary: "#F9A01B"
+        },
+        rotation: {
+          labels: [
+            "Keyonte George",
+            "Cody Williams",
+            "Taylor Hendricks",
+            "Walker Kessler",
+            "Brice Sensabaugh"
+          ],
+          data: [22, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 8, 6, 6],
+          readiness: [6, 6, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 13, 15, 20, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 71, 69],
+          specials: [22, 28, 34, 32, 28]
+        },
+        synergy: {
+          points: [
+            { label: "George downhill reads", x: 102, y: 80, r: 13 },
+            { label: "Hendricks weak-side pop", x: 96, y: 84, r: 12 },
+            { label: "Kessler drop anchor", x: 90, y: 88, r: 11 },
+            { label: "Sensabaugh scoring punch", x: 98, y: 76, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
   "preseason-12400003": {
     teams: [
       {
@@ -772,6 +900,134 @@ window.preseasonDashboards = {
       }
     ]
   },
+  "preseason-12400009": {
+    teams: [
+      {
+        name: "Phoenix Suns",
+        slug: "phoenix-suns",
+        colors: {
+          primary: "#1D1160",
+          secondary: "#E56020",
+          tertiary: "#F9A01B"
+        },
+        rotation: {
+          labels: [
+            "Grayson Allen",
+            "Royce O'Neale",
+            "Bol Bol",
+            "Damion Lee",
+            "Saben Lee"
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 8, 6, 6, 7],
+          readiness: [7, 7, 6, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 12, 18, 22, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [69, 73, 75, 71, 69],
+          specials: [22, 28, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Allen relocation", x: 100, y: 82, r: 13 },
+            { label: "O'Neale switchability", x: 96, y: 86, r: 12 },
+            { label: "Bol weak-side reach", x: 98, y: 78, r: 11 },
+            { label: "Saben Lee pace", x: 104, y: 74, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Los Angeles Lakers",
+        slug: "los-angeles-lakers",
+        colors: {
+          primary: "#552583",
+          secondary: "#FDB927",
+          tertiary: "#000000"
+        },
+        rotation: {
+          labels: [
+            "Dalton Knecht",
+            "Spencer Dinwiddie",
+            "Max Christie",
+            "Bronny James",
+            "Jaxson Hayes"
+          ],
+          data: [20, 18, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 6, 7, 6],
+          readiness: [6, 7, 6, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [25, 12, 14, 21, 28],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 71, 69],
+          specials: [20, 26, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Knecht movement shooting", x: 98, y: 80, r: 13 },
+            { label: "Dinwiddie control", x: 94, y: 82, r: 12 },
+            { label: "Christie stopper reps", x: 96, y: 86, r: 11 },
+            { label: "Bronny pace table", x: 100, y: 78, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
   "preseason-12400010": {
     teams: [
       {
@@ -893,6 +1149,134 @@ window.preseasonDashboards = {
             { label: "Ingram midrange", x: 96, y: 84, r: 12 },
             { label: "Murphy spacers", x: 98, y: 80, r: 11 },
             { label: "Daniels defense", x: 94, y: 88, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400011": {
+    teams: [
+      {
+        name: "International Showcase",
+        slug: "international-showcase",
+        colors: {
+          primary: "#00529B",
+          secondary: "#F2A900",
+          tertiary: "#F5F5F5"
+        },
+        rotation: {
+          labels: [
+            "Tremont Waters",
+            "Luke Travers",
+            "Nigel Hayes-Davis",
+            "Bruno Caboclo",
+            "Khalifa Diop"
+          ],
+          data: [23, 21, 19, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 6, 7, 6, 8],
+          readiness: [6, 6, 7, 5, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 15, 17, 21, 21],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [71, 74, 76, 72, 70],
+          specials: [20, 26, 30, 32, 26]
+        },
+        synergy: {
+          points: [
+            { label: "Waters pace push", x: 104, y: 78, r: 13 },
+            { label: "Travers wing size", x: 96, y: 82, r: 12 },
+            { label: "Hayes-Davis switches", x: 98, y: 76, r: 11 },
+            { label: "Caboclo rim deterrence", x: 92, y: 80, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Philadelphia 76ers",
+        slug: "philadelphia-76ers",
+        colors: {
+          primary: "#006BB6",
+          secondary: "#ED174C",
+          tertiary: "#002B5C"
+        },
+        rotation: {
+          labels: [
+            "Tyrese Maxey",
+            "Jared McCain",
+            "Kelly Oubre Jr.",
+            "Ricky Council IV",
+            "Paul Reed"
+          ],
+          data: [22, 20, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 7, 7, 6],
+          readiness: [7, 7, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [27, 12, 14, 21, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 71, 69],
+          specials: [22, 28, 34, 32, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Maxey burst", x: 104, y: 82, r: 13 },
+            { label: "Oubre cutting", x: 98, y: 78, r: 11 },
+            { label: "McCain spacing", x: 96, y: 84, r: 12 },
+            { label: "Reed short roll", x: 92, y: 86, r: 11 }
           ],
           xLabel: "Tempo index (possessions per 48)",
           yLabel: "Coverage sync score"
@@ -1156,6 +1540,262 @@ window.preseasonDashboards = {
       }
     ]
   },
+  "preseason-12400014": {
+    teams: [
+      {
+        name: "Houston Rockets",
+        slug: "houston-rockets",
+        colors: {
+          primary: "#CE1141",
+          secondary: "#000000",
+          tertiary: "#C4CED4"
+        },
+        rotation: {
+          labels: [
+            "Amen Thompson",
+            "Cam Whitmore",
+            "Jalen Green",
+            "Tari Eason",
+            "Steven Adams"
+          ],
+          data: [22, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 8, 6, 6],
+          readiness: [7, 6, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [27, 13, 15, 22, 23],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 76, 72, 70],
+          specials: [24, 28, 34, 36, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Amen downhill pressure", x: 106, y: 78, r: 13 },
+            { label: "Whitmore power wings", x: 100, y: 82, r: 12 },
+            { label: "Eason disruption", x: 98, y: 88, r: 11 },
+            { label: "Adams screening hub", x: 92, y: 84, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Utah Jazz",
+        slug: "utah-jazz",
+        colors: {
+          primary: "#002B5C",
+          secondary: "#00471B",
+          tertiary: "#F9A01B"
+        },
+        rotation: {
+          labels: [
+            "Keyonte George",
+            "Cody Williams",
+            "Taylor Hendricks",
+            "Walker Kessler",
+            "Brice Sensabaugh"
+          ],
+          data: [22, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 8, 6, 6],
+          readiness: [6, 6, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 13, 15, 20, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 71, 69],
+          specials: [22, 28, 34, 32, 28]
+        },
+        synergy: {
+          points: [
+            { label: "George downhill reads", x: 102, y: 80, r: 13 },
+            { label: "Hendricks weak-side pop", x: 96, y: 84, r: 12 },
+            { label: "Kessler drop anchor", x: 90, y: 88, r: 11 },
+            { label: "Sensabaugh scoring punch", x: 98, y: 76, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400015": {
+    teams: [
+      {
+        name: "Miami Heat",
+        slug: "miami-heat",
+        colors: {
+          primary: "#98002E",
+          secondary: "#000000",
+          tertiary: "#F9A01B"
+        },
+        rotation: {
+          labels: [
+            "Tyler Herro",
+            "Jaime Jaquez Jr.",
+            "Nikola Jović",
+            "Thomas Bryant",
+            "Alondes Williams"
+          ],
+          data: [22, 20, 18, 16, 15]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 7, 6, 6],
+          readiness: [7, 7, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 12, 16, 22, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 74, 70, 69],
+          specials: [20, 26, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Herro trigger sets", x: 100, y: 82, r: 13 },
+            { label: "Jaquez connective", x: 96, y: 84, r: 12 },
+            { label: "Jović point forward", x: 98, y: 78, r: 11 },
+            { label: "Bryant paint seals", x: 92, y: 80, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Charlotte Hornets",
+        slug: "charlotte-hornets",
+        colors: {
+          primary: "#1D1160",
+          secondary: "#00788C",
+          tertiary: "#A1A1A4"
+        },
+        rotation: {
+          labels: [
+            "Brandon Miller",
+            "LaMelo Ball",
+            "Grant Williams",
+            "Nick Smith Jr.",
+            "JT Thor"
+          ],
+          data: [24, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 7, 6, 8, 7],
+          readiness: [7, 7, 6, 7, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [27, 12, 13, 22, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 75, 72, 71],
+          specials: [20, 26, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Ball + Miller creation", x: 104, y: 80, r: 14 },
+            { label: "Grant Williams switches", x: 94, y: 82, r: 12 },
+            { label: "Nick Smith pace", x: 102, y: 74, r: 11 },
+            { label: "Thor weak-side length", x: 96, y: 78, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
   "preseason-12400016": {
     teams: [
       {
@@ -1405,6 +2045,390 @@ window.preseasonDashboards = {
             { label: "Johnson slashing", x: 104, y: 80, r: 12 },
             { label: "Bogdanovic spacing", x: 98, y: 78, r: 11 },
             { label: "Okongwu rim deterrence", x: 96, y: 86, r: 13 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400019": {
+    teams: [
+      {
+        name: "Brooklyn Nets",
+        slug: "brooklyn-nets",
+        colors: {
+          primary: "#000000",
+          secondary: "#FFFFFF",
+          tertiary: "#006BB6"
+        },
+        rotation: {
+          labels: [
+            "Mikal Bridges",
+            "Dennis Schröder",
+            "Cam Thomas",
+            "Noah Clowney",
+            "Day'Ron Sharpe"
+          ],
+          data: [22, 20, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 8, 6, 6],
+          readiness: [7, 6, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 12, 16, 20, 28],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [68, 72, 75, 70, 69],
+          specials: [22, 28, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Bridges primary reps", x: 96, y: 84, r: 13 },
+            { label: "Schröder tempo", x: 100, y: 78, r: 12 },
+            { label: "Thomas scoring burst", x: 104, y: 74, r: 11 },
+            { label: "Clowney weak-side rim", x: 94, y: 82, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Los Angeles Clippers",
+        slug: "los-angeles-clippers",
+        colors: {
+          primary: "#1D428A",
+          secondary: "#C8102E",
+          tertiary: "#BEC0C2"
+        },
+        rotation: {
+          labels: [
+            "Terance Mann",
+            "Norman Powell",
+            "Bones Hyland",
+            "Brandon Boston Jr.",
+            "Moussa Diabaté"
+          ],
+          data: [22, 20, 18, 16, 14]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [7, 7, 7, 6, 6],
+          readiness: [7, 7, 7, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [22, 14, 18, 20, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 72, 69, 68],
+          specials: [18, 24, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Mann drive game", x: 96, y: 84, r: 13 },
+            { label: "Hyland pace", x: 102, y: 78, r: 12 },
+            { label: "Brown spacing", x: 94, y: 80, r: 11 },
+            { label: "Diabaté rim seals", x: 90, y: 76, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400023": {
+    teams: [
+      {
+        name: "Sacramento Kings",
+        slug: "sacramento-kings",
+        colors: {
+          primary: "#5A2D81",
+          secondary: "#63727A",
+          tertiary: "#000000"
+        },
+        rotation: {
+          labels: [
+            "Domantas Sabonis",
+            "De'Aaron Fox",
+            "Keegan Murray",
+            "Malik Monk",
+            "Sasha Vezenkov"
+          ],
+          data: [22, 20, 18, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 8, 6, 9, 8],
+          readiness: [8, 8, 6, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [26, 12, 14, 24, 24],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [70, 74, 76, 72, 70],
+          specials: [22, 28, 34, 36, 32]
+        },
+        synergy: {
+          points: [
+            { label: "Fox + Sabonis dribble handoffs", x: 104, y: 86, r: 14 },
+            { label: "Murray movement shooting", x: 98, y: 82, r: 12 },
+            { label: "Monk bench ignition", x: 102, y: 78, r: 11 },
+            { label: "Vezenkov pick-and-pop", x: 96, y: 80, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Golden State Warriors",
+        slug: "golden-state-warriors",
+        colors: {
+          primary: "#1D428A",
+          secondary: "#FFC72C",
+          tertiary: "#26282A"
+        },
+        rotation: {
+          labels: [
+            "Stephen Curry",
+            "Klay Thompson",
+            "Jonathan Kuminga",
+            "Brandin Podziemski",
+            "Trayce Jackson-Davis"
+          ],
+          data: [18, 18, 20, 18, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [9, 9, 7, 8, 7],
+          readiness: [9, 8, 7, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 10, 12, 22, 32],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [72, 76, 78, 74, 72],
+          specials: [20, 26, 32, 34, 30]
+        },
+        synergy: {
+          points: [
+            { label: "Curry-Draymond cadence", x: 106, y: 88, r: 14 },
+            { label: "Kuminga rim attacks", x: 104, y: 80, r: 12 },
+            { label: "Podziemski connective", x: 100, y: 82, r: 11 },
+            { label: "TJD short roll reads", x: 96, y: 78, r: 10 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      }
+    ]
+  },
+  "preseason-12400035": {
+    teams: [
+      {
+        name: "Los Angeles Clippers",
+        slug: "los-angeles-clippers",
+        colors: {
+          primary: "#1D428A",
+          secondary: "#C8102E",
+          tertiary: "#BEC0C2"
+        },
+        rotation: {
+          labels: [
+            "James Harden",
+            "Paul George",
+            "Kawhi Leonard",
+            "Kobe Brown",
+            "Ivica Zubac"
+          ],
+          data: [18, 18, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 8, 7, 8, 7],
+          readiness: [7, 8, 7, 8, 7]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [24, 12, 16, 22, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [66, 70, 72, 69, 68],
+          specials: [18, 24, 32, 34, 28]
+        },
+        synergy: {
+          points: [
+            { label: "Harden orchestrating", x: 96, y: 86, r: 13 },
+            { label: "PG pull-up fire", x: 100, y: 84, r: 12 },
+            { label: "Kawhi mid-post", x: 94, y: 88, r: 12 },
+            { label: "Zubac rim control", x: 90, y: 82, r: 11 }
+          ],
+          xLabel: "Tempo index (possessions per 48)",
+          yLabel: "Coverage sync score"
+        }
+      },
+      {
+        name: "Portland Trail Blazers",
+        slug: "portland-trail-blazers",
+        colors: {
+          primary: "#E03A3E",
+          secondary: "#000000",
+          tertiary: "#B6BFBF"
+        },
+        rotation: {
+          labels: [
+            "Scoot Henderson",
+            "Anfernee Simons",
+            "Shaedon Sharpe",
+            "Jabari Walker",
+            "Duop Reath"
+          ],
+          data: [22, 20, 18, 16, 16]
+        },
+        skill: {
+          labels: [
+            "Advantage creation",
+            "Spacing gravity",
+            "Defensive disruption",
+            "Playmaking vision",
+            "Tempo pressure"
+          ],
+          training: [8, 8, 7, 7, 7],
+          readiness: [7, 7, 6, 6, 6]
+        },
+        shotProfile: {
+          labels: [
+            "Rim attacks",
+            "Paint floaters",
+            "Mid-post isolations",
+            "Corner threes",
+            "Above-the-break threes"
+          ],
+          team: [28, 12, 14, 20, 26],
+          league: [24, 14, 16, 18, 28]
+        },
+        tempo: {
+          labels: [
+            "Arrival day",
+            "Closed scrimmage",
+            "Open scrimmage",
+            "Special situations",
+            "Shootaround"
+          ],
+          tempo: [72, 76, 78, 74, 72],
+          specials: [22, 28, 34, 36, 32]
+        },
+        synergy: {
+          points: [
+            { label: "Scoot downhill", x: 108, y: 80, r: 13 },
+            { label: "Simons scoring", x: 104, y: 78, r: 12 },
+            { label: "Sharpe aerial threats", x: 102, y: 82, r: 11 },
+            { label: "Reath pick-and-pop", x: 96, y: 76, r: 10 }
           ],
           xLabel: "Tempo index (possessions per 48)",
           yLabel: "Coverage sync score"


### PR DESCRIPTION
## Summary
- add dedicated preview pages for the remaining preseason tour matchups to eliminate 404 errors
- extend preseason dashboard data to include team visuals for the new game IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8973a05ec8327801dd7a44e9ce158