### PR TITLE
Revamp history atlas with scoring trends and state legends

### DIFF
--- a/public/data/history_scoring_trends.json
+++ b/public/data/history_scoring_trends.json
@@ -1,0 +1,558 @@
+{
+  "generatedAt": "2025-09-28T02:02:49.281243Z",
+  "seasons": [
+    {
+      "season": 1946,
+      "games": 20,
+      "averagePoints": 123.35,
+      "regularSeasonAverage": 121.67,
+      "playoffAverage": 138.5
+    },
+    {
+      "season": 1947,
+      "games": 24,
+      "averagePoints": 138.33,
+      "regularSeasonAverage": 138.33,
+      "playoffAverage": null
+    },
+    {
+      "season": 1948,
+      "games": 83,
+      "averagePoints": 158.06,
+      "regularSeasonAverage": 158.49,
+      "playoffAverage": 140.5
+    },
+    {
+      "season": 1949,
+      "games": 137,
+      "averagePoints": 158.46,
+      "regularSeasonAverage": 157.91,
+      "playoffAverage": 162.93
+    },
+    {
+      "season": 1950,
+      "games": 221,
+      "averagePoints": 169.31,
+      "regularSeasonAverage": 169.76,
+      "playoffAverage": 165.43
+    },
+    {
+      "season": 1951,
+      "games": 227,
+      "averagePoints": 167.47,
+      "regularSeasonAverage": 166.85,
+      "playoffAverage": 172.91
+    },
+    {
+      "season": 1952,
+      "games": 235,
+      "averagePoints": 165.42,
+      "regularSeasonAverage": 165.5,
+      "playoffAverage": 164.53
+    },
+    {
+      "season": 1953,
+      "games": 275,
+      "averagePoints": 158.18,
+      "regularSeasonAverage": 157.83,
+      "playoffAverage": 162.0
+    },
+    {
+      "season": 1954,
+      "games": 309,
+      "averagePoints": 186.73,
+      "regularSeasonAverage": 186.13,
+      "playoffAverage": 194.95
+    },
+    {
+      "season": 1955,
+      "games": 311,
+      "averagePoints": 198.05,
+      "regularSeasonAverage": 197.92,
+      "playoffAverage": 199.86
+    },
+    {
+      "season": 1956,
+      "games": 307,
+      "averagePoints": 200.47,
+      "regularSeasonAverage": 199.39,
+      "playoffAverage": 219.0
+    },
+    {
+      "season": 1957,
+      "games": 309,
+      "averagePoints": 212.81,
+      "regularSeasonAverage": 213.27,
+      "playoffAverage": 206.43
+    },
+    {
+      "season": 1958,
+      "games": 310,
+      "averagePoints": 217.28,
+      "regularSeasonAverage": 216.49,
+      "playoffAverage": 227.73
+    },
+    {
+      "season": 1959,
+      "games": 325,
+      "averagePoints": 229.7,
+      "regularSeasonAverage": 230.67,
+      "playoffAverage": 218.12
+    },
+    {
+      "season": 1960,
+      "games": 341,
+      "averagePoints": 235.79,
+      "regularSeasonAverage": 236.25,
+      "playoffAverage": 229.96
+    },
+    {
+      "season": 1961,
+      "games": 389,
+      "averagePoints": 236.61,
+      "regularSeasonAverage": 237.53,
+      "playoffAverage": 225.17
+    },
+    {
+      "season": 1962,
+      "games": 389,
+      "averagePoints": 230.56,
+      "regularSeasonAverage": 230.54,
+      "playoffAverage": 230.9
+    },
+    {
+      "season": 1963,
+      "games": 387,
+      "averagePoints": 221.28,
+      "regularSeasonAverage": 222.0,
+      "playoffAverage": 211.67
+    },
+    {
+      "season": 1964,
+      "games": 386,
+      "averagePoints": 221.65,
+      "regularSeasonAverage": 221.22,
+      "playoffAverage": 227.46
+    },
+    {
+      "season": 1965,
+      "games": 387,
+      "averagePoints": 230.75,
+      "regularSeasonAverage": 231.01,
+      "playoffAverage": 227.26
+    },
+    {
+      "season": 1966,
+      "games": 436,
+      "averagePoints": 234.66,
+      "regularSeasonAverage": 234.9,
+      "playoffAverage": 231.61
+    },
+    {
+      "season": 1967,
+      "games": 532,
+      "averagePoints": 232.53,
+      "regularSeasonAverage": 233.21,
+      "playoffAverage": 224.12
+    },
+    {
+      "season": 1968,
+      "games": 613,
+      "averagePoints": 223.63,
+      "regularSeasonAverage": 224.63,
+      "playoffAverage": 208.85
+    },
+    {
+      "season": 1969,
+      "games": 614,
+      "averagePoints": 232.73,
+      "regularSeasonAverage": 233.39,
+      "playoffAverage": 223.2
+    },
+    {
+      "season": 1970,
+      "games": 737,
+      "averagePoints": 223.85,
+      "regularSeasonAverage": 224.82,
+      "playoffAverage": 206.95
+    },
+    {
+      "season": 1971,
+      "games": 734,
+      "averagePoints": 220.04,
+      "regularSeasonAverage": 220.38,
+      "playoffAverage": 213.7
+    },
+    {
+      "season": 1972,
+      "games": 738,
+      "averagePoints": 214.62,
+      "regularSeasonAverage": 215.18,
+      "playoffAverage": 205.0
+    },
+    {
+      "season": 1973,
+      "games": 738,
+      "averagePoints": 210.64,
+      "regularSeasonAverage": 211.48,
+      "playoffAverage": 196.27
+    },
+    {
+      "season": 1974,
+      "games": 785,
+      "averagePoints": 205.01,
+      "regularSeasonAverage": 205.26,
+      "playoffAverage": 201.0
+    },
+    {
+      "season": 1975,
+      "games": 788,
+      "averagePoints": 208.59,
+      "regularSeasonAverage": 208.69,
+      "playoffAverage": 207.16
+    },
+    {
+      "season": 1976,
+      "games": 955,
+      "averagePoints": 212.82,
+      "regularSeasonAverage": 212.94,
+      "playoffAverage": 210.81
+    },
+    {
+      "season": 1977,
+      "games": 953,
+      "averagePoints": 216.77,
+      "regularSeasonAverage": 216.92,
+      "playoffAverage": 214.04
+    },
+    {
+      "season": 1978,
+      "games": 955,
+      "averagePoints": 220.06,
+      "regularSeasonAverage": 220.68,
+      "playoffAverage": 209.43
+    },
+    {
+      "season": 1979,
+      "games": 950,
+      "averagePoints": 218.12,
+      "regularSeasonAverage": 218.67,
+      "playoffAverage": 207.88
+    },
+    {
+      "season": 1980,
+      "games": 996,
+      "averagePoints": 215.38,
+      "regularSeasonAverage": 216.21,
+      "playoffAverage": 200.62
+    },
+    {
+      "season": 1981,
+      "games": 990,
+      "averagePoints": 216.86,
+      "regularSeasonAverage": 217.15,
+      "playoffAverage": 211.04
+    },
+    {
+      "season": 1982,
+      "games": 986,
+      "averagePoints": 216.93,
+      "regularSeasonAverage": 217.03,
+      "playoffAverage": 214.79
+    },
+    {
+      "season": 1983,
+      "games": 1022,
+      "averagePoints": 219.84,
+      "regularSeasonAverage": 220.22,
+      "playoffAverage": 215.24
+    },
+    {
+      "season": 1984,
+      "games": 1011,
+      "averagePoints": 222.19,
+      "regularSeasonAverage": 221.68,
+      "playoffAverage": 229.38
+    },
+    {
+      "season": 1985,
+      "games": 1011,
+      "averagePoints": 220.52,
+      "regularSeasonAverage": 220.45,
+      "playoffAverage": 221.43
+    },
+    {
+      "season": 1986,
+      "games": 1014,
+      "averagePoints": 219.94,
+      "regularSeasonAverage": 219.87,
+      "playoffAverage": 220.82
+    },
+    {
+      "season": 1987,
+      "games": 1023,
+      "averagePoints": 215.72,
+      "regularSeasonAverage": 216.32,
+      "playoffAverage": 208.64
+    },
+    {
+      "season": 1988,
+      "games": 1087,
+      "averagePoints": 217.85,
+      "regularSeasonAverage": 218.34,
+      "playoffAverage": 209.73
+    },
+    {
+      "season": 1989,
+      "games": 1179,
+      "averagePoints": 213.84,
+      "regularSeasonAverage": 214.03,
+      "playoffAverage": 211.04
+    },
+    {
+      "season": 1990,
+      "games": 1175,
+      "averagePoints": 212.37,
+      "regularSeasonAverage": 212.62,
+      "playoffAverage": 208.31
+    },
+    {
+      "season": 1991,
+      "games": 1180,
+      "averagePoints": 210.36,
+      "regularSeasonAverage": 210.62,
+      "playoffAverage": 206.51
+    },
+    {
+      "season": 1992,
+      "games": 1183,
+      "averagePoints": 209.81,
+      "regularSeasonAverage": 210.54,
+      "playoffAverage": 199.04
+    },
+    {
+      "season": 1993,
+      "games": 1184,
+      "averagePoints": 202.04,
+      "regularSeasonAverage": 203.01,
+      "playoffAverage": 188.0
+    },
+    {
+      "season": 1994,
+      "games": 1180,
+      "averagePoints": 202.55,
+      "regularSeasonAverage": 202.82,
+      "playoffAverage": 198.52
+    },
+    {
+      "season": 1995,
+      "games": 1257,
+      "averagePoints": 198.38,
+      "regularSeasonAverage": 199.01,
+      "playoffAverage": 187.46
+    },
+    {
+      "season": 1996,
+      "games": 1261,
+      "averagePoints": 193.47,
+      "regularSeasonAverage": 193.8,
+      "playoffAverage": 188.04
+    },
+    {
+      "season": 1997,
+      "games": 1260,
+      "averagePoints": 190.65,
+      "regularSeasonAverage": 191.14,
+      "playoffAverage": 182.46
+    },
+    {
+      "season": 1998,
+      "games": 791,
+      "averagePoints": 182.5,
+      "regularSeasonAverage": 183.16,
+      "playoffAverage": 175.24
+    },
+    {
+      "season": 1999,
+      "games": 1264,
+      "averagePoints": 194.28,
+      "regularSeasonAverage": 194.94,
+      "playoffAverage": 183.68
+    },
+    {
+      "season": 2000,
+      "games": 1260,
+      "averagePoints": 189.49,
+      "regularSeasonAverage": 189.62,
+      "playoffAverage": 187.23
+    },
+    {
+      "season": 2001,
+      "games": 1260,
+      "averagePoints": 190.81,
+      "regularSeasonAverage": 190.95,
+      "playoffAverage": 188.46
+    },
+    {
+      "season": 2002,
+      "games": 1277,
+      "averagePoints": 190.29,
+      "regularSeasonAverage": 190.16,
+      "playoffAverage": 192.05
+    },
+    {
+      "season": 2003,
+      "games": 1286,
+      "averagePoints": 186.05,
+      "regularSeasonAverage": 186.8,
+      "playoffAverage": 176.87
+    },
+    {
+      "season": 2004,
+      "games": 1362,
+      "averagePoints": 194.01,
+      "regularSeasonAverage": 194.41,
+      "playoffAverage": 190.29
+    },
+    {
+      "season": 2005,
+      "games": 1432,
+      "averagePoints": 193.58,
+      "regularSeasonAverage": 194.02,
+      "playoffAverage": 190.91
+    },
+    {
+      "season": 2006,
+      "games": 1419,
+      "averagePoints": 196.79,
+      "regularSeasonAverage": 197.48,
+      "playoffAverage": 192.33
+    },
+    {
+      "season": 2007,
+      "games": 1410,
+      "averagePoints": 198.84,
+      "regularSeasonAverage": 199.85,
+      "playoffAverage": 192.0
+    },
+    {
+      "season": 2008,
+      "games": 1420,
+      "averagePoints": 198.85,
+      "regularSeasonAverage": 199.9,
+      "playoffAverage": 192.03
+    },
+    {
+      "season": 2009,
+      "games": 1424,
+      "averagePoints": 200.4,
+      "regularSeasonAverage": 200.9,
+      "playoffAverage": 197.27
+    },
+    {
+      "season": 2010,
+      "games": 1422,
+      "averagePoints": 198.14,
+      "regularSeasonAverage": 199.1,
+      "playoffAverage": 191.99
+    },
+    {
+      "season": 2011,
+      "games": 1104,
+      "averagePoints": 191.82,
+      "regularSeasonAverage": 192.52,
+      "playoffAverage": 185.76
+    },
+    {
+      "season": 2012,
+      "games": 1420,
+      "averagePoints": 195.5,
+      "regularSeasonAverage": 196.28,
+      "playoffAverage": 190.48
+    },
+    {
+      "season": 2013,
+      "games": 1427,
+      "averagePoints": 201.0,
+      "regularSeasonAverage": 202.02,
+      "playoffAverage": 194.62
+    },
+    {
+      "season": 2014,
+      "games": 1418,
+      "averagePoints": 199.91,
+      "regularSeasonAverage": 200.03,
+      "playoffAverage": 199.14
+    },
+    {
+      "season": 2015,
+      "games": 1416,
+      "averagePoints": 204.48,
+      "regularSeasonAverage": 205.34,
+      "playoffAverage": 198.75
+    },
+    {
+      "season": 2016,
+      "games": 1405,
+      "averagePoints": 210.72,
+      "regularSeasonAverage": 211.18,
+      "playoffAverage": 207.49
+    },
+    {
+      "season": 2017,
+      "games": 1382,
+      "averagePoints": 212.15,
+      "regularSeasonAverage": 212.67,
+      "playoffAverage": 207.93
+    },
+    {
+      "season": 2018,
+      "games": 1378,
+      "averagePoints": 221.87,
+      "regularSeasonAverage": 222.42,
+      "playoffAverage": 217.3
+    },
+    {
+      "season": 2019,
+      "games": 1036,
+      "averagePoints": 222.59,
+      "regularSeasonAverage": 222.89,
+      "playoffAverage": 218.03
+    },
+    {
+      "season": 2020,
+      "games": 1417,
+      "averagePoints": 223.67,
+      "regularSeasonAverage": 224.72,
+      "playoffAverage": 218.74
+    },
+    {
+      "season": 2021,
+      "games": 1397,
+      "averagePoints": 220.43,
+      "regularSeasonAverage": 221.23,
+      "playoffAverage": 214.53
+    },
+    {
+      "season": 2022,
+      "games": 1385,
+      "averagePoints": 228.22,
+      "regularSeasonAverage": 229.37,
+      "playoffAverage": 219.08
+    },
+    {
+      "season": 2023,
+      "games": 1383,
+      "averagePoints": 227.13,
+      "regularSeasonAverage": 228.34,
+      "playoffAverage": 220.71
+    },
+    {
+      "season": 2024,
+      "games": 1385,
+      "averagePoints": 226.4,
+      "regularSeasonAverage": 227.3,
+      "playoffAverage": 219.48
+    }
+  ]
+}

