### PR TITLE
Fix rest spectrum tooltip values

### DIFF
--- a/public/scripts/teams.js
+++ b/public/scripts/teams.js
@@ -484,7 +484,16 @@ registerCharts([
             tooltip: {
               callbacks: {
                 label(context) {
-                  return `${context.label}: ${helpers.formatNumber(context.parsed, 0)} intervals`;
+                  const parsed = context.parsed;
+                  const value =
+                    typeof parsed === 'number'
+                      ? parsed
+                      : typeof parsed?.r === 'number'
+                        ? parsed.r
+                        : typeof context.raw === 'number'
+                          ? context.raw
+                          : 0;
+                  return `${context.label}: ${helpers.formatNumber(value, 0)} intervals`;
                 },
               },
             },


### PR DESCRIPTION
## Summary
- guard the rest spectrum tooltip against non-numeric parsed values
- fall back to the raw value so rest interval counts render correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d89b1b013c8327808d442d648d0f72