### PR TITLE
Remove hero copy from games page

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -29,29 +29,6 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Games Observatory</span>
-          <h1>The nightly pulse of the league, reframed as energy signatures.</h1>
-          <p>
-            Each chart below blends scoring swings, itinerary math, and arena physics to decode
-            how NBA games veer toward chaos or control in real time.
-          </p>
-          <dl class="hero-metrics">
-            <div class="hero-metrics__item">
-              <dt>Games tracked</dt>
-              <dd data-metric="tracked-games">—</dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Wildest swing</dt>
-              <dd data-metric="largest-swing">—</dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Road miles logged</dt>
-              <dd data-metric="miles-logged">—</dd>
-            </div>
-            <div class="hero-metrics__item">
-              <dt>Loudest crowd pulse</dt>
-              <dd data-metric="crowd-surge">—</dd>
-            </div>
-          </dl>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the descriptive headline and metrics block from the Games Observatory hero

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a48826788327aebc766d7c692d8b