### PR TITLE
Fix Legends atlas map loading

### DIFF
--- a/public/scripts/history.js
+++ b/public/scripts/history.js
@@ -108,7 +108,7 @@ async function loadStateMapSvg() {
     if (!response.ok) {
       throw new Error('Failed to load state atlas map');
     }
-    stateMapMarkup = await response.text();
+    stateMapMarkup = (await response.text()).replace(/ns0:/g, '');
   }
   const template = document.createElement('template');
   template.innerHTML = stateMapMarkup.trim();


### PR DESCRIPTION
## Summary
- strip the XML namespace prefix from the fetched state map SVG so it can render inside the Legends atlas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8a0854a088327a8a9eccdc7211f4f