### PR TITLE
Move state spotlight below atlas map

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -82,6 +82,13 @@
               </figcaption>
             </figure>
 
+            <aside class="timeline-panel">
+              <h3>State spotlight</h3>
+              <div class="state-spotlight" data-state-spotlight>
+                <p class="state-spotlight__placeholder">Select a state tile to meet its headline legend.</p>
+              </div>
+            </aside>
+
             <figure class="viz-card viz-card--inline viz-card--wide" data-chart-wrapper>
               <header class="viz-card__title">Average points per game by season</header>
               <div class="viz-canvas">
@@ -102,13 +109,6 @@
               </figcaption>
             </figure>
           </div>
-
-          <aside class="timeline-panel">
-            <h3>State spotlight</h3>
-            <div class="state-spotlight" data-state-spotlight>
-              <p class="state-spotlight__placeholder">Select a state tile to meet its headline legend.</p>
-            </div>
-          </aside>
         </section>
 
         <section class="history-section">

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -2759,6 +2759,10 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   align-items: stretch;
 }
 
+.history-mosaic--atlas .timeline-panel {
+  grid-column: 1 / -1;
+}
+
 .history-mosaic--triptych {
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }


### PR DESCRIPTION
## Summary
- embed the state spotlight panel within the legends atlas mosaic so the details surface beneath the map
- update atlas grid styling so the state spotlight panel spans the full width under the map

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8a156fc1c8327a95fdb2a57139dda