### PR TITLE
Ensure Insights Lab charts use real aggregated data

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@
 - **Outputs:** `public/data/players_overview.json`, `public/data/historic_games.json`, `public/data/team_performance.json`, `public/data/player_leaders.json`, and `public/data/player_season_insights.json`.
 - **Why it matters:** Keeps the browser payload tiny while ensuring the MVP reflects every dataset shipped with the repository.
 
+### Insights lab snapshot
+
+- **Description:** Aggregated metrics powering the experimental modules in `public/insights.html`, including monthly scoring curves, rest advantage splits, overtime outcomes, and long-run three-point trends.
+- **How to regenerate:** Run `python scripts/build_insights_lab.py`. The helper streams `Games.csv` and `TeamStatistics.zip`, computes rest differentials for every matchup, and writes the compact browser payload.
+- **Outputs:** `public/data/insights_lab.json`.
+- **Why it matters:** Guarantees that every chart on the Insights Lab page is backed by verifiable data instead of placeholder values.
+
 ### Team profile snapshot (map experience)
 
 - **Description:** All-time franchise dashboards backing the map interaction on `public/teams.html`, including wins, losses, and twelve per-game benchmarks.

--- a/public/data/insights_lab.json
+++ b/public/data/insights_lab.json
@@ -1,214 +1,601 @@
 {
-  "weatherImpact": {
-    "correlation": 0.18,
-    "baseline": 216.4,
-    "sampleSize": 820,
+  "generatedAt": "2025-09-28T03:47:45.724550+00:00",
+  "sampleSize": 71879,
+  "seasonalScoring": {
+    "months": [
+      {
+        "month": "Jan",
+        "games": 12189,
+        "averagePoints": 208.71597341865618,
+        "regularSeasonAverage": 208.71597341865618,
+        "playoffAverage": null
+      },
+      {
+        "month": "Feb",
+        "games": 10543,
+        "averagePoints": 209.7161149577919,
+        "regularSeasonAverage": 209.7161149577919,
+        "playoffAverage": null
+      },
+      {
+        "month": "Mar",
+        "games": 12272,
+        "averagePoints": 209.1300521512386,
+        "regularSeasonAverage": 209.13545416492255,
+        "playoffAverage": 208.93272171253824
+      },
+      {
+        "month": "Apr",
+        "games": 7774,
+        "averagePoints": 206.43015178801133,
+        "regularSeasonAverage": 207.22632205407243,
+        "playoffAverage": 203.7800963081862
+      },
+      {
+        "month": "May",
+        "games": 2012,
+        "averagePoints": 202.14264413518887,
+        "regularSeasonAverage": 218.70391061452514,
+        "playoffAverage": 200.43732895457035
+      },
+      {
+        "month": "Jun",
+        "games": 327,
+        "averagePoints": 199.13455657492355,
+        "regularSeasonAverage": null,
+        "playoffAverage": 199.13455657492355
+      },
+      {
+        "month": "Jul",
+        "games": 49,
+        "averagePoints": 219.73469387755102,
+        "regularSeasonAverage": 244.25,
+        "playoffAverage": 223.25
+      },
+      {
+        "month": "Aug",
+        "games": 123,
+        "averagePoints": 228.47967479674796,
+        "regularSeasonAverage": 230.0625,
+        "playoffAverage": 225.0
+      },
+      {
+        "month": "Sep",
+        "games": 46,
+        "averagePoints": 213.5,
+        "regularSeasonAverage": null,
+        "playoffAverage": 212.88888888888889
+      },
+      {
+        "month": "Oct",
+        "games": 3999,
+        "averagePoints": 208.86471617904476,
+        "regularSeasonAverage": 214.957216940363,
+        "playoffAverage": 214.6
+      },
+      {
+        "month": "Nov",
+        "games": 11046,
+        "averagePoints": 207.15172913271772,
+        "regularSeasonAverage": 207.03158565446932,
+        "playoffAverage": null
+      },
+      {
+        "month": "Dec",
+        "games": 11499,
+        "averagePoints": 207.7829376467519,
+        "regularSeasonAverage": 207.77893630070972,
+        "playoffAverage": null
+      }
+    ],
+    "swing": 29.345118221824407
+  },
+  "restImpact": {
     "buckets": [
       {
-        "label": "Frigid (<35\u00b0F)",
-        "avgPoints": 208.2,
-        "games": 132
+        "label": "+2 days",
+        "games": 3130,
+        "winPct": 0.3875399361022364,
+        "pointMargin": -2.9642172523961663
       },
       {
-        "label": "Cool (35-55\u00b0F)",
-        "avgPoints": 213.6,
-        "games": 198
+        "label": "+1 day",
+        "games": 7012,
+        "winPct": 0.39289788933257275,
+        "pointMargin": -3.0782943525385056
       },
       {
-        "label": "Mild (55-70\u00b0F)",
-        "avgPoints": 218.8,
-        "games": 236
+        "label": "Even rest",
+        "games": 40842,
+        "winPct": 0.39160667939865823,
+        "pointMargin": -3.303976298907987
       },
       {
-        "label": "Warm (70-85\u00b0F)",
-        "avgPoints": 221.4,
-        "games": 176
+        "label": "-1 day",
+        "games": 10899,
+        "winPct": 0.3615928066795119,
+        "pointMargin": -4.2808514542618585
       },
       {
-        "label": "Hot (>85\u00b0F)",
-        "avgPoints": 215.7,
-        "games": 78
+        "label": "-2 days",
+        "games": 6541,
+        "winPct": 0.35499159149977066,
+        "pointMargin": -4.610151353004127
+      },
+      {
+        "label": "Back-to-back",
+        "games": 3427,
+        "winPct": 0.37817332944266124,
+        "pointMargin": -4.209804493726291
       }
-    ]
+    ],
+    "swing": 0.03790629783280208
   },
-  "sampleSize": 71879,
-  "nightlifeEffect": {
-    "tiers": [
+  "closeMargins": {
+    "distribution": [
       {
-        "label": "Sparse (0-5 venues)",
-        "winPct": 0.524,
-        "pointDiff": 2.1
+        "label": "0-2 pts",
+        "games": 7852,
+        "share": 0.1092391379957985,
+        "averageMargin": 1.5680081507896078
       },
       {
-        "label": "Moderate (6-15)",
-        "winPct": 0.508,
-        "pointDiff": 0.4
+        "label": "3-5 pts",
+        "games": 13049,
+        "share": 0.18154120118532535,
+        "averageMargin": 4.019311824660893
       },
       {
-        "label": "Heavy (16-30)",
-        "winPct": 0.493,
-        "pointDiff": -1.2
+        "label": "6-10 pts",
+        "games": 20329,
+        "share": 0.2828225211814299,
+        "averageMargin": 7.88568055487235
       },
       {
-        "label": "Very heavy (31+)",
-        "winPct": 0.471,
-        "pointDiff": -3.6
+        "label": "11-15 pts",
+        "games": 13392,
+        "share": 0.18631310953129565,
+        "averageMargin": 12.801224611708482
+      },
+      {
+        "label": "16+ pts",
+        "games": 17257,
+        "share": 0.24008403010615062,
+        "averageMargin": 22.744683316914877
       }
-    ]
+    ],
+    "closeShare": 0.29078033918112384
   },
-  "mascotStrength": {
+  "overtime": {
     "categories": [
       {
-        "label": "Dog mascots",
-        "winPct": 0.547,
-        "teams": 7,
-        "titles": 9
+        "label": "Regulation",
+        "games": 68110,
+        "share": 0.9475646572712475,
+        "roadWinPct": 0.3784025840552048
       },
       {
-        "label": "Cat mascots",
-        "winPct": 0.512,
-        "teams": 6,
-        "titles": 7
+        "label": "1 OT",
+        "games": 3251,
+        "share": 0.0452287872674912,
+        "roadWinPct": 0.4675484466318056
+      },
+      {
+        "label": "2 OT",
+        "games": 446,
+        "share": 0.006204872076684428,
+        "roadWinPct": 0.47085201793721976
+      },
+      {
+        "label": "3 OT",
+        "games": 60,
+        "share": 0.0008347361538140486,
+        "roadWinPct": 0.45
+      },
+      {
+        "label": "4+ OT",
+        "games": 12,
+        "share": 0.0001669472307628097,
+        "roadWinPct": 0.4166666666666667
       }
     ]
   },
-  "astrologyAlignment": {
-    "clusters": [
+  "threePointTrend": {
+    "seasons": [
       {
-        "label": "Fire signs (Aries/Leo/Sagittarius)",
-        "paceBoost": 2.7,
-        "vibeScore": 74,
-        "teams": 9
+        "season": 1947,
+        "threePointRate": null,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Earth signs (Taurus/Virgo/Capricorn)",
-        "paceBoost": -1.9,
-        "vibeScore": 61,
-        "teams": 7
+        "season": 1948,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Air signs (Gemini/Libra/Aquarius)",
-        "paceBoost": 1.1,
-        "vibeScore": 69,
-        "teams": 8
+        "season": 1949,
+        "threePointRate": null,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Water signs (Cancer/Scorpio/Pisces)",
-        "paceBoost": -0.6,
-        "vibeScore": 66,
-        "teams": 6
-      }
-    ]
-  },
-  "coffeeConsumption": {
-    "levels": [
-      {
-        "label": "Decaf devotees",
-        "avgSleepHours": 7.8,
-        "winPct": 0.521
+        "season": 1950,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "One-cup traditionalists",
-        "avgSleepHours": 7.1,
-        "winPct": 0.509
+        "season": 1951,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Espresso loyalists",
-        "avgSleepHours": 6.5,
-        "winPct": 0.486
+        "season": 1952,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Cold brew experimenters",
-        "avgSleepHours": 6.2,
-        "winPct": 0.478
-      }
-    ],
-    "sampleSize": 420
-  },
-  "playlistMood": {
-    "moods": [
-      {
-        "label": "Lo-fi focus",
-        "games": 138,
-        "pointDiff": 3.2
+        "season": 1953,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Synthwave nostalgia",
-        "games": 112,
-        "pointDiff": 1.4
+        "season": 1954,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "90s R&B",
-        "games": 124,
-        "pointDiff": -0.8
+        "season": 1955,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Podcasts only",
-        "games": 86,
-        "pointDiff": -2.5
-      }
-    ]
-  },
-  "airportDelayIndex": {
-    "ranking": [
-      {
-        "label": "Express hubs (<10 min avg delay)",
-        "delayMinutes": 7.2,
-        "winPct": 0.534
+        "season": 1956,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Patience required (10-20 min)",
-        "delayMinutes": 14.6,
-        "winPct": 0.506
+        "season": 1957,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Chronic delays (>20 min)",
-        "delayMinutes": 23.1,
-        "winPct": 0.471
-      }
-    ],
-    "note": "Based on DOT punctuality reports for charter departures."
-  },
-  "cityTransitEffect": {
-    "tiers": [
-      {
-        "label": "Subway saturation",
-        "avgTurnovers": 12.4,
-        "sampleSize": 410
+        "season": 1958,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Light-rail reliance",
-        "avgTurnovers": 13.1,
-        "sampleSize": 268
+        "season": 1959,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Carpool corridors",
-        "avgTurnovers": 14.8,
-        "sampleSize": 301
-      }
-    ]
-  },
-  "lunarPhaseEnergy": {
-    "phases": [
-      {
-        "label": "New moon",
-        "fgPct": 0.482,
-        "games": 96
+        "season": 1960,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Waxing half",
-        "fgPct": 0.488,
-        "games": 118
+        "season": 1961,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Full moon",
-        "fgPct": 0.475,
-        "games": 104
+        "season": 1962,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
       },
       {
-        "label": "Waning crescent",
-        "fgPct": 0.469,
-        "games": 89
+        "season": 1963,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1964,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1965,
+        "threePointRate": null,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1966,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1967,
+        "threePointRate": null,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1968,
+        "threePointRate": null,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1969,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1970,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1971,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1972,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1973,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1974,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1975,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1976,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1977,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1978,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1979,
+        "threePointRate": 0.0,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1980,
+        "threePointRate": 0.018484288354898338,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1981,
+        "threePointRate": 0.026717557251908396,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1982,
+        "threePointRate": 0.015570014430745082,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1983,
+        "threePointRate": 0.0026988751784740037,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1984,
+        "threePointRate": 0.0022247866756915703,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1985,
+        "threePointRate": 0.005860663691053755,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1986,
+        "threePointRate": 0.038366025837774494,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1987,
+        "threePointRate": 0.053803700777764175,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1988,
+        "threePointRate": 0.057795811606109894,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1989,
+        "threePointRate": 0.07588542504032321,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1990,
+        "threePointRate": 0.07694896242288278,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1991,
+        "threePointRate": 0.08313745078450961,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1992,
+        "threePointRate": 0.08817942723553478,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1993,
+        "threePointRate": 0.10500939168503098,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1994,
+        "threePointRate": 0.11963978986067722,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1995,
+        "threePointRate": 0.19029334891461425,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1996,
+        "threePointRate": 0.20174875462195746,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1997,
+        "threePointRate": 0.214053040933328,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1998,
+        "threePointRate": 0.16099996501521838,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 1999,
+        "threePointRate": 0.16952838456295238,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2000,
+        "threePointRate": 0.1683688766381353,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2001,
+        "threePointRate": 0.1708969850978538,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2002,
+        "threePointRate": 0.18295961057241164,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2003,
+        "threePointRate": 0.1839661546522798,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2004,
+        "threePointRate": 0.18755679763917255,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2005,
+        "threePointRate": 0.19669469996423233,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2006,
+        "threePointRate": 0.2023284106954151,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2007,
+        "threePointRate": 0.21323705736591084,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2008,
+        "threePointRate": 0.2211424974427571,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2009,
+        "threePointRate": 0.22467819984424084,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2010,
+        "threePointRate": 0.22297922376600582,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2011,
+        "threePointRate": 0.22280938493013538,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2012,
+        "threePointRate": 0.2258918104170156,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2013,
+        "threePointRate": 0.24447870727673648,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2014,
+        "threePointRate": 0.2608300990434985,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2015,
+        "threePointRate": 0.27066683026100347,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2016,
+        "threePointRate": 0.2874101110897173,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2017,
+        "threePointRate": 0.31700035491346373,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2018,
+        "threePointRate": 0.3387295220117306,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2019,
+        "threePointRate": 0.3596249220625211,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2020,
+        "threePointRate": 0.38321679842541945,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2021,
+        "threePointRate": 0.39666395606420524,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2022,
+        "threePointRate": 0.4005838191707651,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2023,
+        "threePointRate": 0.3887606795639792,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2024,
+        "threePointRate": 0.3962754138995226,
+        "teamWinPct": 0.5
+      },
+      {
+        "season": 2025,
+        "threePointRate": 0.4213877597430285,
+        "teamWinPct": 0.5
       }
     ]
   }

--- a/public/insights.html
+++ b/public/insights.html
@@ -38,16 +38,16 @@
           </div>
           <dl class="hero-metrics hero-metrics--lab">
             <div class="hero-metrics__item">
-              <dt>Temperature swing effect</dt>
-              <dd data-metric="temp-impact-hero">--</dd>
+              <dt>Seasonal scoring swing</dt>
+              <dd data-metric="seasonal-swing">--</dd>
             </div>
             <div class="hero-metrics__item">
-              <dt>Nightlife penalty</dt>
-              <dd data-metric="nightlife-gap-hero">--</dd>
+              <dt>Road rest advantage</dt>
+              <dd data-metric="rest-gap">--</dd>
             </div>
             <div class="hero-metrics__item">
-              <dt>Mascot edge</dt>
-              <dd data-metric="mascot-edge-hero">--</dd>
+              <dt>Close game share</dt>
+              <dd data-metric="close-share">--</dd>
             </div>
             <div class="hero-metrics__item">
               <dt>Games studied</dt>
@@ -61,119 +61,66 @@
         <section class="lab-grid">
           <article class="lab-module lab-module--wide" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Does weather affect scoring?</h2>
+              <h2>How does scoring change through the calendar?</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Average points by outdoor temperature</span>
-                <span class="lab-chip lab-chip--accent" data-metric="temp-impact-detail">--</span>
+                <span class="lab-chip">Average points by month</span>
+                <span class="lab-chip lab-chip--accent" data-metric="seasonal-swing-detail">--</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="weather-scoring" data-chart-ratio="0.55"></canvas>
+              <canvas id="seasonal-scoring" data-chart-ratio="0.55"></canvas>
             </div>
           </article>
 
           <article class="lab-module lab-module--tall" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Do road teams slump near nightlife?</h2>
+              <h2>How much does rest matter on the road?</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Road win rate vs. strip club density</span>
-                <span class="lab-chip lab-chip--accent" data-metric="nightlife-gap-detail">--</span>
+                <span class="lab-chip">Road win rate by rest edge</span>
+                <span class="lab-chip lab-chip--accent" data-metric="rest-gap-detail">--</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="nightlife-road" data-chart-ratio="0.8"></canvas>
-            </div>
-          </article>
-
-          <article class="lab-module lab-module--tall" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Mascot strength: dogs vs. cats</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Win share battle</span>
-                <span class="lab-chip lab-chip--accent" data-metric="mascot-edge-detail">--</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="mascot-strength" data-chart-ratio="0.8"></canvas>
+              <canvas id="rest-impact" data-chart-ratio="0.78"></canvas>
             </div>
           </article>
 
           <article class="lab-module" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Astrology alignment index</h2>
+              <h2>How often do games stay within reach?</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Vibe score vs. pace boost</span>
-                <span class="lab-chip lab-chip--accent" data-metric="astrology-highlight">Charting stars</span>
+                <span class="lab-chip">Share of games by final margin</span>
+                <span class="lab-chip lab-chip--accent" data-metric="close-share-detail">--</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="astrology-alignment" data-chart-ratio="0.7"></canvas>
+              <canvas id="close-margins" data-chart-ratio="0.7"></canvas>
             </div>
           </article>
 
           <article class="lab-module" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Caffeine economy of sleep</h2>
+              <h2>Overtime heartbeat</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Win% and rest by coffee tier</span>
-                <span class="lab-chip lab-chip--accent" data-metric="coffee-highlight">Brewing data</span>
+                <span class="lab-chip">Road win% by overtime length</span>
+                <span class="lab-chip lab-chip--accent" data-metric="overtime-road-boost">--</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="coffee-consumption" data-chart-ratio="0.72"></canvas>
+              <canvas id="overtime-breakdown" data-chart-ratio="0.68"></canvas>
             </div>
           </article>
 
-          <article class="lab-module" data-chart-wrapper>
+          <article class="lab-module lab-module--wide" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Playlist mood board</h2>
+              <h2>The rise of the three-point era</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Point differential by soundtrack</span>
-                <span class="lab-chip lab-chip--accent" data-metric="playlist-highlight">Queuing tracks</span>
+                <span class="lab-chip">League-wide three-point attempt rate</span>
+                <span class="lab-chip lab-chip--accent" data-metric="three-rate-current">--</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="playlist-mood" data-chart-ratio="0.6"></canvas>
-            </div>
-          </article>
-
-          <article class="lab-module lab-module--tall" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Airport delay index</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Charter wait time vs. wins</span>
-                <span class="lab-chip lab-chip--accent" data-metric="airport-highlight">Tracking departures</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="airport-delay" data-chart-ratio="0.78"></canvas>
-            </div>
-            <p class="lab-module__note" data-note="airport-delay-note" hidden></p>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>City transit effect</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Turnovers by commute style</span>
-                <span class="lab-chip lab-chip--accent" data-metric="transit-highlight">Mapping commutes</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="transit-effect" data-chart-ratio="0.68"></canvas>
-            </div>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Lunar phase energy</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Shooting rhythm by moon cycle</span>
-                <span class="lab-chip lab-chip--accent" data-metric="lunar-highlight">Lunar syncing</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="lunar-phase" data-chart-ratio="0.62"></canvas>
+              <canvas id="three-point-trend" data-chart-ratio="0.6"></canvas>
             </div>
           </article>
         </section>

--- a/public/scripts/insights.js
+++ b/public/scripts/insights.js
@@ -7,37 +7,17 @@ function setMetric(key, value, fallback = '--') {
   if (!target) {
     return;
   }
-  const output = value === null || value === undefined || value === '' ? fallback : value;
-  target.textContent = output;
-}
-
-function setNote(key, value) {
-  const target = document.querySelector(`[data-note="${key}"]`);
-  if (!target) {
-    return;
-  }
-  if (!value) {
-    target.hidden = true;
-    return;
-  }
-  target.hidden = false;
-  target.textContent = value;
-}
-
-function formatPercent(value, digits = 1) {
-  if (typeof value !== 'number' || Number.isNaN(value)) {
-    return null;
-  }
-  return `${helpers.formatNumber(value * 100, digits)}%`;
+  target.textContent = value ?? fallback;
 }
 
 function fallbackConfig(message) {
   return {
-    type: 'doughnut',
+    type: 'bar',
     data: {
       labels: [''],
       datasets: [
         {
+          label: 'Pending data',
           data: [1],
           backgroundColor: ['rgba(17, 86, 214, 0.12)'],
           borderWidth: 0,
@@ -45,245 +25,139 @@ function fallbackConfig(message) {
       ],
     },
     options: {
-      maintainAspectRatio: false,
       plugins: {
         legend: { display: false },
         tooltip: { enabled: false },
         title: { display: true, text: message },
       },
+      scales: {
+        x: { display: false },
+        y: { display: false },
+      },
     },
   };
 }
 
-function createGradient(context, stops) {
-  const { chart } = context;
-  const { ctx, chartArea } = chart || {};
-  if (!ctx || !chartArea) {
-    return stops[0];
-  }
-  const gradient = ctx.createLinearGradient(chartArea.left, chartArea.bottom, chartArea.left, chartArea.top);
-  gradient.addColorStop(0, stops[0]);
-  gradient.addColorStop(1, stops[1] ?? stops[0]);
-  return gradient;
-}
-
 function updateHero(data) {
-  const weather = data?.weatherImpact ?? {};
-  const nightlife = data?.nightlifeEffect ?? {};
-  const mascot = data?.mascotStrength ?? {};
+  const seasonalSwing = data?.seasonalScoring?.swing;
+  const seasonalText = Number.isFinite(seasonalSwing)
+    ? `${helpers.formatNumber(seasonalSwing, 1)} pts`
+    : null;
+  setMetric('seasonal-swing', seasonalText);
+  setMetric('seasonal-swing-detail', seasonalText);
 
-  const correlation = typeof weather.correlation === 'number' ? formatPercent(weather.correlation, 1) : null;
-  const weatherText = correlation ? `${correlation} corr` : 'Calibrating';
-  setMetric('temp-impact-hero', weatherText);
-  setMetric('temp-impact-detail', weatherText);
+  const restSwing = data?.restImpact?.swing;
+  const restText = Number.isFinite(restSwing)
+    ? `${helpers.formatNumber(restSwing * 100, 1)} win% gap`
+    : null;
+  setMetric('rest-gap', restText);
+  setMetric('rest-gap-detail', restText);
 
-  const tiers = Array.isArray(nightlife.tiers) ? nightlife.tiers.filter(Boolean) : [];
-  if (tiers.length >= 2) {
-    const first = tiers[0];
-    const last = tiers[tiers.length - 1];
-    const swing = (first.winPct ?? 0) - (last.winPct ?? 0);
-    const formattedSwing = formatPercent(Math.abs(swing), 1);
-    const nightlifeText = formattedSwing ? `${swing >= 0 ? '-' : '+'}${formattedSwing} swing` : 'Scouting';
-    setMetric('nightlife-gap-hero', nightlifeText);
-    setMetric('nightlife-gap-detail', nightlifeText);
-  } else {
-    setMetric('nightlife-gap-hero', 'Scouting');
-    setMetric('nightlife-gap-detail', 'Scouting');
-  }
+  const closeShare = data?.closeMargins?.closeShare;
+  const closeText = Number.isFinite(closeShare)
+    ? `${helpers.formatNumber(closeShare * 100, 1)}% of games ≤5 pts`
+    : null;
+  setMetric('close-share', closeText);
+  setMetric('close-share-detail', closeText);
 
-  const categories = Array.isArray(mascot.categories) ? mascot.categories.filter(Boolean) : [];
-  const dog = categories.find((entry) => (entry.kind || entry.label || '').toLowerCase().includes('dog'));
-  const cat = categories.find((entry) => (entry.kind || entry.label || '').toLowerCase().includes('cat'));
-  if (dog && cat) {
-    const edge = (dog.winPct ?? 0) - (cat.winPct ?? 0);
-    const formattedEdge = formatPercent(Math.abs(edge), 1);
-    const mascotText = formattedEdge ? `${edge >= 0 ? '+' : '-'}${formattedEdge}` : 'Neck and neck';
-    setMetric('mascot-edge-hero', mascotText);
-    setMetric('mascot-edge-detail', mascotText);
-  } else {
-    setMetric('mascot-edge-hero', 'Neck and neck');
-    setMetric('mascot-edge-detail', 'Neck and neck');
-  }
+  const sampleSize = data?.sampleSize;
+  setMetric('sample-size', Number.isFinite(sampleSize) ? `${helpers.formatNumber(sampleSize, 0)} games` : null);
 
-  const sampleSize = data?.sampleSize ?? weather.sampleSize;
-  setMetric('sample-size', Number.isFinite(sampleSize) ? `${helpers.formatNumber(sampleSize, 0)} games` : 'Collecting');
+  const overtimeCategories = Array.isArray(data?.overtime?.categories)
+    ? data.overtime.categories.filter((entry) => Number.isFinite(entry?.roadWinPct))
+    : [];
+  const regulation = overtimeCategories.find((entry) => entry.label === 'Regulation');
+  const bestOvertime = [...overtimeCategories]
+    .filter((entry) => entry.label !== 'Regulation')
+    .sort((a, b) => (b.roadWinPct ?? 0) - (a.roadWinPct ?? 0))[0];
+  const overtimeText = regulation && bestOvertime
+    ? `${helpers.formatNumber((bestOvertime.roadWinPct - regulation.roadWinPct) * 100, 1)} win% lift`
+    : null;
+  setMetric('overtime-road-boost', overtimeText);
+
+  const seasons = Array.isArray(data?.threePointTrend?.seasons) ? data.threePointTrend.seasons : [];
+  const recent = [...seasons]
+    .filter((entry) => Number.isFinite(entry?.threePointRate))
+    .sort((a, b) => (b.season ?? 0) - (a.season ?? 0))[0];
+  const threeText = recent
+    ? `${recent.season}: ${helpers.formatNumber((recent.threePointRate ?? 0) * 100, 1)}% 3PA share`
+    : null;
+  setMetric('three-rate-current', threeText);
 }
 
-function updateModuleMetrics(data) {
-  const astrology = data?.astrologyAlignment ?? {};
-  const clusters = Array.isArray(astrology.clusters) ? astrology.clusters.filter(Boolean) : [];
-  if (clusters.length) {
-    const topCluster = [...clusters].sort((a, b) => (b.vibeScore ?? 0) - (a.vibeScore ?? 0))[0];
-    const label = (topCluster.label || '').split(' (')[0] || topCluster.label || 'Star cluster';
-    const vibeScore = Number.isFinite(topCluster.vibeScore) ? helpers.formatNumber(topCluster.vibeScore, 0) : null;
-    const paceBoost = Number.isFinite(topCluster.paceBoost)
-      ? `${topCluster.paceBoost >= 0 ? '+' : ''}${helpers.formatNumber(topCluster.paceBoost, 1)} pace`
-      : null;
-    const text = [label, vibeScore ? `${vibeScore} vibe` : null, paceBoost].filter(Boolean).join(' · ');
-    setMetric('astrology-highlight', text || 'Charting stars');
-  } else {
-    setMetric('astrology-highlight', 'Charting stars');
+function buildSeasonalChart(dataRef) {
+  const months = Array.isArray(dataRef?.seasonalScoring?.months) ? dataRef.seasonalScoring.months : [];
+  if (!months.length) {
+    return fallbackConfig('Monthly scoring data unavailable');
   }
 
-  const coffee = data?.coffeeConsumption ?? {};
-  const levels = Array.isArray(coffee.levels) ? coffee.levels.filter(Boolean) : [];
-  if (levels.length) {
-    const topLevel = [...levels].sort((a, b) => (b.winPct ?? 0) - (a.winPct ?? 0))[0];
-    const label = (topLevel.label || '').split(' (')[0] || topLevel.label || 'Brew crew';
-    const winPct = Number.isFinite(topLevel.winPct) ? helpers.formatNumber(topLevel.winPct * 100, 1) : null;
-    const sleep = Number.isFinite(topLevel.avgSleepHours)
-      ? `${helpers.formatNumber(topLevel.avgSleepHours, 1)} hrs sleep`
-      : null;
-    const text = [label, winPct ? `${winPct}% win` : null, sleep].filter(Boolean).join(' · ');
-    setMetric('coffee-highlight', text || 'Brewing data');
-  } else {
-    setMetric('coffee-highlight', 'Brewing data');
-  }
-
-  const playlist = data?.playlistMood ?? {};
-  const moods = Array.isArray(playlist.moods) ? playlist.moods.filter(Boolean) : [];
-  if (moods.length) {
-    const topMood = [...moods].sort((a, b) => (b.pointDiff ?? 0) - (a.pointDiff ?? 0))[0];
-    const label = topMood.label || 'Hot track';
-    const diff = Number.isFinite(topMood.pointDiff)
-      ? `${topMood.pointDiff >= 0 ? '+' : ''}${helpers.formatNumber(topMood.pointDiff, 1)} diff`
-      : null;
-    setMetric('playlist-highlight', diff ? `${label} · ${diff}` : `${label} playlist`);
-  } else {
-    setMetric('playlist-highlight', 'Queuing tracks');
-  }
-
-  const airport = data?.airportDelayIndex ?? {};
-  const rankings = Array.isArray(airport.ranking) ? airport.ranking.filter(Boolean) : [];
-  if (rankings.length >= 2) {
-    const sorted = [...rankings].sort((a, b) => (b.winPct ?? 0) - (a.winPct ?? 0));
-    const leader = sorted[0];
-    const trailer = sorted[sorted.length - 1];
-    const leaderLabel = (leader.label || '').split(' (')[0] || leader.label || 'Leader';
-    const swing = Number.isFinite(leader.winPct) && Number.isFinite(trailer.winPct)
-      ? helpers.formatNumber((leader.winPct - trailer.winPct) * 100, 1)
-      : null;
-    const text = swing ? `${leaderLabel} lead by ${swing} pts` : `${leaderLabel} leading`;
-    setMetric('airport-highlight', text);
-  } else {
-    setMetric('airport-highlight', 'Tracking departures');
-  }
-  setNote('airport-delay-note', airport.note);
-
-  const transit = data?.cityTransitEffect ?? {};
-  const transitTiers = Array.isArray(transit.tiers) ? transit.tiers.filter(Boolean) : [];
-  if (transitTiers.length >= 2) {
-    const turnovers = transitTiers.map((tier) => tier.avgTurnovers ?? 0);
-    const swing = Math.max(...turnovers) - Math.min(...turnovers);
-    const text = `Turnover swing ${swing >= 0 ? '+' : ''}${helpers.formatNumber(swing, 1)}`;
-    setMetric('transit-highlight', text);
-  } else {
-    setMetric('transit-highlight', 'Mapping commutes');
-  }
-
-  const lunar = data?.lunarPhaseEnergy ?? {};
-  const phases = Array.isArray(lunar.phases) ? lunar.phases.filter(Boolean) : [];
-  if (phases.length) {
-    const bestPhase = [...phases].sort((a, b) => (b.fgPct ?? 0) - (a.fgPct ?? 0))[0];
-    const label = bestPhase.label || 'Top phase';
-    const fgPct = Number.isFinite(bestPhase.fgPct) ? helpers.formatNumber(bestPhase.fgPct * 100, 1) : null;
-    setMetric('lunar-highlight', fgPct ? `${label} · ${fgPct}% FG` : label);
-  } else {
-    setMetric('lunar-highlight', 'Lunar syncing');
-  }
-}
-
-function buildWeatherChart(dataRef) {
-  const weather = dataRef?.weatherImpact ?? {};
-  const buckets = Array.isArray(weather.buckets) ? weather.buckets.filter(Boolean) : [];
-  if (!buckets.length) {
-    return fallbackConfig('Weather samples loading');
-  }
-
-  const labels = buckets.map((bucket) => bucket.label || 'Bucket');
-  const points = buckets.map((bucket) => bucket.avgPoints ?? 0);
-  const baseline = typeof weather.baseline === 'number' ? weather.baseline : null;
-
-  const datasets = [
-    {
-      type: 'line',
-      label: 'Avg team points',
-      data: points,
-      tension: 0.42,
-      fill: 'start',
-      borderWidth: 2,
-      borderColor: '#1156d6',
-      backgroundColor: (context) => createGradient(context, ['rgba(17, 86, 214, 0.38)', 'rgba(17, 86, 214, 0.05)']),
-      pointBackgroundColor: '#ffffff',
-      pointBorderColor: '#1156d6',
-      pointBorderWidth: 2,
-      pointRadius: 4,
-      pointHoverRadius: 6,
-    },
-  ];
-
-  if (baseline !== null) {
-    datasets.push({
-      type: 'line',
-      label: 'League baseline',
-      data: buckets.map(() => baseline),
-      borderColor: 'rgba(11, 37, 69, 0.6)',
-      borderWidth: 1.5,
-      borderDash: [6, 6],
-      pointRadius: 0,
-      fill: false,
-    });
-  }
+  const labels = months.map((entry) => entry.month ?? 'Month');
+  const overall = months.map((entry) => entry.averagePoints ?? null);
+  const regular = months.map((entry) => entry.regularSeasonAverage ?? null);
+  const playoff = months.map((entry) => entry.playoffAverage ?? null);
 
   return {
     type: 'line',
     data: {
       labels,
-      datasets,
+      datasets: [
+        {
+          label: 'All games',
+          data: overall,
+          borderColor: '#1156d6',
+          backgroundColor: 'rgba(17, 86, 214, 0.16)',
+          borderWidth: 2,
+          tension: 0.3,
+          spanGaps: true,
+          fill: 'origin',
+        },
+        {
+          label: 'Regular season',
+          data: regular,
+          borderColor: '#0b2545',
+          backgroundColor: 'rgba(11, 37, 69, 0.12)',
+          borderWidth: 1.5,
+          tension: 0.3,
+          spanGaps: true,
+          fill: false,
+        },
+        {
+          label: 'Playoffs',
+          data: playoff,
+          borderColor: '#ef3d5b',
+          backgroundColor: 'rgba(239, 61, 91, 0.12)',
+          borderWidth: 1.5,
+          tension: 0.3,
+          spanGaps: true,
+          fill: false,
+        },
+      ],
     },
     options: {
       maintainAspectRatio: false,
       interaction: { mode: 'index', intersect: false },
       scales: {
         y: {
-          beginAtZero: false,
-          title: { display: true, text: 'Average points per game' },
-          grid: { color: 'rgba(17, 86, 214, 0.1)' },
+          title: { display: true, text: 'Average combined points' },
+          grid: { color: 'rgba(17, 86, 214, 0.12)' },
         },
         x: {
           grid: { color: 'rgba(17, 86, 214, 0.05)' },
-        },
-      },
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              if (context.dataset.label === 'Avg team points') {
-                const bucket = buckets[context.dataIndex];
-                const games = bucket?.games;
-                const suffix = Number.isFinite(games) ? ` (${helpers.formatNumber(games, 0)} games)` : '';
-                return `Avg points: ${helpers.formatNumber(context.parsed.y, 1)}${suffix}`;
-              }
-              return `${context.dataset.label}: ${helpers.formatNumber(context.parsed.y, 1)}`;
-            },
-          },
         },
       },
     },
   };
 }
 
-function buildNightlifeChart(dataRef) {
-  const nightlife = dataRef?.nightlifeEffect ?? {};
-  const tiers = Array.isArray(nightlife.tiers) ? nightlife.tiers.filter(Boolean) : [];
-  if (!tiers.length) {
-    return fallbackConfig('Nightlife scouting pending');
+function buildRestImpactChart(dataRef) {
+  const buckets = Array.isArray(dataRef?.restImpact?.buckets) ? dataRef.restImpact.buckets : [];
+  if (!buckets.length) {
+    return fallbackConfig('Rest advantage data unavailable');
   }
 
-  const labels = tiers.map((tier) => tier.label || 'Tier');
-  const winRates = tiers.map((tier) => (tier.winPct ?? 0) * 100);
-  const pointDiffs = tiers.map((tier) => tier.pointDiff ?? 0);
+  const labels = buckets.map((entry) => entry.label ?? 'Bucket');
+  const winPct = buckets.map((entry) => (Number.isFinite(entry.winPct) ? entry.winPct * 100 : null));
+  const margin = buckets.map((entry) => Number.isFinite(entry.pointMargin) ? entry.pointMargin : null);
 
   return {
     type: 'bar',
@@ -293,241 +167,80 @@ function buildNightlifeChart(dataRef) {
         {
           type: 'bar',
           label: 'Road win %',
-          data: winRates,
+          data: winPct,
           backgroundColor: '#ef3d5b',
+          borderRadius: 18,
+          maxBarThickness: 52,
+        },
+        {
+          type: 'line',
+          label: 'Avg point margin',
+          data: margin,
+          yAxisID: 'margin',
+          borderColor: '#0b2545',
+          borderWidth: 2,
+          tension: 0.32,
+          pointRadius: 4,
+          fill: false,
+        },
+      ],
+    },
+    options: {
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'Road win percentage' },
+          ticks: { callback: (value) => `${helpers.formatNumber(value, 0)}%` },
+          grid: { color: 'rgba(239, 61, 91, 0.12)' },
+        },
+        margin: {
+          position: 'right',
+          title: { display: true, text: 'Average point margin' },
+          grid: { drawOnChartArea: false },
+        },
+        x: {
+          grid: { color: 'rgba(239, 61, 91, 0.05)' },
+        },
+      },
+    },
+  };
+}
+
+function buildCloseMarginsChart(dataRef) {
+  const distribution = Array.isArray(dataRef?.closeMargins?.distribution)
+    ? dataRef.closeMargins.distribution
+    : [];
+  if (!distribution.length) {
+    return fallbackConfig('Close game distribution unavailable');
+  }
+
+  const labels = distribution.map((entry) => entry.label ?? 'Bucket');
+  const shares = distribution.map((entry) => (Number.isFinite(entry.share) ? entry.share * 100 : null));
+  const margins = distribution.map((entry) => Number.isFinite(entry.averageMargin) ? entry.averageMargin : null);
+
+  return {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          type: 'bar',
+          label: 'Share of games',
+          data: shares,
+          backgroundColor: '#1156d6',
           borderRadius: 18,
           maxBarThickness: 48,
         },
         {
           type: 'line',
-          label: 'Avg point differential',
-          data: pointDiffs,
-          yAxisID: 'diff',
-          borderColor: '#0b2545',
-          borderWidth: 2,
-          tension: 0.35,
-          pointBackgroundColor: '#ffffff',
-          pointBorderColor: '#0b2545',
-          pointBorderWidth: 2,
-          pointRadius: 4,
-          fill: false,
-        },
-      ],
-    },
-    options: {
-      maintainAspectRatio: false,
-      interaction: { mode: 'index', intersect: false },
-      scales: {
-        y: {
-          beginAtZero: true,
-          suggestedMax: 60,
-          ticks: {
-            callback: (value) => `${helpers.formatNumber(value, 0)}%`,
-          },
-          title: { display: true, text: 'Road win percentage' },
-          grid: { color: 'rgba(239, 61, 91, 0.12)' },
-        },
-        diff: {
-          position: 'right',
-          beginAtZero: true,
-          suggestedMax: 4,
-          suggestedMin: -5,
-          grid: { drawOnChartArea: false },
-          title: { display: true, text: 'Point differential' },
-        },
-        x: {
-          grid: { color: 'rgba(239, 61, 91, 0.05)' },
-        },
-      },
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              if (context.dataset.label === 'Road win %') {
-                return `Road win %: ${helpers.formatNumber(context.parsed.y, 1)}%`;
-              }
-              return `Point diff: ${context.parsed.y >= 0 ? '+' : ''}${helpers.formatNumber(context.parsed.y, 1)}`;
-            },
-          },
-        },
-      },
-    },
-  };
-}
-
-function buildMascotChart(dataRef) {
-  const mascot = dataRef?.mascotStrength ?? {};
-  const categories = Array.isArray(mascot.categories) ? mascot.categories.filter(Boolean) : [];
-  if (categories.length < 2) {
-    return fallbackConfig('Mascot rivalry forming');
-  }
-
-  const labels = categories.map((entry) => entry.label || entry.kind || 'Mascot');
-  const wins = categories.map((entry) => (entry.winPct ?? 0) * 100);
-  const teams = categories.map((entry) => entry.teams ?? null);
-  const titles = categories.map((entry) => entry.titles ?? null);
-
-  const centerLabel = {
-    id: 'mascotCenterLabel',
-    afterDraw(chart) {
-      const { ctx } = chart;
-      const meta = chart.getDatasetMeta(0);
-      const center = meta?.data?.[0];
-      if (!center) {
-        return;
-      }
-      ctx.save();
-      ctx.fillStyle = '#0b2545';
-      ctx.font = '600 1.4rem "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText('Dogs vs Cats', center.x, center.y - 6);
-      ctx.font = '500 0.75rem "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
-      ctx.fillStyle = 'rgba(11, 37, 69, 0.65)';
-      ctx.fillText('win share %', center.x, center.y + 12);
-      ctx.restore();
-    },
-  };
-
-  return {
-    type: 'doughnut',
-    data: {
-      labels,
-      datasets: [
-        {
-          data: wins,
-          backgroundColor: ['#1156d6', '#f4b53f'],
-          borderWidth: 0,
-          hoverBackgroundColor: ['#0b2545', '#d99216'],
-        },
-      ],
-    },
-    options: {
-      maintainAspectRatio: false,
-      cutout: '62%',
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              const index = context.dataIndex;
-              const winPct = helpers.formatNumber(context.parsed, 1);
-              const teamNote = teams[index] ? `${teams[index]} teams` : null;
-              const titleNote = titles[index] ? `${titles[index]} titles` : null;
-              const extras = [teamNote, titleNote].filter(Boolean).join(' · ');
-              return extras ? `${context.label}: ${winPct}% (${extras})` : `${context.label}: ${winPct}%`;
-            },
-          },
-        },
-      },
-    },
-    plugins: [centerLabel],
-  };
-}
-
-function buildAstrologyChart(dataRef) {
-  const astrology = dataRef?.astrologyAlignment ?? {};
-  const clusters = Array.isArray(astrology.clusters) ? astrology.clusters.filter(Boolean) : [];
-  if (!clusters.length) {
-    return fallbackConfig('Star charts syncing');
-  }
-
-  const points = clusters.map((cluster) => ({
-    x: cluster.paceBoost ?? 0,
-    y: cluster.vibeScore ?? 0,
-    r: Math.max(8, Math.min(22, (cluster.teams ?? 0) * 1.6)),
-    label: cluster.label || 'Cluster',
-    teams: cluster.teams ?? null,
-  }));
-
-  return {
-    type: 'bubble',
-    data: {
-      datasets: [
-        {
-          label: 'Alignment clusters',
-          data: points,
-          backgroundColor: 'rgba(17, 86, 214, 0.55)',
-          borderColor: '#1156d6',
-          borderWidth: 1.5,
-        },
-      ],
-    },
-    options: {
-      maintainAspectRatio: false,
-      scales: {
-        x: {
-          title: { display: true, text: 'Pace boost (possessions per 48)' },
-          grid: { color: 'rgba(17, 86, 214, 0.08)' },
-          ticks: {
-            callback(value) {
-              return `${value >= 0 ? '+' : ''}${helpers.formatNumber(value, 1)}`;
-            },
-          },
-        },
-        y: {
-          title: { display: true, text: 'Vibe score' },
-          grid: { color: 'rgba(17, 86, 214, 0.12)' },
-          suggestedMin: 50,
-          suggestedMax: 80,
-        },
-      },
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            title(items) {
-              return items[0]?.raw?.label || '';
-            },
-            label(context) {
-              const { raw } = context;
-              const pace = `${raw.x >= 0 ? '+' : ''}${helpers.formatNumber(raw.x, 1)} pace`;
-              const vibe = `${helpers.formatNumber(raw.y, 0)} vibe`;
-              const teamCount = Number.isFinite(raw.teams) ? `${raw.teams} teams` : null;
-              return [pace, vibe, teamCount].filter(Boolean);
-            },
-          },
-        },
-      },
-    },
-  };
-}
-
-function buildCoffeeChart(dataRef) {
-  const coffee = dataRef?.coffeeConsumption ?? {};
-  const levels = Array.isArray(coffee.levels) ? coffee.levels.filter(Boolean) : [];
-  if (!levels.length) {
-    return fallbackConfig('Brewing samples');
-  }
-
-  const labels = levels.map((level) => level.label || 'Level');
-  const winRates = levels.map((level) => (level.winPct ?? 0) * 100);
-  const sleepHours = levels.map((level) => level.avgSleepHours ?? null);
-
-  return {
-    type: 'bar',
-    data: {
-      labels,
-      datasets: [
-        {
-          type: 'bar',
-          label: 'Win %',
-          data: winRates,
-          backgroundColor: '#1156d6',
-          maxBarThickness: 46,
-        },
-        {
-          type: 'line',
-          label: 'Avg sleep (hrs)',
-          data: sleepHours,
-          yAxisID: 'sleep',
+          label: 'Average margin',
+          data: margins,
+          yAxisID: 'margin',
           borderColor: '#f4b53f',
           borderWidth: 2,
-          tension: 0.35,
-          pointBackgroundColor: '#ffffff',
-          pointBorderColor: '#f4b53f',
-          pointBorderWidth: 2,
+          tension: 0.32,
           pointRadius: 4,
           fill: false,
         },
@@ -539,116 +252,32 @@ function buildCoffeeChart(dataRef) {
       scales: {
         y: {
           beginAtZero: true,
-          suggestedMax: 60,
-          title: { display: true, text: 'Win percentage' },
-          ticks: {
-            callback: (value) => `${helpers.formatNumber(value, 0)}%`,
-          },
+          ticks: { callback: (value) => `${helpers.formatNumber(value, 0)}%` },
+          title: { display: true, text: 'Share of total games' },
           grid: { color: 'rgba(17, 86, 214, 0.12)' },
         },
-        sleep: {
+        margin: {
           position: 'right',
-          beginAtZero: false,
-          suggestedMin: 5.5,
-          suggestedMax: 8.5,
-          title: { display: true, text: 'Avg sleep (hours)' },
+          title: { display: true, text: 'Average point margin' },
           grid: { drawOnChartArea: false },
         },
         x: {
           grid: { color: 'rgba(17, 86, 214, 0.05)' },
         },
       },
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              if (context.dataset.label === 'Win %') {
-                return `Win %: ${helpers.formatNumber(context.parsed.y, 1)}%`;
-              }
-              return `Avg sleep: ${helpers.formatNumber(context.parsed.y, 1)} hrs`;
-            },
-          },
-        },
-      },
     },
   };
 }
 
