### PR TITLE
Fix Spurs franchise abbreviation

### DIFF
--- a/public/data/active_franchises.json
+++ b/public/data/active_franchises.json
@@ -186,7 +186,7 @@
       "teamId": "1610612759",
       "city": "San Antonio",
       "name": "Spurs",
-      "abbreviation": "SAN",
+      "abbreviation": "SAS",
       "league": "NBA",
       "seasonFounded": 1976,
       "seasonActiveTill": 2100,


### PR DESCRIPTION
## Summary
- correct the San Antonio Spurs abbreviation in the active franchises data so the franchise footprint joins match other datasets

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d8b04318b48327b0ef373b323db08b