### PR TITLE
Fix GOAT franchise polar tooltip values

### DIFF
--- a/public/scripts/goat.js
+++ b/public/scripts/goat.js
@@ -840,7 +840,12 @@ async function init() {
                 tooltip: {
                   callbacks: {
                     label(context) {
-                      return `${context.label}: ${context.parsed}`;
+                      const parsedValue =
+                        typeof context.parsed === 'number' ? context.parsed : context.parsed?.r;
+                      if (typeof parsedValue === 'number' && !Number.isNaN(parsedValue)) {
+                        return `${context.label}: ${parsedValue}`;
+                      }
+                      return context.label ?? '';
                     },
                   },
                 },


### PR DESCRIPTION
## Summary
- sanitize the franchise polar chart tooltip values so Chart.js no longer renders [object Object]
- return the team name when a numeric value cannot be derived

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d89bdc70e48327bfc73dc05f945ae9