-function buildPlaylistChart(dataRef) {
-  const playlist = dataRef?.playlistMood ?? {};
-  const moods = Array.isArray(playlist.moods) ? playlist.moods.filter(Boolean) : [];
-  if (!moods.length) {
-    return fallbackConfig('Playlist cues buffering');
+function buildOvertimeChart(dataRef) {
+  const categories = Array.isArray(dataRef?.overtime?.categories) ? dataRef.overtime.categories : [];
+  if (!categories.length) {
+    return fallbackConfig('Overtime sample unavailable');
   }
 
-  const labels = moods.map((mood) => mood.label || 'Playlist');
-  const pointDiffs = moods.map((mood) => mood.pointDiff ?? 0);
-  const games = moods.map((mood) => mood.games ?? null);
-
-  return {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Point differential',
-          data: pointDiffs,
-          borderColor: '#ef3d5b',
-          borderWidth: 2,
-          backgroundColor: (context) => createGradient(context, ['rgba(239, 61, 91, 0.28)', 'rgba(239, 61, 91, 0.06)']),
-          fill: 'origin',
-          tension: 0.4,
-          pointBackgroundColor: '#ffffff',
-          pointBorderColor: '#ef3d5b',
-          pointBorderWidth: 2,
-          pointRadius: 4,
-          pointHoverRadius: 6,
-        },
-      ],
-    },
-    options: {
-      maintainAspectRatio: false,
-      scales: {
-        y: {
-          title: { display: true, text: 'Point differential' },
-          grid: { color: 'rgba(239, 61, 91, 0.12)' },
-          ticks: {
-            callback: (value) => `${value >= 0 ? '+' : ''}${helpers.formatNumber(value, 1)}`,
-          },
-        },
-        x: {
-          grid: { color: 'rgba(239, 61, 91, 0.05)' },
-        },
-      },
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              const value = context.parsed.y;
-              const prefix = value >= 0 ? '+' : '';
-              const gamesCount = games[context.dataIndex];
-              const gamesNote = Number.isFinite(gamesCount) ? ` · ${helpers.formatNumber(gamesCount, 0)} games` : '';
-              return `Point diff: ${prefix}${helpers.formatNumber(value, 1)}${gamesNote}`;
-            },
-          },
-        },
-      },
-    },
-  };
-}
-
-function buildAirportChart(dataRef) {
-  const airport = dataRef?.airportDelayIndex ?? {};
-  const rankings = Array.isArray(airport.ranking) ? airport.ranking.filter(Boolean) : [];
-  if (!rankings.length) {
-    return fallbackConfig('Delay index syncing');
-  }
-
-  const labels = rankings.map((entry) => entry.label || 'Tier');
-  const delays = rankings.map((entry) => entry.delayMinutes ?? 0);
-  const winRates = rankings.map((entry) => (entry.winPct ?? 0) * 100);
+  const labels = categories.map((entry) => entry.label ?? 'Bucket');
+  const shares = categories.map((entry) => (Number.isFinite(entry.share) ? entry.share * 100 : null));
+  const winPct = categories.map((entry) => (Number.isFinite(entry.roadWinPct) ? entry.roadWinPct * 100 : null));
 
   return {
     type: 'bar',
@@ -657,22 +286,21 @@ function buildAirportChart(dataRef) {
       datasets: [
         {
           type: 'bar',
-          label: 'Avg delay (minutes)',
-          data: delays,
+          label: 'Share of games',
+          data: shares,
           backgroundColor: '#0b2545',
+          borderRadius: 16,
           maxBarThickness: 48,
         },
         {
           type: 'line',
-          label: 'Win %',
-          data: winRates,
+          label: 'Road win %',
+          data: winPct,
           yAxisID: 'win',
           borderColor: '#ef3d5b',
           borderWidth: 2,
-          pointBackgroundColor: '#ffffff',
-          pointBorderColor: '#ef3d5b',
-          pointBorderWidth: 2,
-          tension: 0.35,
+          tension: 0.32,
+          pointRadius: 4,
           fill: false,
         },
       ],
@@ -683,75 +311,57 @@ function buildAirportChart(dataRef) {
       scales: {
         y: {
           beginAtZero: true,
-          title: { display: true, text: 'Avg delay (minutes)' },
+          ticks: { callback: (value) => `${helpers.formatNumber(value, 0)}%` },
+          title: { display: true, text: 'Share of total games' },
           grid: { color: 'rgba(11, 37, 69, 0.12)' },
         },
         win: {
           position: 'right',
-          beginAtZero: true,
-          suggestedMax: 60,
-          title: { display: true, text: 'Win percentage' },
-          ticks: {
-            callback: (value) => `${helpers.formatNumber(value, 0)}%`,
-          },
+          title: { display: true, text: 'Road win percentage' },
           grid: { drawOnChartArea: false },
         },
         x: {
-          grid: { color: 'rgba(11, 37, 69, 0.08)' },
-        },
-      },
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              if (context.dataset.label === 'Avg delay (minutes)') {
-                return `Delay: ${helpers.formatNumber(context.parsed.y, 1)} min`;
-              }
-              return `Win %: ${helpers.formatNumber(context.parsed.y, 1)}%`;
-            },
-          },
+          grid: { color: 'rgba(11, 37, 69, 0.05)' },
         },
       },
     },
   };
 }
 
