### PR TITLE
Remove legends atlas header badges

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -36,20 +36,6 @@
         <section class="history-section">
           <div class="history-section__header">
             <h2>Legends atlas</h2>
-            <div class="history-badges">
-              <span class="history-badge">
-                <span class="history-badge__label">Active franchises</span>
-                <span class="history-badge__value" data-history="franchise-count">--</span>
-              </span>
-              <span class="history-badge">
-                <span class="history-badge__label">Peak expansion</span>
-                <span class="history-badge__value">
-                  <span data-history="peak-expansion-decade">--</span>
-                  <span class="history-badge__divider">•</span>
-                  <span data-history="peak-expansion-total">--</span>
-                </span>
-              </span>
-            </div>
           </div>
 
           <div class="history-mosaic history-mosaic--wide history-mosaic--atlas">


### PR DESCRIPTION
## Summary
- remove the Legends atlas badges that displayed active franchise and peak expansion counts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ba4421e883278dfc741e204794f7