### PR TITLE
Add Franchise Footprint team rankings

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -3619,6 +3619,129 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .team-marker__label { display: none; }
 }
 .players-lab { display: grid; gap: clamp(2.4rem, 5vw, 3.8rem); margin-bottom: 4rem; }
+.franchise-footprint {
+  display: grid;
+  gap: clamp(1.8rem, 3vw, 2.6rem);
+  margin-bottom: clamp(3.4rem, 6vw, 4.8rem);
+}
+.franchise-footprint__intro { display: grid; gap: 0.75rem; max-width: 720px; }
+.franchise-footprint__intro h2 {
+  margin: 0;
+  font-size: clamp(1.85rem, 3.4vw, 2.35rem);
+  color: var(--navy);
+}
+.franchise-footprint__intro p {
+  margin: 0;
+  color: color-mix(in srgb, var(--text-subtle) 82%, var(--navy) 18%);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+.franchise-footprint__panel {
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(242, 246, 255, 0.85) 30%);
+  box-shadow: var(--shadow-soft);
+  padding: clamp(1.6rem, 3.4vw, 2.4rem);
+}
+.franchise-footprint__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: clamp(0.65rem, 1.8vw, 0.95rem);
+}
+.franchise-footprint__item {
+  display: grid;
+  gap: clamp(0.65rem, 1.6vw, 0.9rem);
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  padding: clamp(0.75rem, 1.9vw, 1.05rem) clamp(0.9rem, 2vw, 1.3rem);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.78) 60%, rgba(242, 246, 255, 0.88) 40%);
+}
+.franchise-footprint__item:nth-child(-n + 5) {
+  border-color: color-mix(in srgb, var(--royal) 28%, transparent);
+  background: linear-gradient(150deg, rgba(17, 86, 214, 0.14), rgba(244, 181, 63, 0.1));
+}
+.franchise-footprint__rank {
+  display: grid;
+  place-items: center;
+  width: clamp(2.4rem, 3.6vw, 2.8rem);
+  height: clamp(2.4rem, 3.6vw, 2.8rem);
+  border-radius: 14px;
+  font-weight: 700;
+  font-size: clamp(1.25rem, 2.8vw, 1.6rem);
+  color: var(--surface);
+  background: linear-gradient(135deg, var(--royal), var(--sky));
+  box-shadow: 0 10px 18px rgba(17, 86, 214, 0.18);
+}
+.franchise-footprint__item:nth-child(-n + 3) .franchise-footprint__rank {
+  background: linear-gradient(135deg, var(--gold), #ffdd77);
+  color: var(--navy);
+  box-shadow: 0 12px 22px rgba(244, 181, 63, 0.28);
+}
+.franchise-footprint__body { display: grid; gap: 0.45rem; }
+.franchise-footprint__heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+.franchise-footprint__heading strong { font-size: 1.08rem; color: var(--navy); }
+.franchise-footprint__score {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--navy) 78%, var(--royal) 22%);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(244, 181, 63, 0.18) 40%);
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+}
+.franchise-footprint__meta {
+  font-size: 0.94rem;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+}
+.franchise-footprint__signals {
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
+}
+.franchise-footprint__methodology {
+  display: grid;
+  gap: 0.85rem;
+  padding: clamp(1.4rem, 2.8vw, 2rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.8) 30%);
+  box-shadow: var(--shadow-subtle);
+}
+.franchise-footprint__methodology h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.4vw, 1.55rem);
+  color: var(--navy);
+}
+.franchise-footprint__methodology p {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.65;
+  color: color-mix(in srgb, var(--text-subtle) 82%, var(--navy) 18%);
+}
+.franchise-footprint__methodology ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.4rem;
+  color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
+  font-size: 0.94rem;
+}
+.franchise-footprint__methodology li strong { color: var(--navy); }
+
+@media (max-width: 720px) {
+  .franchise-footprint__item { grid-template-columns: minmax(0, 1fr); }
+  .franchise-footprint__rank { width: 2.3rem; height: 2.3rem; font-size: 1.2rem; }
+  .franchise-footprint__heading { justify-content: space-between; }
+}
 .players-rankings {
   display: grid;
   gap: clamp(1.4rem, 3vw, 2rem);

--- a/public/teams.html
+++ b/public/teams.html
@@ -33,6 +33,24 @@
       </header>
 
       <main>
+        <section class="franchise-footprint" data-footprint>
+          <div class="franchise-footprint__intro">
+            <span class="eyebrow">Franchise Footprint</span>
+            <h2>Ranking every active team by footprint strength.</h2>
+            <p>
+              We blended results, efficiency, and rotational depth to surface how each club's on-court identity
+              resonates across the league in 2024-25. Explore the full ladder below, then dig into the numbers that
+              power every badge.
+            </p>
+          </div>
+          <div class="franchise-footprint__panel">
+            <ol class="franchise-footprint__list" data-footprint-list aria-live="polite"></ol>
+          </div>
+          <section class="franchise-footprint__methodology" aria-label="Franchise Footprint methodology">
+            <h3>How the Franchise Footprint score is built</h3>
+            <div data-footprint-methodology></div>
+          </section>
+        </section>
         <section class="team-explorer">
           <div class="team-explorer__intro">
             <span class="eyebrow">Conference geography</span>


### PR DESCRIPTION
## Summary
- add a Franchise Footprint ranking section to the teams page with descriptive copy and methodology
- style the ranking list and methodology panel to match the hub aesthetic
- compute composite scores from team metrics and render the ordered list client-side

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8aa1c52f883278dfb200909e92ad9