### PR TITLE
Reorder franchise footprint section on teams page

### DIFF
--- a/public/teams.html
+++ b/public/teams.html
@@ -33,24 +33,6 @@
       </header>
 
       <main>
-        <section class="franchise-footprint" data-footprint>
-          <div class="franchise-footprint__intro">
-            <span class="eyebrow">Franchise Footprint</span>
-            <h2>Ranking every active team by footprint strength.</h2>
-            <p>
-              We blended results, efficiency, and rotational depth to surface how each club's on-court identity
-              resonates across the league in 2024-25. Explore the full ladder below, then dig into the numbers that
-              power every badge.
-            </p>
-          </div>
-          <div class="franchise-footprint__panel">
-            <ol class="franchise-footprint__list" data-footprint-list aria-live="polite"></ol>
-          </div>
-          <section class="franchise-footprint__methodology" aria-label="Franchise Footprint methodology">
-            <h3>How the Franchise Footprint score is built</h3>
-            <div data-footprint-methodology></div>
-          </section>
-        </section>
         <section class="team-explorer">
           <div class="team-explorer__intro">
             <span class="eyebrow">Conference geography</span>
@@ -98,6 +80,24 @@
               </header>
               <div class="team-detail__visuals" data-team-visuals></div>
             </div>
+          </section>
+        </section>
+        <section class="franchise-footprint" data-footprint>
+          <div class="franchise-footprint__intro">
+            <span class="eyebrow">Franchise Footprint</span>
+            <h2>Ranking every active team by footprint strength.</h2>
+            <p>
+              We blended results, efficiency, and rotational depth to surface how each club's on-court identity
+              resonates across the league in 2024-25. Explore the full ladder below, then dig into the numbers that
+              power every badge.
+            </p>
+          </div>
+          <div class="franchise-footprint__panel">
+            <ol class="franchise-footprint__list" data-footprint-list aria-live="polite"></ol>
+          </div>
+          <section class="franchise-footprint__methodology" aria-label="Franchise Footprint methodology">
+            <h3>How the Franchise Footprint score is built</h3>
+            <div data-footprint-methodology></div>
           </section>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- move the Franchise Footprint section to appear after the Conference geography map on the teams page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ad32ddd88327baf55edf6b158efc