### PR TITLE
Remove hero metrics from teams page

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -29,21 +29,6 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Team Systems</span>
-          <h1>Benchmark every franchise from culture to crunch time.</h1>
-          <dl class="hero-metrics">
-            <div class="hero-metrics__item">
-              <dt>Active franchises</dt>
-              <dd>35 programs tracking toward 2100</dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Average rest window</dt>
-              <dd>3.04 days between tilts</dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Historic win apex</dt>
-              <dd>59.7% pace from Boston</dd>
-            </div>
-          </dl>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the hero headline and metrics block from teams.html

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a33b96bc83278bf8b75264ee1cd1