-function buildTransitChart(dataRef) {
-  const transit = dataRef?.cityTransitEffect ?? {};
-  const tiers = Array.isArray(transit.tiers) ? transit.tiers.filter(Boolean) : [];
-  if (!tiers.length) {
-    return fallbackConfig('Transit metrics boarding');
+function buildThreePointTrendChart(dataRef) {
+  const seasons = Array.isArray(dataRef?.threePointTrend?.seasons) ? dataRef.threePointTrend.seasons : [];
+  if (!seasons.length) {
+    return fallbackConfig('Three-point trend unavailable');
   }
 
-  const labels = tiers.map((tier) => tier.label || 'Tier');
-  const turnovers = tiers.map((tier) => tier.avgTurnovers ?? 0);
-  const samples = tiers.map((tier) => tier.sampleSize ?? null);
+  const sampled = helpers.evenSample(seasons, 120);
+  const labels = sampled.map((entry) => entry.season ?? 'Season');
+  const rate = sampled.map((entry) => (Number.isFinite(entry.threePointRate) ? entry.threePointRate * 100 : null));
+  const winPct = sampled.map((entry) => (Number.isFinite(entry.teamWinPct) ? entry.teamWinPct * 100 : null));
 
   return {
-    type: 'bar',
+    type: 'line',
     data: {
       labels,
       datasets: [
         {
-          type: 'bar',
-          label: 'Avg turnovers',
-          data: turnovers,
-          backgroundColor: '#1f7bff',
-          maxBarThickness: 48,
+          label: '3PA rate',
+          data: rate,
+          borderColor: '#1156d6',
+          backgroundColor: 'rgba(17, 86, 214, 0.16)',
+          borderWidth: 2,
+          tension: 0.25,
+          spanGaps: true,
+          fill: 'origin',
         },
         {
-          type: 'line',
-          label: 'Games sampled',
-          data: samples,
-          yAxisID: 'sample',
-          borderColor: '#0b2545',
+          label: 'Team win %',
+          data: winPct,
+          borderColor: '#f4b53f',
+          backgroundColor: 'rgba(244, 181, 63, 0.16)',
           borderWidth: 2,
-          pointBackgroundColor: '#ffffff',
-          pointBorderColor: '#0b2545',
-          pointBorderWidth: 2,
-          pointRadius: 4,
-          tension: 0.3,
+          tension: 0.25,
+          spanGaps: true,
           fill: false,
         },
       ],
@@ -762,156 +372,45 @@ function buildTransitChart(dataRef) {
       scales: {
         y: {
           beginAtZero: true,
-          title: { display: true, text: 'Avg turnovers' },
+          title: { display: true, text: 'Percentage' },
+          ticks: { callback: (value) => `${helpers.formatNumber(value, 0)}%` },
           grid: { color: 'rgba(17, 86, 214, 0.12)' },
         },
-        sample: {
-          position: 'right',
-          beginAtZero: true,
-          title: { display: true, text: 'Games sampled' },
-          grid: { drawOnChartArea: false },
-        },
         x: {
+          ticks: { maxRotation: 0 },
           grid: { color: 'rgba(17, 86, 214, 0.05)' },
-        },
-      },
-      plugins: {
-        legend: { position: 'bottom' },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              if (context.dataset.label === 'Avg turnovers') {
-                return `Avg turnovers: ${helpers.formatNumber(context.parsed.y, 1)}`;
-              }
-              return `Games sampled: ${helpers.formatNumber(context.parsed.y, 0)}`;
-            },
-          },
         },
       },
     },
   };
 }
 
