### PR TITLE
Expand Insights Lab with additional modules

### DIFF
--- a/public/data/insights_lab.json
+++ b/public/data/insights_lab.json
@@ -31,6 +31,7 @@
       }
     ]
   },
+  "sampleSize": 71879,
   "nightlifeEffect": {
     "tiers": [
       {

--- a/public/insights.html
+++ b/public/insights.html
@@ -97,6 +97,85 @@
               <canvas id="mascot-strength" data-chart-ratio="0.8"></canvas>
             </div>
           </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Astrology alignment index</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Vibe score vs. pace boost</span>
+                <span class="lab-chip lab-chip--accent" data-metric="astrology-highlight">Charting stars</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="astrology-alignment" data-chart-ratio="0.7"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Caffeine economy of sleep</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Win% and rest by coffee tier</span>
+                <span class="lab-chip lab-chip--accent" data-metric="coffee-highlight">Brewing data</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="coffee-consumption" data-chart-ratio="0.72"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Playlist mood board</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Point differential by soundtrack</span>
+                <span class="lab-chip lab-chip--accent" data-metric="playlist-highlight">Queuing tracks</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="playlist-mood" data-chart-ratio="0.6"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module lab-module--tall" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Airport delay index</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Charter wait time vs. wins</span>
+                <span class="lab-chip lab-chip--accent" data-metric="airport-highlight">Tracking departures</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="airport-delay" data-chart-ratio="0.78"></canvas>
+            </div>
+            <p class="lab-module__note" data-note="airport-delay-note" hidden></p>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>City transit effect</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Turnovers by commute style</span>
+                <span class="lab-chip lab-chip--accent" data-metric="transit-highlight">Mapping commutes</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="transit-effect" data-chart-ratio="0.68"></canvas>
+            </div>
+          </article>
+
+          <article class="lab-module" data-chart-wrapper>
+            <header class="lab-module__header">
+              <h2>Lunar phase energy</h2>
+              <div class="lab-module__meta">
+                <span class="lab-chip">Shooting rhythm by moon cycle</span>
+                <span class="lab-chip lab-chip--accent" data-metric="lunar-highlight">Lunar syncing</span>
+              </div>
+            </header>
+            <div class="viz-canvas">
+              <canvas id="lunar-phase" data-chart-ratio="0.62"></canvas>
+            </div>
+          </article>
         </section>
       </main>
 

--- a/public/scripts/insights.js
+++ b/public/scripts/insights.js
@@ -11,6 +11,19 @@ function setMetric(key, value, fallback = '--') {
   target.textContent = output;
 }
 
+function setNote(key, value) {
+  const target = document.querySelector(`[data-note="${key}"]`);
+  if (!target) {
+    return;
+  }
+  if (!value) {
+    target.hidden = true;
+    return;
+  }
+  target.hidden = false;
+  target.textContent = value;
+}
+
 function formatPercent(value, digits = 1) {
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return null;
@@ -92,8 +105,92 @@ function updateHero(data) {
     setMetric('mascot-edge-detail', 'Neck and neck');
   }
 
-  const sampleSize = weather.sampleSize ?? data?.sampleSize;
+  const sampleSize = data?.sampleSize ?? weather.sampleSize;
   setMetric('sample-size', Number.isFinite(sampleSize) ? `${helpers.formatNumber(sampleSize, 0)} games` : 'Collecting');
+}
+
+function updateModuleMetrics(data) {
+  const astrology = data?.astrologyAlignment ?? {};
+  const clusters = Array.isArray(astrology.clusters) ? astrology.clusters.filter(Boolean) : [];
+  if (clusters.length) {
+    const topCluster = [...clusters].sort((a, b) => (b.vibeScore ?? 0) - (a.vibeScore ?? 0))[0];
+    const label = (topCluster.label || '').split(' (')[0] || topCluster.label || 'Star cluster';
+    const vibeScore = Number.isFinite(topCluster.vibeScore) ? helpers.formatNumber(topCluster.vibeScore, 0) : null;
+    const paceBoost = Number.isFinite(topCluster.paceBoost)
+      ? `${topCluster.paceBoost >= 0 ? '+' : ''}${helpers.formatNumber(topCluster.paceBoost, 1)} pace`
+      : null;
+    const text = [label, vibeScore ? `${vibeScore} vibe` : null, paceBoost].filter(Boolean).join(' · ');
+    setMetric('astrology-highlight', text || 'Charting stars');
+  } else {
+    setMetric('astrology-highlight', 'Charting stars');
+  }
+
+  const coffee = data?.coffeeConsumption ?? {};
+  const levels = Array.isArray(coffee.levels) ? coffee.levels.filter(Boolean) : [];
+  if (levels.length) {
+    const topLevel = [...levels].sort((a, b) => (b.winPct ?? 0) - (a.winPct ?? 0))[0];
+    const label = (topLevel.label || '').split(' (')[0] || topLevel.label || 'Brew crew';
+    const winPct = Number.isFinite(topLevel.winPct) ? helpers.formatNumber(topLevel.winPct * 100, 1) : null;
+    const sleep = Number.isFinite(topLevel.avgSleepHours)
+      ? `${helpers.formatNumber(topLevel.avgSleepHours, 1)} hrs sleep`
+      : null;
+    const text = [label, winPct ? `${winPct}% win` : null, sleep].filter(Boolean).join(' · ');
+    setMetric('coffee-highlight', text || 'Brewing data');
+  } else {
+    setMetric('coffee-highlight', 'Brewing data');
+  }
+
+  const playlist = data?.playlistMood ?? {};
+  const moods = Array.isArray(playlist.moods) ? playlist.moods.filter(Boolean) : [];
+  if (moods.length) {
+    const topMood = [...moods].sort((a, b) => (b.pointDiff ?? 0) - (a.pointDiff ?? 0))[0];
+    const label = topMood.label || 'Hot track';
+    const diff = Number.isFinite(topMood.pointDiff)
+      ? `${topMood.pointDiff >= 0 ? '+' : ''}${helpers.formatNumber(topMood.pointDiff, 1)} diff`
+      : null;
+    setMetric('playlist-highlight', diff ? `${label} · ${diff}` : `${label} playlist`);
+  } else {
+    setMetric('playlist-highlight', 'Queuing tracks');
+  }
+
+  const airport = data?.airportDelayIndex ?? {};
+  const rankings = Array.isArray(airport.ranking) ? airport.ranking.filter(Boolean) : [];
+  if (rankings.length >= 2) {
+    const sorted = [...rankings].sort((a, b) => (b.winPct ?? 0) - (a.winPct ?? 0));
+    const leader = sorted[0];
+    const trailer = sorted[sorted.length - 1];
+    const leaderLabel = (leader.label || '').split(' (')[0] || leader.label || 'Leader';
+    const swing = Number.isFinite(leader.winPct) && Number.isFinite(trailer.winPct)
+      ? helpers.formatNumber((leader.winPct - trailer.winPct) * 100, 1)
+      : null;
+    const text = swing ? `${leaderLabel} lead by ${swing} pts` : `${leaderLabel} leading`;
+    setMetric('airport-highlight', text);
+  } else {
+    setMetric('airport-highlight', 'Tracking departures');
+  }
+  setNote('airport-delay-note', airport.note);
+
+  const transit = data?.cityTransitEffect ?? {};
+  const transitTiers = Array.isArray(transit.tiers) ? transit.tiers.filter(Boolean) : [];
+  if (transitTiers.length >= 2) {
+    const turnovers = transitTiers.map((tier) => tier.avgTurnovers ?? 0);
+    const swing = Math.max(...turnovers) - Math.min(...turnovers);
+    const text = `Turnover swing ${swing >= 0 ? '+' : ''}${helpers.formatNumber(swing, 1)}`;
+    setMetric('transit-highlight', text);
+  } else {
+    setMetric('transit-highlight', 'Mapping commutes');
+  }
+
+  const lunar = data?.lunarPhaseEnergy ?? {};
+  const phases = Array.isArray(lunar.phases) ? lunar.phases.filter(Boolean) : [];
+  if (phases.length) {
+    const bestPhase = [...phases].sort((a, b) => (b.fgPct ?? 0) - (a.fgPct ?? 0))[0];
+    const label = bestPhase.label || 'Top phase';
+    const fgPct = Number.isFinite(bestPhase.fgPct) ? helpers.formatNumber(bestPhase.fgPct * 100, 1) : null;
+    setMetric('lunar-highlight', fgPct ? `${label} · ${fgPct}% FG` : label);
+  } else {
+    setMetric('lunar-highlight', 'Lunar syncing');
+  }
 }
 
 function buildWeatherChart(dataRef) {
@@ -329,6 +426,438 @@ function buildMascotChart(dataRef) {
   };
 }
 
+function buildAstrologyChart(dataRef) {
+  const astrology = dataRef?.astrologyAlignment ?? {};
+  const clusters = Array.isArray(astrology.clusters) ? astrology.clusters.filter(Boolean) : [];
+  if (!clusters.length) {
+    return fallbackConfig('Star charts syncing');
+  }
+
+  const points = clusters.map((cluster) => ({
+    x: cluster.paceBoost ?? 0,
+    y: cluster.vibeScore ?? 0,
+    r: Math.max(8, Math.min(22, (cluster.teams ?? 0) * 1.6)),
+    label: cluster.label || 'Cluster',
+    teams: cluster.teams ?? null,
+  }));
+
+  return {
+    type: 'bubble',
+    data: {
+      datasets: [
+        {
+          label: 'Alignment clusters',
+          data: points,
+          backgroundColor: 'rgba(17, 86, 214, 0.55)',
+          borderColor: '#1156d6',
+          borderWidth: 1.5,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          title: { display: true, text: 'Pace boost (possessions per 48)' },
+          grid: { color: 'rgba(17, 86, 214, 0.08)' },
+          ticks: {
+            callback(value) {
+              return `${value >= 0 ? '+' : ''}${helpers.formatNumber(value, 1)}`;
+            },
+          },
+        },
+        y: {
+          title: { display: true, text: 'Vibe score' },
+          grid: { color: 'rgba(17, 86, 214, 0.12)' },
+          suggestedMin: 50,
+          suggestedMax: 80,
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            title(items) {
+              return items[0]?.raw?.label || '';
+            },
+            label(context) {
+              const { raw } = context;
+              const pace = `${raw.x >= 0 ? '+' : ''}${helpers.formatNumber(raw.x, 1)} pace`;
+              const vibe = `${helpers.formatNumber(raw.y, 0)} vibe`;
+              const teamCount = Number.isFinite(raw.teams) ? `${raw.teams} teams` : null;
+              return [pace, vibe, teamCount].filter(Boolean);
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildCoffeeChart(dataRef) {
+  const coffee = dataRef?.coffeeConsumption ?? {};
+  const levels = Array.isArray(coffee.levels) ? coffee.levels.filter(Boolean) : [];
+  if (!levels.length) {
+    return fallbackConfig('Brewing samples');
+  }
+
+  const labels = levels.map((level) => level.label || 'Level');
+  const winRates = levels.map((level) => (level.winPct ?? 0) * 100);
+  const sleepHours = levels.map((level) => level.avgSleepHours ?? null);
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          type: 'bar',
+          label: 'Win %',
+          data: winRates,
+          backgroundColor: '#1156d6',
+          maxBarThickness: 46,
+        },
+        {
+          type: 'line',
+          label: 'Avg sleep (hrs)',
+          data: sleepHours,
+          yAxisID: 'sleep',
+          borderColor: '#f4b53f',
+          borderWidth: 2,
+          tension: 0.35,
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#f4b53f',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: {
+          beginAtZero: true,
+          suggestedMax: 60,
+          title: { display: true, text: 'Win percentage' },
+          ticks: {
+            callback: (value) => `${helpers.formatNumber(value, 0)}%`,
+          },
+          grid: { color: 'rgba(17, 86, 214, 0.12)' },
+        },
+        sleep: {
+          position: 'right',
+          beginAtZero: false,
+          suggestedMin: 5.5,
+          suggestedMax: 8.5,
+          title: { display: true, text: 'Avg sleep (hours)' },
+          grid: { drawOnChartArea: false },
+        },
+        x: {
+          grid: { color: 'rgba(17, 86, 214, 0.05)' },
+        },
+      },
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              if (context.dataset.label === 'Win %') {
+                return `Win %: ${helpers.formatNumber(context.parsed.y, 1)}%`;
+              }
+              return `Avg sleep: ${helpers.formatNumber(context.parsed.y, 1)} hrs`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildPlaylistChart(dataRef) {
+  const playlist = dataRef?.playlistMood ?? {};
+  const moods = Array.isArray(playlist.moods) ? playlist.moods.filter(Boolean) : [];
+  if (!moods.length) {
+    return fallbackConfig('Playlist cues buffering');
+  }
+
+  const labels = moods.map((mood) => mood.label || 'Playlist');
+  const pointDiffs = moods.map((mood) => mood.pointDiff ?? 0);
+  const games = moods.map((mood) => mood.games ?? null);
+
+  return {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Point differential',
+          data: pointDiffs,
+          borderColor: '#ef3d5b',
+          borderWidth: 2,
+          backgroundColor: (context) => createGradient(context, ['rgba(239, 61, 91, 0.28)', 'rgba(239, 61, 91, 0.06)']),
+          fill: 'origin',
+          tension: 0.4,
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#ef3d5b',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          title: { display: true, text: 'Point differential' },
+          grid: { color: 'rgba(239, 61, 91, 0.12)' },
+          ticks: {
+            callback: (value) => `${value >= 0 ? '+' : ''}${helpers.formatNumber(value, 1)}`,
+          },
+        },
+        x: {
+          grid: { color: 'rgba(239, 61, 91, 0.05)' },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              const value = context.parsed.y;
+              const prefix = value >= 0 ? '+' : '';
+              const gamesCount = games[context.dataIndex];
+              const gamesNote = Number.isFinite(gamesCount) ? ` · ${helpers.formatNumber(gamesCount, 0)} games` : '';
+              return `Point diff: ${prefix}${helpers.formatNumber(value, 1)}${gamesNote}`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildAirportChart(dataRef) {
+  const airport = dataRef?.airportDelayIndex ?? {};
+  const rankings = Array.isArray(airport.ranking) ? airport.ranking.filter(Boolean) : [];
+  if (!rankings.length) {
+    return fallbackConfig('Delay index syncing');
+  }
+
+  const labels = rankings.map((entry) => entry.label || 'Tier');
+  const delays = rankings.map((entry) => entry.delayMinutes ?? 0);
+  const winRates = rankings.map((entry) => (entry.winPct ?? 0) * 100);
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          type: 'bar',
+          label: 'Avg delay (minutes)',
+          data: delays,
+          backgroundColor: '#0b2545',
+          maxBarThickness: 48,
+        },
+        {
+          type: 'line',
+          label: 'Win %',
+          data: winRates,
+          yAxisID: 'win',
+          borderColor: '#ef3d5b',
+          borderWidth: 2,
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#ef3d5b',
+          pointBorderWidth: 2,
+          tension: 0.35,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'Avg delay (minutes)' },
+          grid: { color: 'rgba(11, 37, 69, 0.12)' },
+        },
+        win: {
+          position: 'right',
+          beginAtZero: true,
+          suggestedMax: 60,
+          title: { display: true, text: 'Win percentage' },
+          ticks: {
+            callback: (value) => `${helpers.formatNumber(value, 0)}%`,
+          },
+          grid: { drawOnChartArea: false },
+        },
+        x: {
+          grid: { color: 'rgba(11, 37, 69, 0.08)' },
+        },
+      },
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              if (context.dataset.label === 'Avg delay (minutes)') {
+                return `Delay: ${helpers.formatNumber(context.parsed.y, 1)} min`;
+              }
+              return `Win %: ${helpers.formatNumber(context.parsed.y, 1)}%`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildTransitChart(dataRef) {
+  const transit = dataRef?.cityTransitEffect ?? {};
+  const tiers = Array.isArray(transit.tiers) ? transit.tiers.filter(Boolean) : [];
+  if (!tiers.length) {
+    return fallbackConfig('Transit metrics boarding');
+  }
+
+  const labels = tiers.map((tier) => tier.label || 'Tier');
+  const turnovers = tiers.map((tier) => tier.avgTurnovers ?? 0);
+  const samples = tiers.map((tier) => tier.sampleSize ?? null);
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          type: 'bar',
+          label: 'Avg turnovers',
+          data: turnovers,
+          backgroundColor: '#1f7bff',
+          maxBarThickness: 48,
+        },
+        {
+          type: 'line',
+          label: 'Games sampled',
+          data: samples,
+          yAxisID: 'sample',
+          borderColor: '#0b2545',
+          borderWidth: 2,
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#0b2545',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          tension: 0.3,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'Avg turnovers' },
+          grid: { color: 'rgba(17, 86, 214, 0.12)' },
+        },
+        sample: {
+          position: 'right',
+          beginAtZero: true,
+          title: { display: true, text: 'Games sampled' },
+          grid: { drawOnChartArea: false },
+        },
+        x: {
+          grid: { color: 'rgba(17, 86, 214, 0.05)' },
+        },
+      },
+      plugins: {
+        legend: { position: 'bottom' },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              if (context.dataset.label === 'Avg turnovers') {
+                return `Avg turnovers: ${helpers.formatNumber(context.parsed.y, 1)}`;
+              }
+              return `Games sampled: ${helpers.formatNumber(context.parsed.y, 0)}`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildLunarChart(dataRef) {
+  const lunar = dataRef?.lunarPhaseEnergy ?? {};
+  const phases = Array.isArray(lunar.phases) ? lunar.phases.filter(Boolean) : [];
+  if (!phases.length) {
+    return fallbackConfig('Moon data recalibrating');
+  }
+
+  const labels = phases.map((phase) => phase.label || 'Phase');
+  const fgPct = phases.map((phase) => (phase.fgPct ?? 0) * 100);
+  const games = phases.map((phase) => phase.games ?? null);
+
+  return {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'Field goal %',
+          data: fgPct,
+          borderColor: '#1156d6',
+          borderWidth: 2,
+          backgroundColor: (context) => createGradient(context, ['rgba(17, 86, 214, 0.32)', 'rgba(17, 86, 214, 0.08)']),
+          fill: 'origin',
+          tension: 0.35,
+          pointBackgroundColor: '#ffffff',
+          pointBorderColor: '#1156d6',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      scales: {
+        y: {
+          beginAtZero: false,
+          suggestedMin: 45,
+          suggestedMax: 50,
+          title: { display: true, text: 'Field goal percentage' },
+          ticks: {
+            callback: (value) => `${helpers.formatNumber(value, 1)}%`,
+          },
+          grid: { color: 'rgba(17, 86, 214, 0.12)' },
+        },
+        x: {
+          grid: { color: 'rgba(17, 86, 214, 0.05)' },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          callbacks: {
+            label(context) {
+              const value = context.parsed.y;
+              const gamesCount = games[context.dataIndex];
+              const gamesNote = Number.isFinite(gamesCount) ? ` · ${helpers.formatNumber(gamesCount, 0)} games` : '';
+              return `FG%: ${helpers.formatNumber(value, 1)}%${gamesNote}`;
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
 function registerLabCharts(dataRef) {
   registerCharts([
     {
@@ -343,6 +872,30 @@ function registerLabCharts(dataRef) {
       element: '#mascot-strength',
       createConfig: () => buildMascotChart(dataRef),
     },
+    {
+      element: '#astrology-alignment',
+      createConfig: () => buildAstrologyChart(dataRef),
+    },
+    {
+      element: '#coffee-consumption',
+      createConfig: () => buildCoffeeChart(dataRef),
+    },
+    {
+      element: '#playlist-mood',
+      createConfig: () => buildPlaylistChart(dataRef),
+    },
+    {
+      element: '#airport-delay',
+      createConfig: () => buildAirportChart(dataRef),
+    },
+    {
+      element: '#transit-effect',
+      createConfig: () => buildTransitChart(dataRef),
+    },
+    {
+      element: '#lunar-phase',
+      createConfig: () => buildLunarChart(dataRef),
+    },
   ]);
 }
 
@@ -354,6 +907,7 @@ async function hydrateLab() {
     }
     const data = await response.json();
     updateHero(data);
+    updateModuleMetrics(data);
     registerLabCharts(data);
   } catch (error) {
     console.error('Failed to hydrate insights lab', error);

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -1371,6 +1371,12 @@ section {
   align-items: center;
 }
 
+.lab-module__note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-subtle);
+}
+
 .lab-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add the missing Insights Lab modules so every dataset renders a dedicated visualization and chip metric
- update the shared Insights Lab data set with the full 71,879-game sample size and expose the airport note inline
- style the Insights Lab cards for inline notes and wire up new chart configurations for astrology, coffee, playlists, airport delays, city transit, and lunar phases

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d89c38b55083278241ff26409f25ea