### PR TITLE
Remove history hero metrics banner

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -29,27 +29,6 @@
         </div>
         <div class="hero">
           <span class="eyebrow">League Archive</span>
-          <h1>Chronicle the eras that shaped today's game.</h1>
-          <div class="history-hero-metrics">
-            <article class="history-hero-metric history-hero-metric--primary">
-              <span class="history-hero-metric__label">Games logged</span>
-              <span class="history-hero-metric__value" data-history="total-games">--</span>
-              <span class="history-hero-metric__context">
-                <span data-history="first-game">--</span>
-                <span class="history-hero-metric__divider">to</span>
-                <span data-history="latest-game">--</span>
-              </span>
-            </article>
-            <article class="history-hero-metric">
-              <span class="history-hero-metric__label">Playoff catalog</span>
-              <span class="history-hero-metric__value" data-history="playoff-games">--</span>
-              <span class="history-hero-metric__context" data-history="playoff-share">--</span>
-            </article>
-            <article class="history-hero-metric">
-              <span class="history-hero-metric__label">Attendance record</span>
-              <span class="history-hero-metric__value history-hero-metric__value--compact" data-history="attendance-record">--</span>
-            </article>
-          </div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the hero headline and metrics block from the history page hero

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a4ca9f2083279934e83b938dac94