-function buildLunarChart(dataRef) {
-  const lunar = dataRef?.lunarPhaseEnergy ?? {};
-  const phases = Array.isArray(lunar.phases) ? lunar.phases.filter(Boolean) : [];
-  if (!phases.length) {
-    return fallbackConfig('Moon data recalibrating');
-  }
-
-  const labels = phases.map((phase) => phase.label || 'Phase');
-  const fgPct = phases.map((phase) => (phase.fgPct ?? 0) * 100);
-  const games = phases.map((phase) => phase.games ?? null);
-
-  return {
-    type: 'line',
-    data: {
-      labels,
-      datasets: [
-        {
-          label: 'Field goal %',
-          data: fgPct,
-          borderColor: '#1156d6',
-          borderWidth: 2,
-          backgroundColor: (context) => createGradient(context, ['rgba(17, 86, 214, 0.32)', 'rgba(17, 86, 214, 0.08)']),
-          fill: 'origin',
-          tension: 0.35,
-          pointBackgroundColor: '#ffffff',
-          pointBorderColor: '#1156d6',
-          pointBorderWidth: 2,
-          pointRadius: 4,
-          pointHoverRadius: 6,
-        },
-      ],
-    },
-    options: {
-      maintainAspectRatio: false,
-      scales: {
-        y: {
-          beginAtZero: false,
-          suggestedMin: 45,
-          suggestedMax: 50,
-          title: { display: true, text: 'Field goal percentage' },
-          ticks: {
-            callback: (value) => `${helpers.formatNumber(value, 1)}%`,
-          },
-          grid: { color: 'rgba(17, 86, 214, 0.12)' },
-        },
-        x: {
-          grid: { color: 'rgba(17, 86, 214, 0.05)' },
-        },
-      },
-      plugins: {
-        legend: { display: false },
-        tooltip: {
-          callbacks: {
-            label(context) {
-              const value = context.parsed.y;
-              const gamesCount = games[context.dataIndex];
-              const gamesNote = Number.isFinite(gamesCount) ? ` · ${helpers.formatNumber(gamesCount, 0)} games` : '';
-              return `FG%: ${helpers.formatNumber(value, 1)}%${gamesNote}`;
-            },
-          },
-        },
-      },
-    },
-  };
-}
-
-function registerLabCharts(dataRef) {
-  registerCharts([
-    {
-      element: '#weather-scoring',
-      createConfig: () => buildWeatherChart(dataRef),
-    },
-    {
-      element: '#nightlife-road',
-      createConfig: () => buildNightlifeChart(dataRef),
-    },
-    {
-      element: '#mascot-strength',
-      createConfig: () => buildMascotChart(dataRef),
-    },
-    {
-      element: '#astrology-alignment',
-      createConfig: () => buildAstrologyChart(dataRef),
-    },
-    {
-      element: '#coffee-consumption',
-      createConfig: () => buildCoffeeChart(dataRef),
-    },
-    {
-      element: '#playlist-mood',
-      createConfig: () => buildPlaylistChart(dataRef),
-    },
-    {
-      element: '#airport-delay',
-      createConfig: () => buildAirportChart(dataRef),
-    },
-    {
-      element: '#transit-effect',
-      createConfig: () => buildTransitChart(dataRef),
-    },
-    {
-      element: '#lunar-phase',
-      createConfig: () => buildLunarChart(dataRef),
-    },
-  ]);
-}
-
-async function hydrateLab() {
+async function bootstrap() {
+  let data;
   try {
     const response = await fetch(DATA_URL);
     if (!response.ok) {
-      throw new Error(`Failed to fetch lab data: ${response.status}`);
+      throw new Error(`Failed to load insights lab data: ${response.status}`);
     }
-    const data = await response.json();
-    updateHero(data);
-    updateModuleMetrics(data);
-    registerLabCharts(data);
+    data = await response.json();
   } catch (error) {
-    console.error('Failed to hydrate insights lab', error);
+    console.error('Unable to load insights lab data', error);
+    return;
   }
+
+  updateHero(data);
+
+  registerCharts([
+    { element: '#seasonal-scoring', source: DATA_URL, createConfig: () => buildSeasonalChart(data) },
+    { element: '#rest-impact', source: DATA_URL, createConfig: () => buildRestImpactChart(data) },
+    { element: '#close-margins', source: DATA_URL, createConfig: () => buildCloseMarginsChart(data) },
+    { element: '#overtime-breakdown', source: DATA_URL, createConfig: () => buildOvertimeChart(data) },
+    { element: '#three-point-trend', source: DATA_URL, createConfig: () => buildThreePointTrendChart(data) },
+  ]);
 }
 
-hydrateLab();
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bootstrap, { once: true });
+} else {
+  bootstrap();
+}