--- a/public/data/state_birth_legends.json
+++ b/public/data/state_birth_legends.json
@@ -1,0 +1,550 @@
+{
+  "generatedAt": "2025-09-28T02:10:21.087940Z",
+  "states": [
+    {
+      "state": "AL",
+      "stateName": "Alabama",
+      "player": "Charles Barkley",
+      "birthCity": "Leeds",
+      "headline": "1993 MVP \u2022 11\u00d7 All-Star",
+      "notableTeams": [
+        "Philadelphia 76ers",
+        "Phoenix Suns",
+        "Houston Rockets"
+      ]
+    },
+    {
+      "state": "AK",
+      "stateName": "Alaska",
+      "player": "Carlos Boozer",
+      "birthCity": "Juneau",
+      "headline": "2\u00d7 All-Star \u2022 2008 Olympic gold medalist",
+      "notableTeams": [
+        "Utah Jazz",
+        "Chicago Bulls"
+      ]
+    },
+    {
+      "state": "AZ",
+      "stateName": "Arizona",
+      "player": "Sean Elliott",
+      "birthCity": "Tucson",
+      "headline": "1999 NBA champion \u2022 2\u00d7 All-Star",
+      "notableTeams": [
+        "San Antonio Spurs"
+      ]
+    },
+    {
+      "state": "AR",
+      "stateName": "Arkansas",
+      "player": "Scottie Pippen",
+      "birthCity": "Hamburg",
+      "headline": "6\u00d7 NBA champion \u2022 Hall of Famer",
+      "notableTeams": [
+        "Chicago Bulls",
+        "Portland Trail Blazers"
+      ]
+    },
+    {
+      "state": "CA",
+      "stateName": "California",
+      "player": "Kawhi Leonard",
+      "birthCity": "Riverside",
+      "headline": "2\u00d7 Finals MVP \u2022 2\u00d7 Defensive Player of the Year",
+      "notableTeams": [
+        "San Antonio Spurs",
+        "Toronto Raptors",
+        "Los Angeles Clippers"
+      ]
+    },
+    {
+      "state": "CO",
+      "stateName": "Colorado",
+      "player": "Chauncey Billups",
+      "birthCity": "Denver",
+      "headline": "2004 Finals MVP \u2022 5\u00d7 All-Star",
+      "notableTeams": [
+        "Detroit Pistons",
+        "Denver Nuggets"
+      ]
+    },
+    {
+      "state": "CT",
+      "stateName": "Connecticut",
+      "player": "Calvin Murphy",
+      "birthCity": "Norwalk",
+      "headline": "1979 All-Star \u2022 Hall of Famer",
+      "notableTeams": [
+        "Houston Rockets"
+      ]
+    },
+    {
+      "state": "DE",
+      "stateName": "Delaware",
+      "player": "Walt Hazzard",
+      "birthCity": "Wilmington",
+      "headline": "1964 Olympic gold \u2022 1968 All-Star",
+      "notableTeams": [
+        "Los Angeles Lakers",
+        "Seattle SuperSonics"
+      ]
+    },
+    {
+      "state": "DC",
+      "stateName": "District of Columbia",
+      "player": "Kevin Durant",
+      "birthCity": "Washington",
+      "headline": "2014 MVP \u2022 2\u00d7 Finals MVP",
+      "notableTeams": [
+        "Oklahoma City Thunder",
+        "Golden State Warriors",
+        "Phoenix Suns"
+      ]
+    },
+    {
+      "state": "FL",
+      "stateName": "Florida",
+      "player": "Vince Carter",
+      "birthCity": "Daytona Beach",
+      "headline": "8\u00d7 All-Star \u2022 1999 Rookie of the Year",
+      "notableTeams": [
+        "Toronto Raptors",
+        "New Jersey Nets"
+      ]
+    },
+    {
+      "state": "GA",
+      "stateName": "Georgia",
+      "player": "Dwight Howard",
+      "birthCity": "Atlanta",
+      "headline": "3\u00d7 Defensive Player of the Year \u2022 8\u00d7 All-Star",
+      "notableTeams": [
+        "Orlando Magic",
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "HI",
+      "stateName": "Hawaii",
+      "player": "Cedric Ceballos",
+      "birthCity": "Maui",
+      "headline": "1995 All-Star \u2022 Slam Dunk champion",
+      "notableTeams": [
+        "Phoenix Suns",
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "ID",
+      "stateName": "Idaho",
+      "player": "Luke Ridnour",
+      "birthCity": "Coeur d'Alene",
+      "headline": "2005 All-Rookie Team point guard",
+      "notableTeams": [
+        "Seattle SuperSonics",
+        "Milwaukee Bucks"
+      ]
+    },
+    {
+      "state": "IL",
+      "stateName": "Illinois",
+      "player": "Dwyane Wade",
+      "birthCity": "Chicago",
+      "headline": "3\u00d7 NBA champion \u2022 13\u00d7 All-Star",
+      "notableTeams": [
+        "Miami Heat",
+        "Chicago Bulls"
+      ]
+    },
+    {
+      "state": "IN",
+      "stateName": "Indiana",
+      "player": "Larry Bird",
+      "birthCity": "West Baden Springs",
+      "headline": "3\u00d7 MVP \u2022 12\u00d7 All-Star",
+      "notableTeams": [
+        "Boston Celtics"
+      ]
+    },
+    {
+      "state": "IA",
+      "stateName": "Iowa",
+      "player": "Harrison Barnes",
+      "birthCity": "Ames",
+      "headline": "2015 NBA champion \u2022 Olympic gold medalist",
+      "notableTeams": [
+        "Golden State Warriors",
+        "Sacramento Kings"
+      ]
+    },
+    {
+      "state": "KS",
+      "stateName": "Kansas",
+      "player": "Alvan Adams",
+      "birthCity": "Lawrence",
+      "headline": "1976 Rookie of the Year \u2022 All-Star",
+      "notableTeams": [
+        "Phoenix Suns"
+      ]
+    },
+    {
+      "state": "KY",
+      "stateName": "Kentucky",
+      "player": "Wes Unseld",
+      "birthCity": "Louisville",
+      "headline": "1969 MVP & Rookie of the Year",
+      "notableTeams": [
+        "Washington Bullets"
+      ]
+    },
+    {
+      "state": "LA",
+      "stateName": "Louisiana",
+      "player": "Karl Malone",
+      "birthCity": "Summerfield",
+      "headline": "2\u00d7 MVP \u2022 14\u00d7 All-Star",
+      "notableTeams": [
+        "Utah Jazz"
+      ]
+    },
+    {
+      "state": "ME",
+      "stateName": "Maine",
+      "player": "Duncan Robinson",
+      "birthCity": "York",
+      "headline": "Heat sharpshooter with multiple 200+ three-point seasons",
+      "notableTeams": [
+        "Miami Heat"
+      ]
+    },
+    {
+      "state": "MD",
+      "stateName": "Maryland",
+      "player": "Victor Oladipo",
+      "birthCity": "Silver Spring",
+      "headline": "2\u00d7 All-Star \u2022 2018 steals leader",
+      "notableTeams": [
+        "Indiana Pacers",
+        "Orlando Magic"
+      ]
+    },
+    {
+      "state": "MA",
+      "stateName": "Massachusetts",
+      "player": "Bill Laimbeer",
+      "birthCity": "Boston",
+      "headline": "2\u00d7 NBA champion \u2022 4\u00d7 All-Star",
+      "notableTeams": [
+        "Detroit Pistons"
+      ]
+    },
+    {
+      "state": "MI",
+      "stateName": "Michigan",
+      "player": "Magic Johnson",
+      "birthCity": "Lansing",
+      "headline": "5\u00d7 NBA champion \u2022 3\u00d7 MVP",
+      "notableTeams": [
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "MN",
+      "stateName": "Minnesota",
+      "player": "Kevin McHale",
+      "birthCity": "Hibbing",
+      "headline": "3\u00d7 NBA champion \u2022 Hall of Famer",
+      "notableTeams": [
+        "Boston Celtics"
+      ]
+    },
+    {
+      "state": "MS",
+      "stateName": "Mississippi",
+      "player": "Spencer Haywood",
+      "birthCity": "Silver City",
+      "headline": "1970 scoring champ \u2022 Hall of Famer",
+      "notableTeams": [
+        "Seattle SuperSonics",
+        "New York Knicks"
+      ]
+    },
+    {
+      "state": "MO",
+      "stateName": "Missouri",
+      "player": "Jayson Tatum",
+      "birthCity": "St. Louis",
+      "headline": "Multiple All-NBA first team selections",
+      "notableTeams": [
+        "Boston Celtics"
+      ]
+    },
+    {
+      "state": "MT",
+      "stateName": "Montana",
+      "player": "Phil Jackson",
+      "birthCity": "Deer Lodge",
+      "headline": "2\u00d7 NBA champion forward \u2022 11\u00d7 title-winning coach",
+      "notableTeams": [
+        "New York Knicks",
+        "Chicago Bulls"
+      ]
+    },
+    {
+      "state": "NE",
+      "stateName": "Nebraska",
+      "player": "Bob Boozer",
+      "birthCity": "Omaha",
+      "headline": "1968 All-Star \u2022 Olympic gold medalist",
+      "notableTeams": [
+        "Cincinnati Royals",
+        "Chicago Bulls"
+      ]
+    },
+    {
+      "state": "NV",
+      "stateName": "Nevada",
+      "player": "Greg Anthony",
+      "birthCity": "Las Vegas",
+      "headline": "1990 NCAA champion floor general",
+      "notableTeams": [
+        "New York Knicks",
+        "Portland Trail Blazers"
+      ]
+    },
+    {
+      "state": "NH",
+      "stateName": "New Hampshire",
+      "player": "Matt Bonner",
+      "birthCity": "Concord",
+      "headline": "2\u00d7 NBA champion stretch big",
+      "notableTeams": [
+        "San Antonio Spurs",
+        "Toronto Raptors"
+      ]
+    },
+    {
+      "state": "NJ",
+      "stateName": "New Jersey",
+      "player": "Shaquille O'Neal",
+      "birthCity": "Newark",
+      "headline": "4\u00d7 NBA champion \u2022 2000 MVP",
+      "notableTeams": [
+        "Los Angeles Lakers",
+        "Miami Heat"
+      ]
+    },
+    {
+      "state": "NM",
+      "stateName": "New Mexico",
+      "player": "Bill Bridges",
+      "birthCity": "Hobbs",
+      "headline": "3\u00d7 All-Star \u2022 1975 NBA champion",
+      "notableTeams": [
+        "St. Louis/Atlanta Hawks",
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "NY",
+      "stateName": "New York",
+      "player": "Michael Jordan",
+      "birthCity": "Brooklyn",
+      "headline": "6\u00d7 NBA champion \u2022 5\u00d7 MVP",
+      "notableTeams": [
+        "Chicago Bulls"
+      ]
+    },
+    {
+      "state": "NC",
+      "stateName": "North Carolina",
+      "player": "Chris Paul",
+      "birthCity": "Winston-Salem",
+      "headline": "12\u00d7 All-Star \u2022 6\u00d7 steals leader",
+      "notableTeams": [
+        "New Orleans Hornets",
+        "Phoenix Suns"
+      ]
+    },
+    {
+      "state": "ND",
+      "stateName": "North Dakota",
+      "player": "Doug McDermott",
+      "birthCity": "Grand Forks",
+      "headline": "2014 National Player of the Year \u2022 NBA sharpshooter",
+      "notableTeams": [
+        "Indiana Pacers",
+        "San Antonio Spurs"
+      ]
+    },
+    {
+      "state": "OH",
+      "stateName": "Ohio",
+      "player": "LeBron James",
+      "birthCity": "Akron",
+      "headline": "4\u00d7 NBA champion \u2022 4\u00d7 MVP",
+      "notableTeams": [
+        "Cleveland Cavaliers",
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "OK",
+      "stateName": "Oklahoma",
+      "player": "Blake Griffin",
+      "birthCity": "Oklahoma City",
+      "headline": "6\u00d7 All-Star \u2022 2011 Rookie of the Year",
+      "notableTeams": [
+        "Los Angeles Clippers",
+        "Detroit Pistons"
+      ]
+    },
+    {
+      "state": "OR",
+      "stateName": "Oregon",
+      "player": "Danny Ainge",
+      "birthCity": "Eugene",
+      "headline": "2\u00d7 NBA champion guard",
+      "notableTeams": [
+        "Boston Celtics"
+      ]
+    },
+    {
+      "state": "PA",
+      "stateName": "Pennsylvania",
+      "player": "Kobe Bryant",
+      "birthCity": "Philadelphia",
+      "headline": "5\u00d7 NBA champion \u2022 2008 MVP",
+      "notableTeams": [
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "RI",
+      "stateName": "Rhode Island",
+      "player": "Marvin Barnes",
+      "birthCity": "Providence",
+      "headline": "1975 ABA Rookie of the Year",
+      "notableTeams": [
+        "Spirit of St. Louis",
+        "Detroit Pistons"
+      ]
+    },
+    {
+      "state": "SC",
+      "stateName": "South Carolina",
+      "player": "Kevin Garnett",
+      "birthCity": "Greenville",
+      "headline": "2004 MVP \u2022 15\u00d7 All-Star",
+      "notableTeams": [
+        "Minnesota Timberwolves",
+        "Boston Celtics"
+      ]
+    },
+    {
+      "state": "SD",
+      "stateName": "South Dakota",
+      "player": "Mike Miller",
+      "birthCity": "Mitchell",
+      "headline": "2001 Rookie of the Year \u2022 2\u00d7 champion",
+      "notableTeams": [
+        "Memphis Grizzlies",
+        "Miami Heat"
+      ]
+    },
+    {
+      "state": "TN",
+      "stateName": "Tennessee",
+      "player": "Penny Hardaway",
+      "birthCity": "Memphis",
+      "headline": "4\u00d7 All-Star \u2022 2\u00d7 All-NBA First Team",
+      "notableTeams": [
+        "Orlando Magic",
+        "Phoenix Suns"
+      ]
+    },
+    {
+      "state": "TX",
+      "stateName": "Texas",
+      "player": "LaMarcus Aldridge",
+      "birthCity": "Dallas",
+      "headline": "7\u00d7 All-Star \u2022 5\u00d7 All-NBA",
+      "notableTeams": [
+        "Portland Trail Blazers",
+        "San Antonio Spurs"
+      ]
+    },
+    {
+      "state": "UT",
+      "stateName": "Utah",
+      "player": "Tom Chambers",
+      "birthCity": "Ogden",
+      "headline": "4\u00d7 All-Star \u2022 1987 All-Star Game MVP",
+      "notableTeams": [
+        "Seattle SuperSonics",
+        "Phoenix Suns"
+      ]
+    },
+    {
+      "state": "VT",
+      "stateName": "Vermont",
+      "player": null,
+      "birthCity": null,
+      "headline": "Still awaiting its first NBA alumnus",
+      "notableTeams": []
+    },
+    {
+      "state": "VA",
+      "stateName": "Virginia",
+      "player": "Allen Iverson",
+      "birthCity": "Hampton",
+      "headline": "2001 MVP \u2022 11\u00d7 All-Star",
+      "notableTeams": [
+        "Philadelphia 76ers",
+        "Denver Nuggets"
+      ]
+    },
+    {
+      "state": "WA",
+      "stateName": "Washington",
+      "player": "John Stockton",
+      "birthCity": "Spokane",
+      "headline": "All-time assists & steals leader",
+      "notableTeams": [
+        "Utah Jazz"
+      ]
+    },
+    {
+      "state": "WV",
+      "stateName": "West Virginia",
+      "player": "Jerry West",
+      "birthCity": "Chelyan",
+      "headline": "14\u00d7 All-Star \u2022 NBA logo inspiration",
+      "notableTeams": [
+        "Los Angeles Lakers"
+      ]
+    },
+    {
+      "state": "WI",
+      "stateName": "Wisconsin",
+      "player": "Latrell Sprewell",
+      "birthCity": "Milwaukee",
+      "headline": "4\u00d7 All-Star swingman",
+      "notableTeams": [
+        "Golden State Warriors",
+        "New York Knicks"
+      ]
+    },
+    {
+      "state": "WY",
+      "stateName": "Wyoming",
+      "player": "James Johnson",
+      "birthCity": "Cheyenne",
+      "headline": "Versatile forward and 2011 NBA champion",
+      "notableTeams": [
+        "Miami Heat",
+        "Toronto Raptors"
+      ]
+    }
+  ]
+}

--- a/public/history.html
+++ b/public/history.html
@@ -55,7 +55,7 @@
       <main>
         <section class="history-section">
           <div class="history-section__header">
-            <h2>Timeline atlas</h2>
+            <h2>Legends atlas</h2>
             <div class="history-badges">
               <span class="history-badge">
                 <span class="history-badge__label">Active franchises</span>
@@ -72,49 +72,41 @@
             </div>
           </div>
 
-          <div class="history-mosaic history-mosaic--wide">
-            <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Games logged by decade</header>
+          <div class="history-mosaic history-mosaic--wide history-mosaic--atlas">
+            <figure class="viz-card viz-card--inline viz-card--wide" data-chart-wrapper>
+              <header class="viz-card__title">Average points per game by season</header>
               <div class="viz-canvas">
-                <canvas data-chart="games-by-decade" aria-describedby="games-by-decade-caption"></canvas>
+                <canvas data-chart="scoring-averages" aria-describedby="scoring-averages-caption"></canvas>
               </div>
-              <figcaption id="games-by-decade-caption" class="viz-card__caption">
-                A filled spline highlights how the archive scales from the BAA launch through today's slate.
+              <figcaption id="scoring-averages-caption" class="viz-card__caption">
+                Line traces highlight how regular season and postseason scoring pace has ebbed and surged across every logged season.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline viz-card--tall" data-state-map>
+              <header class="viz-card__title">Best NBA star born in each state</header>
+              <div class="state-map" data-state-map-tiles></div>
+              <figcaption class="viz-card__caption">
+                Select a tile to spotlight the most decorated NBA player born in that state.
               </figcaption>
             </figure>
 
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Season logging velocity</header>
+              <header class="viz-card__title">Highest scoring seasons on record</header>
               <div class="viz-canvas">
-                <canvas data-chart="season-velocity" data-chart-ratio="0.62" aria-describedby="season-velocity-caption"></canvas>
+                <canvas data-chart="scoring-leaders" aria-describedby="scoring-leaders-caption"></canvas>
               </div>
-              <figcaption id="season-velocity-caption" class="viz-card__caption">
-                Each season's captured games stream across the decades to show spikes in schedule density.
+              <figcaption id="scoring-leaders-caption" class="viz-card__caption">
+                The loudest combined point totals underscore when pace and shot-making pushed games to all-time highs.
               </figcaption>
-            </figure>
-
-            <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Cumulative archive build</header>
-              <div class="viz-canvas">
-                <canvas data-chart="cumulative-games" data-chart-ratio="0.62" aria-describedby="cumulative-games-caption"></canvas>
-              </div>
-              <figcaption id="cumulative-games-caption" class="viz-card__caption">
-                An ascending ribbon quantifies how quickly total logged contests approach the modern era.</figcaption>
-            </figure>
-
-            <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Expansion fingerprint</header>
-              <div class="viz-canvas">
-                <canvas data-chart="franchise-radar" data-chart-ratio="0.75" aria-describedby="franchise-radar-caption"></canvas>
-              </div>
-              <figcaption id="franchise-radar-caption" class="viz-card__caption">
-                A radial map compares franchise arrivals by decade to spotlight expansion surges.</figcaption>
             </figure>
           </div>
 
           <aside class="timeline-panel">
-            <h3>Expansion timeline</h3>
-            <ol class="timeline" data-history="expansion-timeline"></ol>
+            <h3>State spotlight</h3>
+            <div class="state-spotlight" data-state-spotlight>
+              <p class="state-spotlight__placeholder">Select a state tile to meet its headline legend.</p>
+            </div>
           </aside>
         </section>
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -2747,8 +2747,155 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
+.history-mosaic--atlas {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+
 .history-mosaic--triptych {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.viz-card--wide {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.viz-card--tall {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.state-map {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(2.75rem, 1fr));
+  grid-auto-rows: minmax(2.75rem, 1fr);
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.08));
+}
+
+.state-tile {
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--royal) 20%, transparent);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--navy);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  cursor: pointer;
+  position: relative;
+  padding: 0.2rem;
+}
+
+.state-tile:hover,
+.state-tile:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(17, 86, 214, 0.18);
+  outline: none;
+}
+
+.state-tile--selected {
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.92), rgba(239, 61, 91, 0.85));
+  color: #fff;
+  box-shadow: 0 16px 26px rgba(17, 86, 214, 0.32);
+}
+
+.state-tile--empty {
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text-subtle);
+  border-style: dashed;
+  cursor: default;
+  box-shadow: none;
+}
+
+.state-tile--empty:hover,
+.state-tile--empty:focus-visible {
+  transform: none;
+  box-shadow: none;
+}
+
+.state-spotlight {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.state-spotlight__placeholder {
+  margin: 0;
+  color: var(--text-subtle);
+  font-style: italic;
+}
+
+.state-spotlight__state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--royal);
+}
+
+.state-spotlight__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
+.state-spotlight__player {
+  margin: 0;
+  font-size: clamp(1.3rem, 2.2vw, 1.7rem);
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.state-spotlight__headline {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+.state-spotlight__teams {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.state-spotlight__team {
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(17, 86, 214, 0.12);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: var(--royal);
+}
+
+.state-spotlight__empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-subtle);
+}
+
+@media (min-width: 960px) {
+  .history-mosaic--atlas .viz-card--wide {
+    grid-column: span 2;
+  }
+
+  .history-mosaic--atlas .viz-card--tall {
+    grid-row: span 2;
+  }
 }
 
 .timeline-panel {


### PR DESCRIPTION
## Summary
- replace the history timeline atlas with a refreshed "Legends atlas" layout featuring scoring-trend and high-scoring season charts plus an interactive state tile map
- add supporting datasets for season-long scoring averages and the best NBA player born in each state
- extend hub styles and history scripting to render the new atlas experience and spotlight details for the selected state

## Testing
- Manual verification by serving `public/` and reviewing `history.html`


------
https://chatgpt.com/codex/tasks/task_e_68d896d4fbd48327a81b9398ba83c50a