### PR TITLE
Fix Legends atlas map placement

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -74,6 +74,14 @@
           </div>
 
           <div class="history-mosaic history-mosaic--wide history-mosaic--atlas">
+            <figure class="viz-card viz-card--inline viz-card--atlas-map" data-state-map>
+              <header class="viz-card__title">Best NBA star born in each state</header>
+              <div class="state-map" data-state-map-tiles></div>
+              <figcaption class="viz-card__caption">
+                Select a tile to spotlight the most decorated NBA player born in that state.
+              </figcaption>
+            </figure>
+
             <figure class="viz-card viz-card--inline viz-card--wide" data-chart-wrapper>
               <header class="viz-card__title">Average points per game by season</header>
               <div class="viz-canvas">
@@ -81,14 +89,6 @@
               </div>
               <figcaption id="scoring-averages-caption" class="viz-card__caption">
                 Line traces highlight how regular season and postseason scoring pace has ebbed and surged across every logged season.
-              </figcaption>
-            </figure>
-
-            <figure class="viz-card viz-card--inline viz-card--tall" data-state-map>
-              <header class="viz-card__title">Best NBA star born in each state</header>
-              <div class="state-map" data-state-map-tiles></div>
-              <figcaption class="viz-card__caption">
-                Select a tile to spotlight the most decorated NBA player born in that state.
               </figcaption>
             </figure>
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -2755,6 +2755,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 .history-mosaic--atlas {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-auto-flow: row dense;
   align-items: stretch;
 }
 
@@ -2772,6 +2773,18 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   gap: 0.75rem;
 }
 
+.viz-card--atlas-map {
+  position: relative;
+}
+
+.viz-card--atlas-map .viz-card__title {
+  font-size: clamp(1.15rem, 2.1vw, 1.35rem);
+}
+
+.viz-card--atlas-map .state-map {
+  min-height: clamp(280px, 38vw, 480px);
+}
+
 .state-map {
   display: flex;
   align-items: center;
@@ -2781,6 +2794,10 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background: linear-gradient(135deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.08));
   min-height: 0;
+}
+
+.history-mosaic--atlas .viz-card--atlas-map {
+  order: 0;
 }
 
 .state-map__svg {
@@ -2903,12 +2920,12 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 
 @media (min-width: 960px) {
-  .history-mosaic--atlas .viz-card--wide {
-    grid-column: span 2;
+  .history-mosaic--atlas .viz-card--atlas-map {
+    grid-column: 1 / -1;
   }
 
-  .history-mosaic--atlas .viz-card--tall {
-    grid-row: span 2;
+  .history-mosaic--atlas .viz-card--wide {
+    grid-column: 1 / -1;
   }
 }
 


### PR DESCRIPTION
## Summary
- make the Legends atlas map the lead card in the history mosaic so it anchors the section
- add styling so the map spans the full grid width and pushes the scoring averages chart beneath it
- enlarge the map canvas and typography to emphasize it as the centerpiece

## Testing
- not run (non-code changes)


------
https://chatgpt.com/codex/tasks/task_e_68d89f1f878c832798b06d23cbbb9917