--- a/scripts/build_insights_lab.py
+++ b/scripts/build_insights_lab.py
@@ -1,0 +1,444 @@
+"""Generate data for the Insights Lab experience using league datasets."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import zipfile
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_DATA_DIR = ROOT / "public" / "data"
+GAMES_PATH = ROOT / "Games.csv"
+TEAM_STATS_ARCHIVE = ROOT / "TeamStatistics.zip"
+
+MONTH_LABELS = {
+    1: "Jan",
+    2: "Feb",
+    3: "Mar",
+    4: "Apr",
+    5: "May",
+    6: "Jun",
+    7: "Jul",
+    8: "Aug",
+    9: "Sep",
+    10: "Oct",
+    11: "Nov",
+    12: "Dec",
+}
+
+
+@dataclass
+class MonthAggregate:
+    label: str
+    games: int = 0
+    total_points: float = 0.0
+    regular_games: int = 0
+    regular_points: float = 0.0
+    playoff_games: int = 0
+    playoff_points: float = 0.0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "month": self.label,
+            "games": self.games,
+            "averagePoints": (self.total_points / self.games) if self.games else None,
+            "regularSeasonAverage": (self.regular_points / self.regular_games)
+            if self.regular_games
+            else None,
+            "playoffAverage": (self.playoff_points / self.playoff_games)
+            if self.playoff_games
+            else None,
+        }
+
+
+@dataclass
+class CloseBucket:
+    label: str
+    minimum: float
+    maximum: float | None
+    games: int = 0
+    margin_sum: float = 0.0
+
+    def contains(self, value: float) -> bool:
+        if value < self.minimum:
+            return False
+        if self.maximum is None:
+            return True
+        return value <= self.maximum
+
+    def to_dict(self, total_games: int) -> dict[str, object]:
+        share = (self.games / total_games) if total_games else 0.0
+        return {
+            "label": self.label,
+            "games": self.games,
+            "share": share,
+            "averageMargin": (self.margin_sum / self.games) if self.games else None,
+        }
+
+
+@dataclass
+class RestBucket:
+    label: str
+    games: int = 0
+    wins: int = 0
+    margin_sum: float = 0.0
+
+    def add_sample(self, won: bool, margin: float) -> None:
+        self.games += 1
+        if won:
+            self.wins += 1
+        self.margin_sum += margin
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "games": self.games,
+            "winPct": (self.wins / self.games) if self.games else None,
+            "pointMargin": (self.margin_sum / self.games) if self.games else None,
+        }
+
+
+@dataclass
+class OvertimeBucket:
+    label: str
+    games: int = 0
+    road_wins: int = 0
+
+    def add_sample(self, road_win: bool) -> None:
+        self.games += 1
+        if road_win:
+            self.road_wins += 1
+
+    def to_dict(self, total_games: int) -> dict[str, object]:
+        share = (self.games / total_games) if total_games else 0.0
+        return {
+            "label": self.label,
+            "games": self.games,
+            "share": share,
+            "roadWinPct": (self.road_wins / self.games) if self.games else None,
+        }
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_output_dir() -> None:
+    PUBLIC_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _write_json(filename: str, payload: dict[str, object]) -> None:
+    _ensure_output_dir()
+    path = PUBLIC_DATA_DIR / filename
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace(" ", "T"))
+    except ValueError:
+        return None
+
+
+def _to_float(value: str | None) -> float | None:
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _season_from_date(dt: datetime) -> int:
+    return dt.year + 1 if dt.month >= 7 else dt.year
+
+
+def build_monthly_scoring() -> tuple[list[dict[str, object]], float, int]:
+    aggregates: dict[int, MonthAggregate] = {}
+    total_games = 0
+    with GAMES_PATH.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            dt = _parse_datetime(row.get("gameDate"))
+            if not dt:
+                continue
+            month = dt.month
+            label = MONTH_LABELS.get(month, str(month))
+            bucket = aggregates.setdefault(month, MonthAggregate(label=label))
+            home_score = _to_float(row.get("homeScore")) or 0.0
+            away_score = _to_float(row.get("awayScore")) or 0.0
+            total = home_score + away_score
+            bucket.games += 1
+            bucket.total_points += total
+            total_games += 1
+            game_type = (row.get("gameType") or "").strip().lower()
+            if game_type == "regular season":
+                bucket.regular_games += 1
+                bucket.regular_points += total
+            elif game_type == "playoffs":
+                bucket.playoff_games += 1
+                bucket.playoff_points += total
+    if not aggregates:
+        return [], 0.0, 0
+
+    ordered_months = [aggregates[key] for key in sorted(aggregates)]
+    month_dicts = [entry.to_dict() for entry in ordered_months]
+    averages = [entry["averagePoints"] for entry in month_dicts if entry["averagePoints"] is not None]
+    swing = 0.0
+    if averages:
+        swing = max(averages) - min(averages)
+    return month_dicts, swing, total_games
+
+
+def build_close_margin_distribution(total_games: int) -> tuple[list[dict[str, object]], float]:
+    buckets = [
+        CloseBucket("0-2 pts", 0, 2),
+        CloseBucket("3-5 pts", 3, 5),
+        CloseBucket("6-10 pts", 6, 10),
+        CloseBucket("11-15 pts", 11, 15),
+        CloseBucket("16+ pts", 16, None),
+    ]
+    with GAMES_PATH.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            home_score = _to_float(row.get("homeScore"))
+            away_score = _to_float(row.get("awayScore"))
+            if home_score is None or away_score is None:
+                continue
+            margin = abs(home_score - away_score)
+            for bucket in buckets:
+                if bucket.contains(margin):
+                    bucket.games += 1
+                    bucket.margin_sum += margin
+                    break
+    distribution = [bucket.to_dict(total_games) for bucket in buckets if bucket.games]
+    close_share = sum(bucket["share"] for bucket in distribution if bucket["label"] in {"0-2 pts", "3-5 pts"})
+    return distribution, close_share
+
+
+def _load_team_statistics() -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    with zipfile.ZipFile(TEAM_STATS_ARCHIVE) as archive:
+        with archive.open("TeamStatistics.csv") as handle:
+            text_stream = io.TextIOWrapper(handle, encoding="utf-8")
+            reader = csv.DictReader(text_stream)
+            for row in reader:
+                game_id = (row.get("gameId") or "").strip()
+                team_id = (row.get("teamId") or "").strip()
+                dt = _parse_datetime(row.get("gameDate"))
+                if not game_id or not team_id or not dt:
+                    continue
+                home = (row.get("home") or "").strip() == "1"
+                win = (row.get("win") or "").strip() == "1"
+                team_score = _to_float(row.get("teamScore")) or 0.0
+                opponent_score = _to_float(row.get("opponentScore")) or 0.0
+                num_minutes = _to_float(row.get("numMinutes"))
+                row_payload = {
+                    "game_id": game_id,
+                    "team_id": team_id,
+                    "game_date": dt,
+                    "home": home,
+                    "win": win,
+                    "team_score": team_score,
+                    "opponent_score": opponent_score,
+                    "three_attempts": _to_float(row.get("threePointersAttempted")) or 0.0,
+                    "field_goal_attempts": _to_float(row.get("fieldGoalsAttempted")) or 0.0,
+                    "num_minutes": num_minutes,
+                }
+                rows.append(row_payload)
+    rows.sort(key=lambda record: (record["game_date"], record["game_id"], record["team_id"]))
+    return rows
+
+
+def _annotate_rest_days(rows: list[dict[str, object]]) -> None:
+    last_game_by_team: dict[str, datetime] = {}
+    for row in rows:
+        team_id = row["team_id"]
+        previous = last_game_by_team.get(team_id)
+        if previous is None:
+            rest_days = None
+        else:
+            delta: timedelta = row["game_date"] - previous
+            rest_days = delta.total_seconds() / 86400
+        row["rest_days"] = rest_days
+        last_game_by_team[team_id] = row["game_date"]
+
+
+def _rest_bucket(road_rest: float, home_rest: float) -> str:
+    rest_diff = road_rest - home_rest
+    if road_rest < 1:
+        return "Back-to-back"
+    if rest_diff >= 2:
+        return "+2 days"
+    if rest_diff >= 1:
+        return "+1 day"
+    if rest_diff <= -2:
+        return "-2 days"
+    if rest_diff <= -1:
+        return "-1 day"
+    return "Even rest"
+
+
+def build_rest_impact(rows: list[dict[str, object]]) -> tuple[list[dict[str, object]], float]:
+    buckets: dict[str, RestBucket] = {
+        "+2 days": RestBucket("+2 days"),
+        "+1 day": RestBucket("+1 day"),
+        "Even rest": RestBucket("Even rest"),
+        "-1 day": RestBucket("-1 day"),
+        "-2 days": RestBucket("-2 days"),
+        "Back-to-back": RestBucket("Back-to-back"),
+    }
+    games: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in rows:
+        games[row["game_id"]].append(row)
+    for pair in games.values():
+        if len(pair) != 2:
+            continue
+        home_entry = next((item for item in pair if item["home"]), None)
+        road_entry = next((item for item in pair if not item["home"]), None)
+        if not home_entry or not road_entry:
+            continue
+        road_rest = road_entry.get("rest_days")
+        home_rest = home_entry.get("rest_days")
+        if road_rest is None or home_rest is None:
+            continue
+        bucket_label = _rest_bucket(road_rest, home_rest)
+        bucket = buckets[bucket_label]
+        road_win = bool(road_entry.get("win"))
+        margin = (road_entry.get("team_score") or 0.0) - (road_entry.get("opponent_score") or 0.0)
+        bucket.add_sample(road_win, margin)
+    ordered = [
+        buckets[label]
+        for label in ["+2 days", "+1 day", "Even rest", "-1 day", "-2 days", "Back-to-back"]
+        if buckets[label].games
+    ]
+    if not ordered:
+        return [], 0.0
+    stats = [bucket.to_dict() for bucket in ordered]
+    positive = [entry for entry in stats if entry["label"].startswith("+")]
+    negative = [entry for entry in stats if entry["label"].startswith("-") or entry["label"] == "Back-to-back"]
+    best = max((entry for entry in positive if entry.get("winPct") is not None), default=None, key=lambda e: e["winPct"])
+    worst = min((entry for entry in negative if entry.get("winPct") is not None), default=None, key=lambda e: e["winPct"])
+    swing = 0.0
+    if best and worst:
+        swing = best["winPct"] - worst["winPct"]
+    return stats, swing
+
+
+def build_overtime_distribution(rows: list[dict[str, object]], total_games: int) -> list[dict[str, object]]:
+    buckets: dict[str, OvertimeBucket] = {
+        "Regulation": OvertimeBucket("Regulation"),
+        "1 OT": OvertimeBucket("1 OT"),
+        "2 OT": OvertimeBucket("2 OT"),
+        "3 OT": OvertimeBucket("3 OT"),
+        "4+ OT": OvertimeBucket("4+ OT"),
+    }
+    games: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in rows:
+        games[row["game_id"]].append(row)
+    for pair in games.values():
+        if len(pair) != 2:
+            continue
+        home_entry = next((item for item in pair if item["home"]), None)
+        road_entry = next((item for item in pair if not item["home"]), None)
+        if not home_entry or not road_entry:
+            continue
+        ot_counts = []
+        for candidate in (home_entry, road_entry):
+            minutes = candidate.get("num_minutes")
+            if minutes is None:
+                continue
+            overtime = max(0.0, minutes - 240.0)
+            periods = int(round(overtime / 25.0))
+            ot_counts.append(periods)
+        periods_played = max(ot_counts) if ot_counts else 0
+        if periods_played <= 0:
+            label = "Regulation"
+        elif periods_played == 1:
+            label = "1 OT"
+        elif periods_played == 2:
+            label = "2 OT"
+        elif periods_played == 3:
+            label = "3 OT"
+        else:
+            label = "4+ OT"
+        bucket = buckets[label]
+        bucket.add_sample(bool(road_entry.get("win")))
+    return [bucket.to_dict(total_games) for bucket in buckets.values() if bucket.games]
+
+
+def build_three_point_trend(rows: Iterable[dict[str, object]]) -> list[dict[str, object]]:
+    aggregates: dict[int, dict[str, float]] = defaultdict(lambda: {"three": 0.0, "fga": 0.0, "wins": 0.0, "games": 0.0})
+    for row in rows:
+        dt: datetime = row["game_date"]
+        season = _season_from_date(dt)
+        stats = aggregates[season]
+        stats["three"] += row.get("three_attempts") or 0.0
+        stats["fga"] += row.get("field_goal_attempts") or 0.0
+        stats["wins"] += 1.0 if row.get("win") else 0.0
+        stats["games"] += 1.0
+    trend = []
+    for season in sorted(aggregates):
+        stats = aggregates[season]
+        if stats["games"] == 0:
+            continue
+        three_rate = (stats["three"] / stats["fga"]) if stats["fga"] else None
+        trend.append(
+            {
+                "season": season,
+                "threePointRate": three_rate,
+                "teamWinPct": stats["wins"] / stats["games"],
+            }
+        )
+    return trend
+
+
+def main() -> None:
+    months, scoring_swing, total_games = build_monthly_scoring()
+    close_distribution, close_share = build_close_margin_distribution(total_games)
+    team_rows = _load_team_statistics()
+    _annotate_rest_days(team_rows)
+    rest_buckets, rest_swing = build_rest_impact(team_rows)
+    overtime = build_overtime_distribution(team_rows, total_games)
+    three_trend = build_three_point_trend(team_rows)
+
+    payload: dict[str, object] = {
+        "generatedAt": _timestamp(),
+        "sampleSize": total_games,
+        "seasonalScoring": {
+            "months": months,
+            "swing": scoring_swing,
+        },
+        "restImpact": {
+            "buckets": rest_buckets,
+            "swing": rest_swing,
+        },
+        "closeMargins": {
+            "distribution": close_distribution,
+            "closeShare": close_share,
+        },
+        "overtime": {
+            "categories": overtime,
+        },
+        "threePointTrend": {
+            "seasons": three_trend,
+        },
+    }
+
+    _write_json("insights_lab.json", payload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a build_insights_lab.py helper that aggregates scoring, rest, overtime, and shooting trends from the CSV archives
- rebuild insights_lab.json and rework insights.html/insights.js to surface the new metrics and charts backed by those calculations
- document how to regenerate the Insights Lab snapshot in the README

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d8ae558dbc832784d4607450d90a41