### PR TITLE
Fix GOAT birthplace rankings and clarify atlas details

### DIFF
--- a/public/data/goat_birth_index.json
+++ b/public/data/goat_birth_index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-28T04:58:57.753357Z",
+  "generatedAt": "2025-09-28T05:10:59.254624Z",
   "players": [
     {
       "personId": "2544",

--- a/public/data/state_birth_legends.json
+++ b/public/data/state_birth_legends.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-28T04:58:57.753357Z",
+  "generatedAt": "2025-09-28T05:10:59.254624Z",
   "states": [
     {
       "state": "AK",
@@ -26,7 +26,8 @@
           "birthCity": "Anchorage",
           "birthState": "AK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -57,7 +58,8 @@
           "birthCity": "Leeds",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1112",
@@ -76,7 +78,8 @@
           "birthCity": "White Hall",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "202326",
@@ -98,7 +101,8 @@
           "birthCity": "Mobile",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "202339",
@@ -117,7 +121,8 @@
           "birthCity": "Birmingham",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "2222",
@@ -137,7 +142,8 @@
           "birthCity": "Sylacauga",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "201960",
@@ -159,7 +165,8 @@
           "birthCity": "Birmingham",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "203210",
@@ -178,7 +185,8 @@
           "birthCity": "Montgomery",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "203909",
@@ -197,7 +205,8 @@
           "birthCity": "Birmingham",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "964",
@@ -216,7 +225,8 @@
           "birthCity": "Linden",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201591",
@@ -234,7 +244,8 @@
           "birthCity": "Tuscaloosa",
           "birthState": "AL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -265,7 +276,8 @@
           "birthCity": "Hamburg",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "965",
@@ -284,7 +296,8 @@
           "birthCity": "Little Rock",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "78151",
@@ -304,7 +317,8 @@
           "birthCity": "Prescott",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "2207",
@@ -326,7 +340,8 @@
           "birthCity": "Little Rock",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "201144",
@@ -343,7 +358,8 @@
           "birthCity": "Fayetteville",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1626171",
@@ -361,7 +377,8 @@
           "birthCity": "Little Rock",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "2410",
@@ -380,7 +397,8 @@
           "birthCity": "Malvern",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1629655",
@@ -397,7 +415,8 @@
           "birthCity": "El Dorado",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1628370",
@@ -414,7 +433,8 @@
           "birthCity": "Jonesboro",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "202341",
@@ -433,7 +453,8 @@
           "birthCity": "El Dorado",
           "birthState": "AR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -474,7 +495,8 @@
           "birthCity": "Phoenix",
           "birthState": "AZ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1629680",
@@ -490,7 +512,8 @@
           "birthCity": "Scottsdale",
           "birthState": "AZ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1628963",
@@ -508,7 +531,8 @@
           "birthCity": "Tempe",
           "birthState": "AZ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "203910",
@@ -526,7 +550,8 @@
           "birthCity": "Tempe",
           "birthState": "AZ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1628778",
@@ -543,7 +568,8 @@
           "birthCity": "Phoenix",
           "birthState": "AZ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2596",
@@ -560,7 +586,8 @@
           "birthCity": "Phoenix",
           "birthState": "AZ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         }
       ]
     },
@@ -593,7 +620,8 @@
           "birthCity": "San Francisco",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "201935",
@@ -612,7 +640,8 @@
           "birthCity": "Los Angeles",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "201566",
@@ -632,7 +661,8 @@
           "birthCity": "Long Beach",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "951",
@@ -650,7 +680,8 @@
           "birthCity": "Merced",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "56",
@@ -671,7 +702,8 @@
           "birthCity": "Oakland",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1718",
@@ -689,7 +721,8 @@
           "birthCity": "Oakland",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "77141",
@@ -706,7 +739,8 @@
           "birthCity": "Compton",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "397",
@@ -721,7 +755,8 @@
           "birthCity": "Riverside",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "202691",
@@ -737,7 +772,8 @@
           "birthCity": "Los Angeles",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "202695",
@@ -754,7 +790,8 @@
           "birthCity": "Los Angeles",
           "birthState": "CA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -795,7 +832,8 @@
           "birthCity": "Denver",
           "birthState": "CO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1628401",
@@ -811,7 +849,8 @@
           "birthCity": "Parker",
           "birthState": "CO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "201160",
@@ -832,7 +871,8 @@
           "birthCity": "Greeley",
           "birthState": "CO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1913",
@@ -853,7 +893,8 @@
           "birthCity": "Denver",
           "birthState": "CO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "201174",
@@ -870,7 +911,8 @@
           "birthCity": "Arvada",
           "birthState": "CO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2079",
@@ -890,7 +932,8 @@
           "birthCity": "Denver",
           "birthState": "CO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         }
       ]
     },
@@ -927,7 +970,8 @@
           "birthCity": "Hartford",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1627739",
@@ -948,7 +992,8 @@
           "birthCity": "New London",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "101155",
@@ -966,7 +1011,8 @@
           "birthCity": "Waterbury",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "2042",
@@ -984,7 +1030,8 @@
           "birthCity": "Bridgeport",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1629682",
@@ -1002,7 +1049,8 @@
           "birthCity": "New Haven",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2226",
@@ -1019,7 +1067,8 @@
           "birthCity": "Hartford",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "202716",
@@ -1034,7 +1083,8 @@
           "birthCity": "Torrington",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1627771",
@@ -1050,7 +1100,8 @@
           "birthCity": "Hartford",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "201185",
@@ -1066,7 +1117,8 @@
           "birthCity": "Hartford",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1755",
@@ -1081,7 +1133,8 @@
           "birthCity": "New Britain",
           "birthState": "CT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -1116,7 +1169,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "76504",
@@ -1137,7 +1191,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "76127",
@@ -1152,7 +1207,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "2753",
@@ -1170,7 +1226,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "202335",
@@ -1190,7 +1247,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2586",
@@ -1214,7 +1272,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "202334",
@@ -1236,7 +1295,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "966",
@@ -1254,7 +1314,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1626188",
@@ -1276,7 +1337,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201970",
@@ -1293,7 +1355,8 @@
           "birthCity": "Washington",
           "birthState": "DC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -1324,7 +1387,8 @@
           "birthCity": "Wilmington",
           "birthState": "DE",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -1351,7 +1415,8 @@
           "birthCity": "Key West",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1713",
@@ -1373,7 +1438,8 @@
           "birthCity": "Daytona Beach",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "901",
@@ -1396,7 +1462,8 @@
           "birthCity": "Boynton Beach",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "2772",
@@ -1421,7 +1488,8 @@
           "birthCity": "Miami",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1503",
@@ -1442,7 +1510,8 @@
           "birthCity": "Bartow",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "224",
@@ -1461,7 +1530,8 @@
           "birthCity": "Pompano Beach",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "2617",
@@ -1476,7 +1546,8 @@
           "birthCity": "Miami",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "2405",
@@ -1494,7 +1565,8 @@
           "birthCity": "Lake Wales",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "2592",
@@ -1513,7 +1585,8 @@
           "birthCity": "Miami",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "2240",
@@ -1531,7 +1604,8 @@
           "birthCity": "Tampa",
           "birthState": "FL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -1560,7 +1634,8 @@
           "birthCity": "Atlanta",
           "birthState": "GA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "270",
@@ -1578,7 +1653,8 @@
           "birthCity": "Augusta",
           "birthState": "GA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "77721",
@@ -1595,7 +1671,8 @@
           "birthCity": "Macon",
           "birthState": "GA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "905",
@@ -1614,7 +1691,8 @@
           "birthCity": "Toccoa",
           "birthState": "GA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "201159",
@@ -1632,7 +1710,8 @@
           "birthCity": "Atlanta",
           "birthState": "GA",
           "birthCountry": "U.S.",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         }
       ]
     },
@@ -1665,7 +1744,8 @@
           "birthCity": "Ames",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "2550",
@@ -1682,7 +1762,8 @@
           "birthCity": "Sioux City",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "2555",
@@ -1698,7 +1779,8 @@
           "birthCity": "Orange City",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1711",
@@ -1716,7 +1798,8 @@
           "birthCity": "Hampton",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1763",
@@ -1734,7 +1817,8 @@
           "birthCity": "Fort Madison",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "200753",
@@ -1752,7 +1836,8 @@
           "birthCity": "Oskaloosa",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1627779",
@@ -1768,7 +1853,8 @@
           "birthCity": "Cedar Rapids",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "201183",
@@ -1784,7 +1870,8 @@
           "birthCity": "Carroll",
           "birthState": "IA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         }
       ]
     },
@@ -1819,7 +1906,8 @@
           "birthCity": "Coeur d'Alene",
           "birthState": "ID",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -1850,7 +1938,8 @@
           "birthCity": "Chicago",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "2738",
@@ -1869,7 +1958,8 @@
           "birthCity": "Springfield",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1890",
@@ -1888,7 +1978,8 @@
           "birthCity": "Waukegan",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "78318",
@@ -1903,7 +1994,8 @@
           "birthCity": "Chicago",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "78149",
@@ -1919,7 +2011,8 @@
           "birthCity": "Kankakee",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "76385",
@@ -1938,7 +2031,8 @@
           "birthCity": "Chicago",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "714",
@@ -1956,7 +2050,8 @@
           "birthCity": "Chicago",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "204",
@@ -1973,7 +2068,8 @@
           "birthCity": "Elmhurst",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "203076",
@@ -1991,7 +2087,8 @@
           "birthCity": "Chicago",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "952",
@@ -2011,7 +2108,8 @@
           "birthCity": "Chicago",
           "birthState": "IL",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -2038,7 +2136,8 @@
           "birthCity": "West Baden Springs",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "2216",
@@ -2057,7 +2156,8 @@
           "birthCity": "Marion",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "201588",
@@ -2079,7 +2179,8 @@
           "birthCity": "Indianapolis",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "201952",
@@ -2098,7 +2199,8 @@
           "birthCity": "Indianapolis",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "202330",
@@ -2116,7 +2218,8 @@
           "birthCity": "Indianapolis",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "201569",
@@ -2136,7 +2239,8 @@
           "birthCity": "Indianapolis",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "203486",
@@ -2157,7 +2261,8 @@
           "birthCity": "Fort Wayne",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1629636",
@@ -2172,7 +2277,8 @@
           "birthCity": "Gary",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1719",
@@ -2192,7 +2298,8 @@
           "birthCity": "Muncie",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201584",
@@ -2214,7 +2321,8 @@
           "birthCity": "Indianapolis",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -2253,7 +2361,8 @@
           "birthCity": "Kansas City",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1559",
@@ -2273,7 +2382,8 @@
           "birthCity": "Wichita",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1626161",
@@ -2292,7 +2402,8 @@
           "birthCity": "Spearville",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1628400",
@@ -2309,7 +2420,8 @@
           "birthCity": "Overland Park",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1629731",
@@ -2324,7 +2436,8 @@
           "birthCity": "Wichita",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "101134",
@@ -2339,7 +2452,8 @@
           "birthCity": "Leavenworth",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1748",
@@ -2354,7 +2468,8 @@
           "birthCity": "Wichita",
           "birthState": "KS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         }
       ]
     },
@@ -2383,7 +2498,8 @@
           "birthCity": "Newport",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "78392",
@@ -2400,7 +2516,8 @@
           "birthCity": "Louisville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "200765",
@@ -2423,7 +2540,8 @@
           "birthCity": "Louisville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1626156",
@@ -2441,7 +2559,8 @@
           "birthCity": "Louisville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1507",
@@ -2462,7 +2581,8 @@
           "birthCity": "Louisville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1629023",
@@ -2478,7 +2598,8 @@
           "birthCity": "Louisville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "202714",
@@ -2499,7 +2620,8 @@
           "birthCity": "Lexington",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1628436",
@@ -2518,7 +2640,8 @@
           "birthCity": "Lexington",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1761",
@@ -2537,7 +2660,8 @@
           "birthCity": "Hopkinsville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1909",
@@ -2555,7 +2679,8 @@
           "birthCity": "Louisville",
           "birthState": "KY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -2582,7 +2707,8 @@
           "birthCity": "Monroe",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "252",
@@ -2598,7 +2724,8 @@
           "birthCity": "Summerfield",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "76979",
@@ -2617,7 +2744,8 @@
           "birthCity": "Rayville",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "305",
@@ -2635,7 +2763,8 @@
           "birthCity": "Shreveport",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "17",
@@ -2651,7 +2780,8 @@
           "birthCity": "New Orleans",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "200794",
@@ -2670,7 +2800,8 @@
           "birthCity": "Monroe",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "77160",
@@ -2687,7 +2818,8 @@
           "birthCity": "Natchitoches",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1740",
@@ -2705,7 +2837,8 @@
           "birthCity": "Pineville",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1712",
@@ -2725,7 +2858,8 @@
           "birthCity": "Shreveport",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201152",
@@ -2747,7 +2881,8 @@
           "birthCity": "New Orleans",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -2776,7 +2911,8 @@
           "birthCity": "Boston",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1628971",
@@ -2796,7 +2932,8 @@
           "birthCity": "Boston",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1626192",
@@ -2812,7 +2949,8 @@
           "birthCity": "Arlington",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "203457",
@@ -2832,7 +2970,8 @@
           "birthCity": "Malden",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "203487",
@@ -2852,7 +2991,8 @@
           "birthCity": "Hamilton",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "203943",
@@ -2874,7 +3014,8 @@
           "birthCity": "Salem",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "203894",
@@ -2894,7 +3035,8 @@
           "birthCity": "Roxbury",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1627774",
@@ -2911,7 +3053,8 @@
           "birthCity": "Wrentham",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "2214",
@@ -2930,7 +3073,8 @@
           "birthCity": "Worcester",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1914",
@@ -2946,7 +3090,8 @@
           "birthCity": "Fall River",
           "birthState": "MA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -2979,7 +3124,8 @@
           "birthCity": "Harford County",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "208",
@@ -3002,7 +3148,8 @@
           "birthCity": "Baltimore",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "201145",
@@ -3028,7 +3175,8 @@
           "birthCity": "Cheverly",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1883",
@@ -3046,7 +3194,8 @@
           "birthCity": "Takoma Park",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "101127",
@@ -3070,7 +3219,8 @@
           "birthCity": "Fort Washington",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "203506",
@@ -3089,7 +3239,8 @@
           "birthCity": "Silver Spring",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1628404",
@@ -3107,7 +3258,8 @@
           "birthCity": "Silver Spring",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "201951",
@@ -3126,7 +3278,8 @@
           "birthCity": "Clinton",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "203115",
@@ -3144,7 +3297,8 @@
           "birthCity": "Baltimore",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201563",
@@ -3166,7 +3320,8 @@
           "birthCity": "Cheverly",
           "birthState": "MD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -3193,7 +3348,8 @@
           "birthCity": "York",
           "birthState": "ME",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -3220,7 +3376,8 @@
           "birthCity": "Lansing",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "185",
@@ -3239,7 +3396,8 @@
           "birthCity": "Detroit",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "203110",
@@ -3254,7 +3412,8 @@
           "birthCity": "Saginaw",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "136",
@@ -3275,7 +3434,8 @@
           "birthCity": "Detroit",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "76804",
@@ -3291,7 +3451,8 @@
           "birthCity": "Detroit",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2030",
@@ -3310,7 +3471,8 @@
           "birthCity": "Saginaw",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "2203",
@@ -3327,7 +3489,8 @@
           "birthCity": "Birmingham",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1626164",
@@ -3342,7 +3505,8 @@
           "birthCity": "Grand Rapids",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "2202",
@@ -3361,7 +3525,8 @@
           "birthCity": "Saginaw",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201580",
@@ -3384,7 +3549,8 @@
           "birthCity": "Flint",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -3411,7 +3577,8 @@
           "birthCity": "Hibbing",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1904",
@@ -3428,7 +3595,8 @@
           "birthCity": "Minneapolis",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "2743",
@@ -3452,7 +3620,8 @@
           "birthCity": "Minneapolis",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "203488",
@@ -3473,7 +3642,8 @@
           "birthCity": "St. Louis Park",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1626145",
@@ -3491,7 +3661,8 @@
           "birthCity": "Burnsville",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2038",
@@ -3509,7 +3680,8 @@
           "birthCity": "Monticello",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "202720",
@@ -3528,7 +3700,8 @@
           "birthCity": "Long Lake",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "202332",
@@ -3549,7 +3722,8 @@
           "birthCity": "Burnsville",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1629599",
@@ -3564,7 +3738,8 @@
           "birthCity": "Hopkins",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1519",
@@ -3584,7 +3759,8 @@
           "birthCity": "Minneapolis",
           "birthState": "MN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -3611,7 +3787,8 @@
           "birthCity": "St. Louis",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "78510",
@@ -3628,7 +3805,8 @@
           "birthCity": "St. Louis",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "203078",
@@ -3644,7 +3822,8 @@
           "birthCity": "St. Louis",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "101135",
@@ -3663,7 +3842,8 @@
           "birthCity": "St. Louis",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1716",
@@ -3686,7 +3866,8 @@
           "birthCity": "St. Louis",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1629008",
@@ -3701,7 +3882,8 @@
           "birthCity": "Columbia",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "202692",
@@ -3723,7 +3905,8 @@
           "birthCity": "Grandview",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1731",
@@ -3744,7 +3927,8 @@
           "birthCity": "Mexico",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "201575",
@@ -3763,7 +3947,8 @@
           "birthCity": "Kansas City",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1629013",
@@ -3783,7 +3968,8 @@
           "birthCity": "Kansas City",
           "birthState": "MO",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -3816,7 +4002,8 @@
           "birthCity": "Jackson",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "2590",
@@ -3837,7 +4024,8 @@
           "birthCity": "Jackson",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "2744",
@@ -3856,7 +4044,8 @@
           "birthCity": "Monticello",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "956",
@@ -3875,7 +4064,8 @@
           "birthCity": "Jackson",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "953",
@@ -3894,7 +4084,8 @@
           "birthCity": "Oxford",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "203918",
@@ -3914,7 +4105,8 @@
           "birthCity": "Meridian",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "970",
@@ -3933,7 +4125,8 @@
           "birthCity": "Jackson",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "2566",
@@ -3952,7 +4145,8 @@
           "birthCity": "Starkville",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1629234",
@@ -3971,7 +4165,8 @@
           "birthCity": "Starkville",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1886",
@@ -3987,7 +4182,8 @@
           "birthCity": "Picayune",
           "birthState": "MS",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -4020,7 +4216,8 @@
           "birthCity": "Glendive",
           "birthState": "MT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -4061,7 +4258,8 @@
           "birthCity": "Winston-Salem",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "77498",
@@ -4082,7 +4280,8 @@
           "birthCity": "Greensboro",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "433",
@@ -4099,7 +4298,8 @@
           "birthCity": "Rocky Mount",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1460",
@@ -4114,7 +4314,8 @@
           "birthCity": "Gastonia",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "202322",
@@ -4131,7 +4332,8 @@
           "birthCity": "Raleigh",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "200782",
@@ -4153,7 +4355,8 @@
           "birthCity": "Raleigh",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "2572",
@@ -4171,7 +4374,8 @@
           "birthCity": "Winston-Salem",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1627742",
@@ -4188,7 +4392,8 @@
           "birthCity": "Kinston",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1517",
@@ -4209,7 +4414,8 @@
           "birthCity": "East Spencer",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "202397",
@@ -4236,7 +4442,8 @@
           "birthCity": "Charlotte",
           "birthState": "NC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -4275,7 +4482,8 @@
           "birthCity": "Grand Forks",
           "birthState": "ND",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "2782",
@@ -4294,7 +4502,8 @@
           "birthCity": "Bismarck",
           "birthState": "ND",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         }
       ]
     },
@@ -4327,7 +4536,8 @@
           "birthCity": "Omaha",
           "birthState": "NE",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -4356,7 +4566,8 @@
           "birthCity": "Concord",
           "birthState": "NH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -4393,7 +4604,8 @@
           "birthCity": "Newark",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "600013",
@@ -4410,7 +4622,8 @@
           "birthCity": "Elizabeth",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "23",
@@ -4429,7 +4642,8 @@
           "birthCity": "Trenton",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1710",
@@ -4449,7 +4663,8 @@
           "birthCity": "Cherry Hill",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "2561",
@@ -4468,7 +4683,8 @@
           "birthCity": "Teaneck",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "2747",
@@ -4488,7 +4704,8 @@
           "birthCity": "Freehold Borough",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1626157",
@@ -4504,7 +4721,8 @@
           "birthCity": "Edison",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1628389",
@@ -4519,7 +4737,8 @@
           "birthCity": "Newark",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1733",
@@ -4540,7 +4759,8 @@
           "birthCity": "Orange",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1628973",
@@ -4556,7 +4776,8 @@
           "birthCity": "New Brunswick",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -4591,7 +4812,8 @@
           "birthCity": "Hobbs",
           "birthState": "NM",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "203460",
@@ -4607,7 +4829,8 @@
           "birthCity": "Las Cruces",
           "birthState": "NM",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "202345",
@@ -4627,7 +4850,8 @@
           "birthCity": "Hobbs",
           "birthState": "NM",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         }
       ]
     },
@@ -4664,7 +4888,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1628972",
@@ -4683,7 +4908,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1628380",
@@ -4700,7 +4926,8 @@
           "birthCity": "North Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1727",
@@ -4716,7 +4943,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "2556",
@@ -4735,7 +4963,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "77964",
@@ -4751,7 +4980,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "203467",
@@ -4768,7 +4998,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "203510",
@@ -4784,7 +5015,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "202359",
@@ -4799,7 +5031,8 @@
           "birthCity": "Las Vegas",
           "birthState": "NV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         }
       ]
     },
@@ -4828,7 +5061,8 @@
           "birthCity": "Brooklyn",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "76003",
@@ -4844,7 +5078,8 @@
           "birthCity": "New York City",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "76681",
@@ -4859,7 +5094,8 @@
           "birthCity": "Roosevelt",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "349",
@@ -4880,7 +5116,8 @@
           "birthCity": "Brooklyn",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "2546",
@@ -4900,7 +5137,8 @@
           "birthCity": "Brooklyn",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1885",
@@ -4918,7 +5156,8 @@
           "birthCity": "Queens",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "361",
@@ -4937,7 +5176,8 @@
           "birthCity": "Buffalo",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "64",
@@ -4956,7 +5196,8 @@
           "birthCity": "Brooklyn",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "78549",
@@ -4974,7 +5215,8 @@
           "birthCity": "Mount Vernon",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "78530",
@@ -4992,7 +5234,8 @@
           "birthCity": "Brooklyn",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -5023,7 +5266,8 @@
           "birthCity": "Akron",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "201939",
@@ -5038,7 +5282,8 @@
           "birthCity": "Akron",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "76970",
@@ -5053,7 +5298,8 @@
           "birthCity": "Martins Ferry",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "600001",
@@ -5071,7 +5317,8 @@
           "birthCity": "Akron",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "891",
@@ -5090,7 +5337,8 @@
           "birthCity": "Cleveland",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "166",
@@ -5108,7 +5356,8 @@
           "birthCity": "Dayton",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "77418",
@@ -5125,7 +5374,8 @@
           "birthCity": "Middletown",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "203468",
@@ -5141,7 +5391,8 @@
           "birthCity": "Canton",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1899",
@@ -5162,7 +5413,8 @@
           "birthCity": "Cleveland",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "954",
@@ -5178,7 +5430,8 @@
           "birthCity": "Dayton",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -5211,7 +5464,8 @@
           "birthCity": "Oklahoma City",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1626196",
@@ -5231,7 +5485,8 @@
           "birthCity": "Edmond",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "200749",
@@ -5252,7 +5507,8 @@
           "birthCity": "Oklahoma City",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "2063",
@@ -5273,7 +5529,8 @@
           "birthCity": "Tulsa",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1629610",
@@ -5294,7 +5551,8 @@
           "birthCity": "Edmond",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1629637",
@@ -5310,7 +5568,8 @@
           "birthCity": "Norman",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1628390",
@@ -5326,7 +5585,8 @@
           "birthCity": "Tulsa",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "201616",
@@ -5344,7 +5604,8 @@
           "birthCity": "Oklahoma City",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "202350",
@@ -5362,7 +5623,8 @@
           "birthCity": "Oklahoma City",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "2415",
@@ -5380,7 +5642,8 @@
           "birthCity": "Tulsa",
           "birthState": "OK",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -5413,7 +5676,8 @@
           "birthCity": "Portland",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1627734",
@@ -5430,7 +5694,8 @@
           "birthCity": "Portland",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1628392",
@@ -5450,7 +5715,8 @@
           "birthCity": "Eugene",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "203924",
@@ -5469,7 +5735,8 @@
           "birthCity": "Portland",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "203082",
@@ -5486,7 +5753,8 @@
           "birthCity": "Portland",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "200758",
@@ -5506,7 +5774,8 @@
           "birthCity": "Portland",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "202713",
@@ -5522,7 +5791,8 @@
           "birthCity": "Medford",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "969",
@@ -5539,7 +5809,8 @@
           "birthCity": "Hillsboro",
           "birthState": "OR",
           "birthCountry": "U.S.",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "2424",
@@ -5561,7 +5832,8 @@
           "birthCity": "Portland",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "2739",
@@ -5582,7 +5854,8 @@
           "birthCity": "Eugene",
           "birthState": "OR",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -5615,7 +5888,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "977",
@@ -5630,7 +5904,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "739",
@@ -5650,7 +5925,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "200768",
@@ -5669,7 +5945,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1888",
@@ -5686,7 +5963,8 @@
           "birthCity": "Coatesville",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1749",
@@ -5705,7 +5983,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1628969",
@@ -5722,7 +6001,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "2749",
@@ -5742,7 +6022,8 @@
           "birthCity": "Chester",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "202693",
@@ -5764,7 +6045,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "201936",
@@ -5782,7 +6064,8 @@
           "birthCity": "Chester",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -5811,7 +6094,8 @@
           "birthCity": "Providence",
           "birthState": "RI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -5842,7 +6126,8 @@
           "birthCity": "Greenville",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "76673",
@@ -5860,7 +6145,8 @@
           "birthCity": "Columbia",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "77685",
@@ -5876,7 +6162,8 @@
           "birthCity": "Anderson",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "979",
@@ -5897,7 +6184,8 @@
           "birthCity": "Columbia",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "203114",
@@ -5914,7 +6202,8 @@
           "birthCity": "Charleston",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "101109",
@@ -5935,7 +6224,8 @@
           "birthCity": "Latta",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1629630",
@@ -5950,7 +6240,8 @@
           "birthCity": "Dalzell",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1533",
@@ -5971,7 +6262,8 @@
           "birthCity": "Charleston",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "201196",
@@ -5993,7 +6285,8 @@
           "birthCity": "Myrtle Beach",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1628470",
@@ -6013,7 +6306,8 @@
           "birthCity": "Columbia",
           "birthState": "SC",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -6052,7 +6346,8 @@
           "birthCity": "Mitchell",
           "birthState": "SD",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     },
@@ -6081,7 +6376,8 @@
           "birthCity": "Charlotte",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "200755",
@@ -6101,7 +6397,8 @@
           "birthCity": "Cookeville",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "101150",
@@ -6121,7 +6418,8 @@
           "birthCity": "Memphis",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1626166",
@@ -6143,7 +6441,8 @@
           "birthCity": "Memphis",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1500",
@@ -6164,7 +6463,8 @@
           "birthCity": "Nashville",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "960",
@@ -6186,7 +6486,8 @@
           "birthCity": "Covington",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "2239",
@@ -6204,7 +6505,8 @@
           "birthCity": "Clarksville",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "201975",
@@ -6225,7 +6527,8 @@
           "birthCity": "Nashville",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "201148",
@@ -6246,7 +6549,8 @@
           "birthCity": "Nashville",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "200761",
@@ -6267,7 +6571,8 @@
           "birthCity": "Memphis",
           "birthState": "TN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -6296,7 +6601,8 @@
           "birthCity": "Dallas",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "202710",
@@ -6315,7 +6621,8 @@
           "birthCity": "Houston",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "200746",
@@ -6332,7 +6639,8 @@
           "birthCity": "Dallas",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1536",
@@ -6354,7 +6662,8 @@
           "birthCity": "Port Arthur",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "201599",
@@ -6375,7 +6684,8 @@
           "birthCity": "Houston",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1629027",
@@ -6390,7 +6700,8 @@
           "birthCity": "Lubbock",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "203944",
@@ -6408,7 +6719,8 @@
           "birthCity": "Dallas",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "203935",
@@ -6425,7 +6737,8 @@
           "birthCity": "Flower Mound",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "2570",
@@ -6443,7 +6756,8 @@
           "birthCity": "Nederland",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1626167",
@@ -6458,7 +6772,8 @@
           "birthCity": "Bedford",
           "birthState": "TX",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -6489,7 +6804,8 @@
           "birthCity": "Ogden",
           "birthState": "UT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1628381",
@@ -6505,7 +6821,8 @@
           "birthCity": "Layton",
           "birthState": "UT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1513",
@@ -6525,7 +6842,8 @@
           "birthCity": "Murray",
           "birthState": "UT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "2484",
@@ -6546,7 +6864,8 @@
           "birthCity": "Salt Lake City",
           "birthState": "UT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "203912",
@@ -6564,7 +6883,8 @@
           "birthCity": "Pleasant Grove",
           "birthState": "UT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "41534",
@@ -6577,7 +6897,8 @@
           "birthCity": "Provo",
           "birthState": "UT",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         }
       ]
     },
@@ -6616,7 +6937,8 @@
           "birthCity": "Petersburg",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "947",
@@ -6634,7 +6956,8 @@
           "birthCity": "Hampton",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "76500",
@@ -6650,7 +6973,8 @@
           "birthCity": "Richmond",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "297",
@@ -6668,7 +6992,8 @@
           "birthCity": "Chesapeake",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1627827",
@@ -6685,7 +7010,8 @@
           "birthCity": "Portsmouth",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "203087",
@@ -6704,7 +7030,8 @@
           "birthCity": "Henrico",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "201945",
@@ -6721,7 +7048,8 @@
           "birthCity": "Richmond",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "1629640",
@@ -6736,7 +7064,8 @@
           "birthCity": "Chesterfield",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "203118",
@@ -6754,7 +7083,8 @@
           "birthCity": "Chesapeake",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "203086",
@@ -6771,7 +7101,8 @@
           "birthCity": "Woodbridge",
           "birthState": "VA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -6798,7 +7129,8 @@
           "birthCity": "Spokane",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "1891",
@@ -6818,7 +7150,8 @@
           "birthCity": "Seattle",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "2037",
@@ -6841,7 +7174,8 @@
           "birthCity": "Seattle",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "101107",
@@ -6859,7 +7193,8 @@
           "birthCity": "Bremerton",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "202738",
@@ -6883,7 +7218,8 @@
           "birthCity": "Tacoma",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "203897",
@@ -6900,7 +7236,8 @@
           "birthCity": "Renton",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "1627749",
@@ -6917,7 +7254,8 @@
           "birthCity": "Seattle",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "201150",
@@ -6937,7 +7275,8 @@
           "birthCity": "Seattle",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "200750",
@@ -6953,7 +7292,8 @@
           "birthCity": "Seattle",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "101126",
@@ -6975,7 +7315,8 @@
           "birthCity": "Seattle",
           "birthState": "WA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -7006,7 +7347,8 @@
           "birthCity": "Milwaukee",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "2406",
@@ -7029,7 +7371,8 @@
           "birthCity": "Racine",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "2734",
@@ -7048,7 +7391,8 @@
           "birthCity": "Milwaukee",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "1629639",
@@ -7063,7 +7407,8 @@
           "birthCity": "Greenfield",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "1629673",
@@ -7079,7 +7424,8 @@
           "birthCity": "Marshfield",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "1626172",
@@ -7094,7 +7440,8 @@
           "birthCity": "Milwaukee",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "201171",
@@ -7113,7 +7460,8 @@
           "birthCity": "Milwaukee",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "2036",
@@ -7131,7 +7479,8 @@
           "birthCity": "Milwaukee",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1934",
@@ -7150,7 +7499,8 @@
           "birthCity": "Milwaukee",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "1626155",
@@ -7169,7 +7519,8 @@
           "birthCity": "Sheboygan",
           "birthState": "WI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -7196,7 +7547,8 @@
           "birthCity": "Chelyan",
           "birthState": "WV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "101114",
@@ -7215,7 +7567,8 @@
           "birthCity": "Parkersburg",
           "birthState": "WV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "1715",
@@ -7233,7 +7586,8 @@
           "birthCity": "Belle",
           "birthState": "WV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "201564",
@@ -7250,7 +7604,8 @@
           "birthCity": "Huntington",
           "birthState": "WV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "2447",
@@ -7266,7 +7621,8 @@
           "birthCity": "Beckley",
           "birthState": "WV",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         }
       ]
     },
@@ -7313,7 +7669,8 @@
           "birthCity": "Cheyenne",
           "birthState": "WY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         }
       ]
     }

--- a/public/data/world_birth_legends.json
+++ b/public/data/world_birth_legends.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-28T04:58:57.753357Z",
+  "generatedAt": "2025-09-28T05:10:59.254624Z",
   "countries": [
     {
       "country": "AO",
@@ -30,7 +30,8 @@
           "birthCity": "Luanda",
           "birthState": null,
           "birthCountry": "Angola",
-          "birthCountryCode": "AO"
+          "birthCountryCode": "AO",
+          "groupRank": 1
         }
       ]
     },
@@ -67,7 +68,8 @@
           "birthCity": "St. John's",
           "birthState": null,
           "birthCountry": "Antigua and Barbuda",
-          "birthCountryCode": "AG"
+          "birthCountryCode": "AG",
+          "groupRank": 1
         }
       ]
     },
@@ -94,7 +96,8 @@
           "birthCity": "Bahía Blanca",
           "birthState": null,
           "birthCountry": "Argentina",
-          "birthCountryCode": "AR"
+          "birthCountryCode": "AR",
+          "groupRank": 1
         },
         {
           "personId": "2568",
@@ -112,7 +115,8 @@
           "birthCity": "Santa Fe",
           "birthState": null,
           "birthCountry": "Argentina",
-          "birthCountryCode": "AR"
+          "birthCountryCode": "AR",
+          "groupRank": 2
         },
         {
           "personId": "64093",
@@ -125,7 +129,8 @@
           "birthCity": "Buenos Aires",
           "birthState": null,
           "birthCountry": "Argentina",
-          "birthCountryCode": "AR"
+          "birthCountryCode": "AR",
+          "groupRank": 3
         }
       ]
     },
@@ -158,7 +163,8 @@
           "birthCity": "Sydney",
           "birthState": null,
           "birthCountry": "Australia",
-          "birthCountryCode": "AU"
+          "birthCountryCode": "AU",
+          "groupRank": 1
         },
         {
           "personId": "1627732",
@@ -175,7 +181,8 @@
           "birthCity": "Melbourne",
           "birthState": null,
           "birthCountry": "Australia",
-          "birthCountryCode": "AU"
+          "birthCountryCode": "AU",
+          "groupRank": 2
         },
         {
           "personId": "201988",
@@ -196,7 +203,8 @@
           "birthCity": "Canberra",
           "birthState": null,
           "birthCountry": "Australia",
-          "birthCountryCode": "AU"
+          "birthCountryCode": "AU",
+          "groupRank": 3
         },
         {
           "personId": "203521",
@@ -213,7 +221,8 @@
           "birthCity": "Maryborough",
           "birthState": null,
           "birthCountry": "Australia",
-          "birthCountryCode": "AU"
+          "birthCountryCode": "AU",
+          "groupRank": 4
         },
         {
           "personId": "203957",
@@ -231,7 +240,8 @@
           "birthCity": "Melbourne",
           "birthState": null,
           "birthCountry": "Australia",
-          "birthCountryCode": "AU"
+          "birthCountryCode": "AU",
+          "groupRank": 5
         },
         {
           "personId": "56022",
@@ -244,7 +254,8 @@
           "birthCity": "Adelaide",
           "birthState": null,
           "birthCountry": "Australia",
-          "birthCountryCode": "AU"
+          "birthCountryCode": "AU",
+          "groupRank": 6
         }
       ]
     },
@@ -273,7 +284,8 @@
           "birthCity": "Vienna",
           "birthState": null,
           "birthCountry": "Austria",
-          "birthCountryCode": "AT"
+          "birthCountryCode": "AT",
+          "groupRank": 1
         }
       ]
     },
@@ -302,7 +314,8 @@
           "birthCity": "Nassau",
           "birthState": null,
           "birthCountry": "Bahamas",
-          "birthCountryCode": "BS"
+          "birthCountryCode": "BS",
+          "groupRank": 1
         },
         {
           "personId": "1627741",
@@ -321,7 +334,8 @@
           "birthCity": "Freeport",
           "birthState": null,
           "birthCountry": "Bahamas",
-          "birthCountryCode": "BS"
+          "birthCountryCode": "BS",
+          "groupRank": 2
         },
         {
           "personId": "202375",
@@ -337,7 +351,8 @@
           "birthCity": "Freeport",
           "birthState": null,
           "birthCountry": "Bahamas",
-          "birthCountryCode": "BS"
+          "birthCountryCode": "BS",
+          "groupRank": 3
         }
       ]
     },
@@ -366,7 +381,8 @@
           "birthCity": "Bruges",
           "birthState": null,
           "birthCountry": "Belgium",
-          "birthCountryCode": "BE"
+          "birthCountryCode": "BE",
+          "groupRank": 1
         },
         {
           "personId": "1628373",
@@ -383,7 +399,8 @@
           "birthCity": "Ixelles",
           "birthState": null,
           "birthCountry": "Belgium",
-          "birthCountryCode": "BE"
+          "birthCountryCode": "BE",
+          "groupRank": 2
         },
         {
           "personId": "202333",
@@ -401,7 +418,8 @@
           "birthCity": "Ghent",
           "birthState": null,
           "birthCountry": "Belgium",
-          "birthCountryCode": "BE"
+          "birthCountryCode": "BE",
+          "groupRank": 3
         },
         {
           "personId": "40048",
@@ -414,7 +432,8 @@
           "birthCity": "Liège",
           "birthState": null,
           "birthCountry": "Belgium",
-          "birthCountryCode": "BE"
+          "birthCountryCode": "BE",
+          "groupRank": 4
         }
       ]
     },
@@ -447,7 +466,8 @@
           "birthCity": "Tuzla",
           "birthState": null,
           "birthCountry": "Bosnia and Herzegovina",
-          "birthCountryCode": "BA"
+          "birthCountryCode": "BA",
+          "groupRank": 1
         },
         {
           "personId": "1627826",
@@ -463,7 +483,8 @@
           "birthCity": "Mostar",
           "birthState": null,
           "birthCountry": "Bosnia and Herzegovina",
-          "birthCountryCode": "BA"
+          "birthCountryCode": "BA",
+          "groupRank": 2
         },
         {
           "personId": "1627733",
@@ -480,7 +501,8 @@
           "birthCity": "Caplijina",
           "birthState": null,
           "birthCountry": "Bosnia and Herzegovina",
-          "birthCountryCode": "BA"
+          "birthCountryCode": "BA",
+          "groupRank": 3
         },
         {
           "personId": "196294544",
@@ -493,7 +515,8 @@
           "birthCity": "Bihac",
           "birthState": null,
           "birthCountry": "Bosnia and Herzegovina",
-          "birthCountryCode": "BA"
+          "birthCountryCode": "BA",
+          "groupRank": 4
         },
         {
           "personId": "1962936525",
@@ -506,7 +529,8 @@
           "birthCity": "Mostar",
           "birthState": null,
           "birthCountry": "Bosnia and Herzegovina",
-          "birthCountryCode": "BA"
+          "birthCountryCode": "BA",
+          "groupRank": 5
         }
       ]
     },
@@ -541,7 +565,8 @@
           "birthCity": "São Paulo",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 1
         },
         {
           "personId": "201168",
@@ -558,7 +583,8 @@
           "birthCity": "Blumenau",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 2
         },
         {
           "personId": "203526",
@@ -576,7 +602,8 @@
           "birthCity": "Belo Horizonte",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 3
         },
         {
           "personId": "203512",
@@ -591,7 +618,8 @@
           "birthCity": "São Gonçalo",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 4
         },
         {
           "personId": "203097",
@@ -607,7 +635,8 @@
           "birthCity": "Juiz de Fora, Minas Gerais",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 5
         },
         {
           "personId": "196294585",
@@ -620,7 +649,8 @@
           "birthCity": "Osasco",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 6
         },
         {
           "personId": "43219",
@@ -633,7 +663,8 @@
           "birthCity": "Pouso Alegre",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 7
         },
         {
           "personId": "43216",
@@ -646,7 +677,8 @@
           "birthCity": "Rio de Janeiro",
           "birthState": null,
           "birthCountry": "Brazil",
-          "birthCountryCode": "BR"
+          "birthCountryCode": "BR",
+          "groupRank": 8
         }
       ]
     },
@@ -673,7 +705,8 @@
           "birthCity": "Yaounde",
           "birthState": null,
           "birthCountry": "Cameroon",
-          "birthCountryCode": "CM"
+          "birthCountryCode": "CM",
+          "groupRank": 1
         },
         {
           "personId": "1627783",
@@ -689,7 +722,8 @@
           "birthCity": "Douala",
           "birthState": null,
           "birthCountry": "Cameroon",
-          "birthCountryCode": "CM"
+          "birthCountryCode": "CM",
+          "groupRank": 2
         },
         {
           "personId": "201601",
@@ -709,7 +743,8 @@
           "birthCity": "Yaoundé",
           "birthState": null,
           "birthCountry": "Cameroon",
-          "birthCountryCode": "CM"
+          "birthCountryCode": "CM",
+          "groupRank": 3
         },
         {
           "personId": "2257",
@@ -727,7 +762,8 @@
           "birthCity": "Edéa",
           "birthState": null,
           "birthCountry": "Cameroon",
-          "birthCountryCode": "CM"
+          "birthCountryCode": "CM",
+          "groupRank": 4
         },
         {
           "personId": "267636",
@@ -740,7 +776,8 @@
           "birthCity": "Tiko",
           "birthState": null,
           "birthCountry": "Cameroon",
-          "birthCountryCode": "CM"
+          "birthCountryCode": "CM",
+          "groupRank": 5
         }
       ]
     },
@@ -769,7 +806,8 @@
           "birthCity": "Toronto",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 1
         },
         {
           "personId": "1627750",
@@ -784,7 +822,8 @@
           "birthCity": "Kitchener",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 2
         },
         {
           "personId": "203952",
@@ -801,7 +840,8 @@
           "birthCity": "Toronto",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 3
         },
         {
           "personId": "202709",
@@ -822,7 +862,8 @@
           "birthCity": "Pickering",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 4
         },
         {
           "personId": "203482",
@@ -843,7 +884,8 @@
           "birthCity": "Toronto",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 5
         },
         {
           "personId": "1629628",
@@ -859,7 +901,8 @@
           "birthCity": "Toronto",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 6
         },
         {
           "personId": "1628415",
@@ -875,7 +918,8 @@
           "birthCity": "Mississaugua",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 7
         },
         {
           "personId": "1629652",
@@ -890,7 +934,8 @@
           "birthCity": "Montreal",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 8
         },
         {
           "personId": "203939",
@@ -906,7 +951,8 @@
           "birthCity": "Toronto",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 9
         },
         {
           "personId": "1626168",
@@ -925,7 +971,8 @@
           "birthCity": "Saskatoon",
           "birthState": null,
           "birthCountry": "Canada",
-          "birthCountryCode": "CA"
+          "birthCountryCode": "CA",
+          "groupRank": 10
         }
       ]
     },
@@ -948,7 +995,8 @@
           "birthCity": "Bimbo",
           "birthState": null,
           "birthCountry": "Central African Republic",
-          "birthCountryCode": "CF"
+          "birthCountryCode": "CF",
+          "groupRank": 1
         }
       ]
     },
@@ -979,7 +1027,8 @@
           "birthCity": "Beijing",
           "birthState": null,
           "birthCountry": "China",
-          "birthCountryCode": "CN"
+          "birthCountryCode": "CN",
+          "groupRank": 1
         },
         {
           "personId": "1627753",
@@ -994,7 +1043,8 @@
           "birthCity": "Xinxiang, Henan",
           "birthState": null,
           "birthCountry": "China",
-          "birthCountryCode": "CN"
+          "birthCountryCode": "CN",
+          "groupRank": 2
         }
       ]
     },
@@ -1029,7 +1079,8 @@
           "birthCity": "Brazzaville",
           "birthState": null,
           "birthCountry": "Republic of the Congo",
-          "birthCountryCode": "CG"
+          "birthCountryCode": "CG",
+          "groupRank": 1
         }
       ]
     },
@@ -1068,7 +1119,8 @@
           "birthCity": "Kinshasa",
           "birthState": null,
           "birthCountry": "Democratic Republic of the Congo",
-          "birthCountryCode": "CD"
+          "birthCountryCode": "CD",
+          "groupRank": 1
         }
       ]
     },
@@ -1105,7 +1157,8 @@
           "birthCity": "Sibenik",
           "birthState": null,
           "birthCountry": "Croatia",
-          "birthCountryCode": "HR"
+          "birthCountryCode": "HR",
+          "groupRank": 1
         },
         {
           "personId": "1627790",
@@ -1120,7 +1173,8 @@
           "birthCity": "Split",
           "birthState": null,
           "birthCountry": "Croatia",
-          "birthCountryCode": "HR"
+          "birthCountryCode": "HR",
+          "groupRank": 2
         },
         {
           "personId": "1629677",
@@ -1137,7 +1191,8 @@
           "birthCity": "Zagreb",
           "birthState": null,
           "birthCountry": "Croatia",
-          "birthCountryCode": "HR"
+          "birthCountryCode": "HR",
+          "groupRank": 3
         },
         {
           "personId": "56024",
@@ -1150,7 +1205,8 @@
           "birthCity": "Dubrovnik",
           "birthState": null,
           "birthCountry": "Croatia",
-          "birthCountryCode": "HR"
+          "birthCountryCode": "HR",
+          "groupRank": 4
         }
       ]
     },
@@ -1177,7 +1233,8 @@
           "birthCity": "Nicosia",
           "birthState": null,
           "birthCountry": "Cyprus",
-          "birthCountryCode": "CY"
+          "birthCountryCode": "CY",
+          "groupRank": 1
         }
       ]
     },
@@ -1200,7 +1257,8 @@
           "birthCity": "Copenhagen",
           "birthState": null,
           "birthCountry": "Denmark",
-          "birthCountryCode": "DK"
+          "birthCountryCode": "DK",
+          "groupRank": 1
         }
       ]
     },
@@ -1233,7 +1291,8 @@
           "birthCity": "Puerto Plata",
           "birthState": null,
           "birthCountry": "Dominican Republic",
-          "birthCountryCode": "DO"
+          "birthCountryCode": "DO",
+          "groupRank": 1
         },
         {
           "personId": "2784",
@@ -1251,7 +1310,8 @@
           "birthCity": "San Pedro de Macoris",
           "birthState": null,
           "birthCountry": "Dominican Republic",
-          "birthCountryCode": "DO"
+          "birthCountryCode": "DO",
+          "groupRank": 2
         }
       ]
     },
@@ -1282,7 +1342,8 @@
           "birthCity": "Alexandria",
           "birthState": null,
           "birthCountry": "Egypt",
-          "birthCountryCode": "EG"
+          "birthCountryCode": "EG",
+          "groupRank": 1
         }
       ]
     },
@@ -1313,7 +1374,8 @@
           "birthCity": "Vantaa",
           "birthState": null,
           "birthCountry": "Finland",
-          "birthCountryCode": "FI"
+          "birthCountryCode": "FI",
+          "groupRank": 1
         }
       ]
     },
@@ -1348,7 +1410,8 @@
           "birthCity": "Paris",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 1
         },
         {
           "personId": "2564",
@@ -1367,7 +1430,8 @@
           "birthCity": "Cormeilles-en-Parisis, Val-d'Oise",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 2
         },
         {
           "personId": "203497",
@@ -1383,7 +1447,8 @@
           "birthCity": "Saint-Quentin",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 3
         },
         {
           "personId": "201587",
@@ -1401,7 +1466,8 @@
           "birthCity": "Lisieux",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 4
         },
         {
           "personId": "203095",
@@ -1420,7 +1486,8 @@
           "birthCity": "Saint-Quentin",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 5
         },
         {
           "personId": "101133",
@@ -1438,7 +1505,8 @@
           "birthCity": "Rouen",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 6
         },
         {
           "personId": "1505",
@@ -1456,7 +1524,8 @@
           "birthCity": "Maisons-Alfort, Val-de-Marne",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 7
         },
         {
           "personId": "1627789",
@@ -1477,7 +1546,8 @@
           "birthCity": "Cannes",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 8
         },
         {
           "personId": "101130",
@@ -1496,7 +1566,8 @@
           "birthCity": "Paris",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 9
         },
         {
           "personId": "203530",
@@ -1514,7 +1585,8 @@
           "birthCity": "Mulhouse",
           "birthState": null,
           "birthCountry": "France",
-          "birthCountryCode": "FR"
+          "birthCountryCode": "FR",
+          "groupRank": 10
         }
       ]
     },
@@ -1543,7 +1615,8 @@
           "birthCity": "Cayenne",
           "birthState": null,
           "birthCountry": "French Guiana",
-          "birthCountryCode": "GF"
+          "birthCountryCode": "GF",
+          "groupRank": 1
         },
         {
           "personId": "203520",
@@ -1558,7 +1631,8 @@
           "birthCity": "Cayenne",
           "birthState": null,
           "birthCountry": "French Guiana",
-          "birthCountryCode": "GF"
+          "birthCountryCode": "GF",
+          "groupRank": 2
         }
       ]
     },
@@ -1593,7 +1667,8 @@
           "birthCity": "Libreville",
           "birthState": null,
           "birthCountry": "Gabon",
-          "birthCountryCode": "GA"
+          "birthCountryCode": "GA",
+          "groupRank": 1
         },
         {
           "personId": "41629",
@@ -1606,7 +1681,8 @@
           "birthCity": "Port-Gentil",
           "birthState": null,
           "birthCountry": "Gabon",
-          "birthCountryCode": "GA"
+          "birthCountryCode": "GA",
+          "groupRank": 2
         }
       ]
     },
@@ -1645,7 +1721,8 @@
           "birthCity": "Atlanta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 1
         },
         {
           "personId": "2746",
@@ -1664,7 +1741,8 @@
           "birthCity": "College Park",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 2
         },
         {
           "personId": "1627759",
@@ -1679,7 +1757,8 @@
           "birthCity": "Marietta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 3
         },
         {
           "personId": "949",
@@ -1697,7 +1776,8 @@
           "birthCity": "Marietta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 4
         },
         {
           "personId": "203109",
@@ -1720,7 +1800,8 @@
           "birthCity": "Villa Rica",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 5
         },
         {
           "personId": "203484",
@@ -1739,7 +1820,8 @@
           "birthCity": "Thomaston",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 6
         },
         {
           "personId": "1627763",
@@ -1758,7 +1840,8 @@
           "birthCity": "Atlanta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 7
         },
         {
           "personId": "1000",
@@ -1776,7 +1859,8 @@
           "birthCity": "Atlanta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 8
         },
         {
           "personId": "202324",
@@ -1796,7 +1880,8 @@
           "birthCity": "Atlanta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 9
         },
         {
           "personId": "202329",
@@ -1819,7 +1904,8 @@
           "birthCity": "Atlanta",
           "birthState": null,
           "birthCountry": "Georgia",
-          "birthCountryCode": "GE"
+          "birthCountryCode": "GE",
+          "groupRank": 10
         }
       ]
     },
@@ -1862,7 +1948,8 @@
           "birthCity": "Braunschweig",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 1
         },
         {
           "personId": "1628464",
@@ -1882,7 +1969,8 @@
           "birthCity": "Salzgitter",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 2
         },
         {
           "personId": "1628467",
@@ -1898,7 +1986,8 @@
           "birthCity": "Wurzburg",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 3
         },
         {
           "personId": "201195",
@@ -1913,7 +2002,8 @@
           "birthCity": "Ulm",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 4
         },
         {
           "personId": "1629067",
@@ -1930,7 +2020,8 @@
           "birthCity": "Neuwied",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 5
         },
         {
           "personId": "1627835",
@@ -1945,7 +2036,8 @@
           "birthCity": "Heidelberg",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 6
         },
         {
           "personId": "203528",
@@ -1960,7 +2052,8 @@
           "birthCity": "Frankfurt",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 7
         },
         {
           "personId": "43224",
@@ -1973,7 +2066,8 @@
           "birthCity": "Berlin",
           "birthState": null,
           "birthCountry": "Germany",
-          "birthCountryCode": "DE"
+          "birthCountryCode": "DE",
+          "groupRank": 8
         }
       ]
     },
@@ -2002,7 +2096,8 @@
           "birthCity": "Sekondi-Takoradi",
           "birthState": null,
           "birthCountry": "Ghana",
-          "birthCountryCode": "GH"
+          "birthCountryCode": "GH",
+          "groupRank": 1
         }
       ]
     },
@@ -2029,7 +2124,8 @@
           "birthCity": "Athens",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 1
         },
         {
           "personId": "203648",
@@ -2045,7 +2141,8 @@
           "birthCity": "Athens",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 2
         },
         {
           "personId": "203123",
@@ -2061,7 +2158,8 @@
           "birthCity": "Trikala",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 3
         },
         {
           "personId": "1627834",
@@ -2077,7 +2175,8 @@
           "birthCity": "Marousi",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 4
         },
         {
           "personId": "1628961",
@@ -2094,7 +2193,8 @@
           "birthCity": "Athens",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 5
         },
         {
           "personId": "981",
@@ -2109,7 +2209,8 @@
           "birthCity": "Trikala",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 6
         },
         {
           "personId": "2779",
@@ -2124,7 +2225,8 @@
           "birthCity": "Larissa",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 7
         },
         {
           "personId": "2238",
@@ -2139,7 +2241,8 @@
           "birthCity": "Maroussi",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 8
         },
         {
           "personId": "267625",
@@ -2152,7 +2255,8 @@
           "birthCity": "Chania",
           "birthState": null,
           "birthCountry": "Greece",
-          "birthCountryCode": "GR"
+          "birthCountryCode": "GR",
+          "groupRank": 9
         }
       ]
     },
@@ -2183,7 +2287,8 @@
           "birthCity": "Conakry",
           "birthState": null,
           "birthCountry": "Guinea",
-          "birthCountryCode": "GN"
+          "birthCountryCode": "GN",
+          "groupRank": 1
         }
       ]
     },
@@ -2220,7 +2325,8 @@
           "birthCity": "Port-au-Prince",
           "birthState": null,
           "birthCountry": "Haiti",
-          "birthCountryCode": "HT"
+          "birthCountryCode": "HT",
+          "groupRank": 1
         },
         {
           "personId": "1627746",
@@ -2237,7 +2343,8 @@
           "birthCity": "Port-au-Prince",
           "birthState": null,
           "birthCountry": "Haiti",
-          "birthCountryCode": "HT"
+          "birthCountryCode": "HT",
+          "groupRank": 2
         }
       ]
     },
@@ -2266,7 +2373,8 @@
           "birthCity": "Isfahan",
           "birthState": null,
           "birthCountry": "Iran",
-          "birthCountryCode": "IR"
+          "birthCountryCode": "IR",
+          "groupRank": 1
         }
       ]
     },
@@ -2297,7 +2405,8 @@
           "birthCity": "Dublin",
           "birthState": null,
           "birthCountry": "Ireland",
-          "birthCountryCode": "IE"
+          "birthCountryCode": "IE",
+          "groupRank": 1
         }
       ]
     },
@@ -2320,7 +2429,8 @@
           "birthCity": "Ramat Gan",
           "birthState": null,
           "birthCountry": "Israel",
-          "birthCountryCode": "IL"
+          "birthCountryCode": "IL",
+          "groupRank": 1
         },
         {
           "personId": "551",
@@ -2333,7 +2443,8 @@
           "birthCity": "Holon",
           "birthState": null,
           "birthCountry": "Israel",
-          "birthCountryCode": "IL"
+          "birthCountryCode": "IL",
+          "groupRank": 2
         },
         {
           "personId": "572",
@@ -2346,7 +2457,8 @@
           "birthCity": "Tel Aviv",
           "birthState": null,
           "birthCountry": "Israel",
-          "birthCountryCode": "IL"
+          "birthCountryCode": "IL",
+          "groupRank": 3
         }
       ]
     },
@@ -2381,7 +2493,8 @@
           "birthCity": "Pordenone",
           "birthState": null,
           "birthCountry": "Italy",
-          "birthCountryCode": "IT"
+          "birthCountryCode": "IT",
+          "groupRank": 1
         },
         {
           "personId": "201568",
@@ -2404,7 +2517,8 @@
           "birthCity": "Saint'Angelo Lodigiano",
           "birthState": null,
           "birthCountry": "Italy",
-          "birthCountryCode": "IT"
+          "birthCountryCode": "IT",
+          "groupRank": 2
         },
         {
           "personId": "201158",
@@ -2427,7 +2541,8 @@
           "birthCity": "San Giovanni in Persiceto",
           "birthState": null,
           "birthCountry": "Italy",
-          "birthCountryCode": "IT"
+          "birthCountryCode": "IT",
+          "groupRank": 3
         },
         {
           "personId": "200745",
@@ -2444,7 +2559,8 @@
           "birthCity": "Rome",
           "birthState": null,
           "birthCountry": "Italy",
-          "birthCountryCode": "IT"
+          "birthCountryCode": "IT",
+          "groupRank": 4
         },
         {
           "personId": "56043",
@@ -2457,7 +2573,8 @@
           "birthCity": "Maddaloni",
           "birthState": null,
           "birthCountry": "Italy",
-          "birthCountryCode": "IT"
+          "birthCountryCode": "IT",
+          "groupRank": 5
         },
         {
           "personId": "56040",
@@ -2470,7 +2587,8 @@
           "birthCity": "Reggio Emilia",
           "birthState": null,
           "birthCountry": "Italy",
-          "birthCountryCode": "IT"
+          "birthCountryCode": "IT",
+          "groupRank": 6
         }
       ]
     },
@@ -2503,7 +2621,8 @@
           "birthCity": "Kingston",
           "birthState": null,
           "birthCountry": "Jamaica",
-          "birthCountryCode": "JM"
+          "birthCountryCode": "JM",
+          "groupRank": 1
         },
         {
           "personId": "201607",
@@ -2519,7 +2638,8 @@
           "birthCity": "Kingston",
           "birthState": null,
           "birthCountry": "Jamaica",
-          "birthCountryCode": "JM"
+          "birthCountryCode": "JM",
+          "groupRank": 2
         }
       ]
     },
@@ -2548,7 +2668,8 @@
           "birthCity": "Toyama",
           "birthState": null,
           "birthCountry": "Japan",
-          "birthCountryCode": "JP"
+          "birthCountryCode": "JP",
+          "groupRank": 1
         },
         {
           "personId": "1629139",
@@ -2566,7 +2687,8 @@
           "birthCity": "Yokohama",
           "birthState": null,
           "birthCountry": "Japan",
-          "birthCountryCode": "JP"
+          "birthCountryCode": "JP",
+          "groupRank": 2
         }
       ]
     },
@@ -2599,7 +2721,8 @@
           "birthCity": "Liepaja",
           "birthState": null,
           "birthCountry": "Latvia",
-          "birthCountryCode": "LV"
+          "birthCountryCode": "LV",
+          "groupRank": 1
         },
         {
           "personId": "202722",
@@ -2618,7 +2741,8 @@
           "birthCity": "Rujiena",
           "birthState": null,
           "birthCountry": "Latvia",
-          "birthCountryCode": "LV"
+          "birthCountryCode": "LV",
+          "groupRank": 2
         },
         {
           "personId": "1628394",
@@ -2634,7 +2758,8 @@
           "birthCity": "Riga",
           "birthState": null,
           "birthCountry": "Latvia",
-          "birthCountryCode": "LV"
+          "birthCountryCode": "LV",
+          "groupRank": 3
         }
       ]
     },
@@ -2669,7 +2794,8 @@
           "birthCity": "Utena",
           "birthState": null,
           "birthCountry": "Lithuania",
-          "birthCountryCode": "LT"
+          "birthCountryCode": "LT",
+          "groupRank": 1
         }
       ]
     },
@@ -2696,7 +2822,8 @@
           "birthCity": "Luxembourg",
           "birthState": null,
           "birthCountry": "Luxembourg",
-          "birthCountryCode": "LU"
+          "birthCountryCode": "LU",
+          "groupRank": 1
         }
       ]
     },
@@ -2729,7 +2856,8 @@
           "birthCity": "Kayes",
           "birthState": null,
           "birthCountry": "Mali",
-          "birthCountryCode": "ML"
+          "birthCountryCode": "ML",
+          "groupRank": 1
         },
         {
           "personId": "2066",
@@ -2745,7 +2873,8 @@
           "birthCity": "Bougouni",
           "birthState": null,
           "birthCountry": "Mali",
-          "birthCountryCode": "ML"
+          "birthCountryCode": "ML",
+          "groupRank": 2
         }
       ]
     },
@@ -2786,7 +2915,8 @@
           "birthCity": "Fort-de-France",
           "birthState": null,
           "birthCountry": "Martinique",
-          "birthCountryCode": "MQ"
+          "birthCountryCode": "MQ",
+          "groupRank": 1
         }
       ]
     },
@@ -2823,7 +2953,8 @@
           "birthCity": "Rotterdam",
           "birthState": null,
           "birthCountry": "Netherlands",
-          "birthCountryCode": "NL"
+          "birthCountryCode": "NL",
+          "groupRank": 1
         },
         {
           "personId": "2429",
@@ -2842,7 +2973,8 @@
           "birthCity": "The Hague",
           "birthState": null,
           "birthCountry": "Netherlands",
-          "birthCountryCode": "NL"
+          "birthCountryCode": "NL",
+          "groupRank": 2
         }
       ]
     },
@@ -2875,7 +3007,8 @@
           "birthCity": "Rotorua",
           "birthState": null,
           "birthCountry": "New Zealand",
-          "birthCountryCode": "NZ"
+          "birthCountryCode": "NZ",
+          "groupRank": 1
         },
         {
           "personId": "203382",
@@ -2894,7 +3027,8 @@
           "birthCity": "Gisborne",
           "birthState": null,
           "birthCountry": "New Zealand",
-          "birthCountryCode": "NZ"
+          "birthCountryCode": "NZ",
+          "groupRank": 2
         },
         {
           "personId": "1752",
@@ -2915,7 +3049,8 @@
           "birthCity": "Auckland",
           "birthState": null,
           "birthCountry": "New Zealand",
-          "birthCountryCode": "NZ"
+          "birthCountryCode": "NZ",
+          "groupRank": 3
         }
       ]
     },
@@ -2944,7 +3079,8 @@
           "birthCity": "Lagos",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 1
         },
         {
           "personId": "1709",
@@ -2961,7 +3097,8 @@
           "birthCity": "Lagos",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 2
         },
         {
           "personId": "203105",
@@ -2977,7 +3114,8 @@
           "birthCity": "Benin City",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 3
         },
         {
           "personId": "1629006",
@@ -2994,7 +3132,8 @@
           "birthCity": "Lagos",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 4
         },
         {
           "personId": "1918",
@@ -3014,7 +3153,8 @@
           "birthCity": "Port Harcourt, Rivers State",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 5
         },
         {
           "personId": "202374",
@@ -3030,7 +3170,8 @@
           "birthCity": "Kaduna",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 6
         },
         {
           "personId": "2071",
@@ -3046,7 +3187,8 @@
           "birthCity": "Ibadan, Oyo State",
           "birthState": null,
           "birthCountry": "Nigeria",
-          "birthCountryCode": "NG"
+          "birthCountryCode": "NG",
+          "groupRank": 7
         }
       ]
     },
@@ -3079,7 +3221,8 @@
           "birthCity": "Łódź",
           "birthState": null,
           "birthCountry": "Poland",
-          "birthCountryCode": "PL"
+          "birthCountryCode": "PL",
+          "groupRank": 1
         },
         {
           "personId": "41631",
@@ -3092,7 +3235,8 @@
           "birthCity": "Łódź",
           "birthState": null,
           "birthCountry": "Poland",
-          "birthCountryCode": "PL"
+          "birthCountryCode": "PL",
+          "groupRank": 2
         }
       ]
     },
@@ -3121,7 +3265,8 @@
           "birthCity": "Mayaguez",
           "birthState": null,
           "birthCountry": "Puerto Rico",
-          "birthCountryCode": "PR"
+          "birthCountryCode": "PR",
+          "groupRank": 1
         },
         {
           "personId": "2306",
@@ -3142,7 +3287,8 @@
           "birthCity": "Fajardo",
           "birthState": null,
           "birthCountry": "Puerto Rico",
-          "birthCountryCode": "PR"
+          "birthCountryCode": "PR",
+          "groupRank": 2
         },
         {
           "personId": "2762",
@@ -3157,7 +3303,8 @@
           "birthCity": "Fajardo",
           "birthState": null,
           "birthCountry": "Puerto Rico",
-          "birthCountryCode": "PR"
+          "birthCountryCode": "PR",
+          "groupRank": 3
         },
         {
           "personId": "200799",
@@ -3172,7 +3319,8 @@
           "birthCity": "San Juan",
           "birthState": null,
           "birthCountry": "Puerto Rico",
-          "birthCountryCode": "PR"
+          "birthCountryCode": "PR",
+          "groupRank": 4
         }
       ]
     },
@@ -3201,7 +3349,8 @@
           "birthCity": "Kaunas, Lithuanian SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 1
         },
         {
           "personId": "1905",
@@ -3218,7 +3367,8 @@
           "birthCity": "Izhevsk, Russian SFSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 2
         },
         {
           "personId": "2585",
@@ -3238,7 +3388,8 @@
           "birthCity": "Tbilisi, Georgian SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 3
         },
         {
           "personId": "958",
@@ -3256,7 +3407,8 @@
           "birthCity": "Kiev, Ukrainian SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 4
         },
         {
           "personId": "2443",
@@ -3275,7 +3427,8 @@
           "birthCity": "Marijampolė, Lithuanian SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 5
         },
         {
           "personId": "2401",
@@ -3295,7 +3448,8 @@
           "birthCity": "Tbilisi, Georgia SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 6
         },
         {
           "personId": "2751",
@@ -3311,7 +3465,8 @@
           "birthCity": "Kiev, Ukrainian SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 7
         },
         {
           "personId": "101117",
@@ -3326,7 +3481,8 @@
           "birthCity": "Moscow, Russian SFSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 8
         },
         {
           "personId": "2752",
@@ -3342,7 +3498,8 @@
           "birthCity": "Saratov, Russian SFSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 9
         },
         {
           "personId": "42536",
@@ -3355,7 +3512,8 @@
           "birthCity": "Kaunas, Lithuanian SSR",
           "birthState": null,
           "birthCountry": "Soviet Union",
-          "birthCountryCode": "RU"
+          "birthCountryCode": "RU",
+          "groupRank": 10
         }
       ]
     },
@@ -3384,7 +3542,8 @@
           "birthCity": "Castries",
           "birthState": null,
           "birthCountry": "Saint Lucia",
-          "birthCountryCode": "LC"
+          "birthCountryCode": "LC",
+          "groupRank": 1
         }
       ]
     },
@@ -3415,7 +3574,8 @@
           "birthCity": "Canouan, Saint Vincent",
           "birthState": null,
           "birthCountry": "Saint Vincent and the Grenadines",
-          "birthCountryCode": "VC"
+          "birthCountryCode": "VC",
+          "groupRank": 1
         }
       ]
     },
@@ -3448,7 +3608,8 @@
           "birthCity": "Kebemer",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 1
         },
         {
           "personId": "2205",
@@ -3466,7 +3627,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 2
         },
         {
           "personId": "2055",
@@ -3486,7 +3648,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 3
         },
         {
           "personId": "2776",
@@ -3501,7 +3664,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 4
         },
         {
           "personId": "200754",
@@ -3518,7 +3682,8 @@
           "birthCity": "Thiès",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 5
         },
         {
           "personId": "202380",
@@ -3534,7 +3699,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 6
         },
         {
           "personId": "2587",
@@ -3549,7 +3715,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 7
         },
         {
           "personId": "41549",
@@ -3562,7 +3729,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 8
         },
         {
           "personId": "196295070",
@@ -3575,7 +3743,8 @@
           "birthCity": "Dakar",
           "birthState": null,
           "birthCountry": "Senegal",
-          "birthCountryCode": "SN"
+          "birthCountryCode": "SN",
+          "groupRank": 9
         }
       ]
     },
@@ -3608,7 +3777,8 @@
           "birthCity": "Prijepolje",
           "birthState": null,
           "birthCountry": "Serbia",
-          "birthCountryCode": "RS"
+          "birthCountryCode": "RS",
+          "groupRank": 1
         }
       ]
     },
@@ -3635,7 +3805,8 @@
           "birthCity": "Koper",
           "birthState": null,
           "birthCountry": "Slovenia",
-          "birthCountryCode": "SI"
+          "birthCountryCode": "SI",
+          "groupRank": 1
         }
       ]
     },
@@ -3666,7 +3837,8 @@
           "birthCity": "Johannesburg",
           "birthState": null,
           "birthCountry": "South Africa",
-          "birthCountryCode": "ZA"
+          "birthCountryCode": "ZA",
+          "groupRank": 1
         }
       ]
     },
@@ -3703,7 +3875,8 @@
           "birthCity": "Barcelona",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 1
         },
         {
           "personId": "201188",
@@ -3720,7 +3893,8 @@
           "birthCity": "Barcelona",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 2
         },
         {
           "personId": "1887",
@@ -3738,7 +3912,8 @@
           "birthCity": "Madrid",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 3
         },
         {
           "personId": "1626195",
@@ -3755,7 +3930,8 @@
           "birthCity": "Madrid",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 4
         },
         {
           "personId": "56078",
@@ -3768,7 +3944,8 @@
           "birthCity": "Badalona",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 5
         },
         {
           "personId": "8010",
@@ -3781,7 +3958,8 @@
           "birthCity": "Sant Feliu de Llobregat",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 6
         },
         {
           "personId": "8013",
@@ -3794,7 +3972,8 @@
           "birthCity": "El Masnou",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 7
         },
         {
           "personId": "56056",
@@ -3807,7 +3986,8 @@
           "birthCity": "MahÃ³n, Balearic Islands",
           "birthState": null,
           "birthCountry": "Spain",
-          "birthCountryCode": "ES"
+          "birthCountryCode": "ES",
+          "groupRank": 8
         }
       ]
     },
@@ -3840,7 +4020,8 @@
           "birthCity": "Wau",
           "birthState": null,
           "birthCountry": "Sudan",
-          "birthCountryCode": "SD"
+          "birthCountryCode": "SD",
+          "groupRank": 1
         },
         {
           "personId": "1629626",
@@ -3857,7 +4038,8 @@
           "birthCity": "Khartoum",
           "birthState": null,
           "birthCountry": "Sudan",
-          "birthCountryCode": "SD"
+          "birthCountryCode": "SD",
+          "groupRank": 2
         },
         {
           "personId": "1966938185",
@@ -3870,7 +4052,8 @@
           "birthCity": "Khartoum",
           "birthState": null,
           "birthCountry": "Sudan",
-          "birthCountryCode": "SD"
+          "birthCountryCode": "SD",
+          "groupRank": 3
         }
       ]
     },
@@ -3903,7 +4086,8 @@
           "birthCity": "Kinna",
           "birthState": null,
           "birthCountry": "Sweden",
-          "birthCountryCode": "SE"
+          "birthCountryCode": "SE",
+          "groupRank": 1
         },
         {
           "personId": "203106",
@@ -3918,7 +4102,8 @@
           "birthCity": "Norrköping",
           "birthState": null,
           "birthCountry": "Sweden",
-          "birthCountryCode": "SE"
+          "birthCountryCode": "SE",
+          "groupRank": 2
         },
         {
           "personId": "1750",
@@ -3933,7 +4118,8 @@
           "birthCity": "Stockholm",
           "birthState": null,
           "birthCountry": "Sweden",
-          "birthCountryCode": "SE"
+          "birthCountryCode": "SE",
+          "groupRank": 3
         }
       ]
     },
@@ -3964,7 +4150,8 @@
           "birthCity": "Morges",
           "birthState": null,
           "birthCountry": "Switzerland",
-          "birthCountryCode": "CH"
+          "birthCountryCode": "CH",
+          "groupRank": 1
         },
         {
           "personId": "203991",
@@ -3980,7 +4167,8 @@
           "birthCity": "Geneva",
           "birthState": null,
           "birthCountry": "Switzerland",
-          "birthCountryCode": "CH"
+          "birthCountryCode": "CH",
+          "groupRank": 2
         },
         {
           "personId": "200757",
@@ -3999,7 +4187,8 @@
           "birthCity": "Vevey",
           "birthState": null,
           "birthCountry": "Switzerland",
-          "birthCountryCode": "CH"
+          "birthCountryCode": "CH",
+          "groupRank": 3
         }
       ]
     },
@@ -4030,7 +4219,8 @@
           "birthCity": "Kaohsiung",
           "birthState": null,
           "birthCountry": "Taiwan",
-          "birthCountryCode": "TW"
+          "birthCountryCode": "TW",
+          "groupRank": 1
         }
       ]
     },
@@ -4065,7 +4255,8 @@
           "birthCity": "Dar es Salaam",
           "birthState": null,
           "birthCountry": "Tanzania",
-          "birthCountryCode": "TZ"
+          "birthCountryCode": "TZ",
+          "groupRank": 1
         }
       ]
     },
@@ -4102,7 +4293,8 @@
           "birthCity": "Antratsyt",
           "birthState": null,
           "birthCountry": "Ukraine",
-          "birthCountryCode": "UA"
+          "birthCountryCode": "UA",
+          "groupRank": 1
         },
         {
           "personId": "1627762",
@@ -4118,7 +4310,8 @@
           "birthCity": "Donetsk",
           "birthState": null,
           "birthCountry": "Ukraine",
-          "birthCountryCode": "UA"
+          "birthCountryCode": "UA",
+          "groupRank": 2
         }
       ]
     },
@@ -4147,7 +4340,8 @@
           "birthCity": "London",
           "birthState": null,
           "birthCountry": "England",
-          "birthCountryCode": "GB"
+          "birthCountryCode": "GB",
+          "groupRank": 1
         },
         {
           "personId": "2732",
@@ -4166,7 +4360,8 @@
           "birthCity": "London",
           "birthState": null,
           "birthCountry": "England",
-          "birthCountryCode": "GB"
+          "birthCountryCode": "GB",
+          "groupRank": 2
         },
         {
           "personId": "200777",
@@ -4181,7 +4376,8 @@
           "birthCity": "Aldershot, Hampshire",
           "birthState": null,
           "birthCountry": "England",
-          "birthCountryCode": "GB"
+          "birthCountryCode": "GB",
+          "groupRank": 3
         },
         {
           "personId": "1629678",
@@ -4198,7 +4394,8 @@
           "birthCity": "London",
           "birthState": null,
           "birthCountry": "England",
-          "birthCountryCode": "GB"
+          "birthCountryCode": "GB",
+          "groupRank": 4
         },
         {
           "personId": "2425",
@@ -4216,7 +4413,8 @@
           "birthCity": "Paisley, Renfrewshire",
           "birthState": null,
           "birthCountry": "Scotland",
-          "birthCountryCode": "GB"
+          "birthCountryCode": "GB",
+          "groupRank": 5
         },
         {
           "personId": "2569",
@@ -4232,7 +4430,8 @@
           "birthCity": "London",
           "birthState": null,
           "birthCountry": "England",
-          "birthCountryCode": "GB"
+          "birthCountryCode": "GB",
+          "groupRank": 6
         }
       ]
     },
@@ -4263,7 +4462,8 @@
           "birthCity": "Akron",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 1
         },
         {
           "personId": "893",
@@ -4279,7 +4479,8 @@
           "birthCity": "Brooklyn",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 2
         },
         {
           "personId": "76003",
@@ -4295,7 +4496,8 @@
           "birthCity": "New York City",
           "birthState": "NY",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 3
         },
         {
           "personId": "77142",
@@ -4310,7 +4512,8 @@
           "birthCity": "Lansing",
           "birthState": "MI",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 4
         },
         {
           "personId": "78049",
@@ -4325,7 +4528,8 @@
           "birthCity": "Monroe",
           "birthState": "LA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 5
         },
         {
           "personId": "201939",
@@ -4340,7 +4544,8 @@
           "birthCity": "Akron",
           "birthState": "OH",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 6
         },
         {
           "personId": "406",
@@ -4360,7 +4565,8 @@
           "birthCity": "Newark",
           "birthState": "NJ",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 7
         },
         {
           "personId": "203999",
@@ -4375,7 +4581,8 @@
           "birthCity": "Sombor",
           "birthState": null,
           "birthCountry": "Serbia (FRMR Yugoslavia)",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 8
         },
         {
           "personId": "1449",
@@ -4390,7 +4597,8 @@
           "birthCity": "West Baden Springs",
           "birthState": "IN",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 9
         },
         {
           "personId": "76375",
@@ -4408,7 +4616,8 @@
           "birthCity": "Philadelphia",
           "birthState": "PA",
           "birthCountry": "United States",
-          "birthCountryCode": "US"
+          "birthCountryCode": "US",
+          "groupRank": 10
         }
       ]
     },
@@ -4435,7 +4644,8 @@
           "birthCity": "Saint Croix",
           "birthState": null,
           "birthCountry": "U.S. Virgin Islands",
-          "birthCountryCode": "VI"
+          "birthCountryCode": "VI",
+          "groupRank": 1
         }
       ]
     }

--- a/public/scripts/history.js
+++ b/public/scripts/history.js
@@ -323,11 +323,15 @@ function renderAtlasSpotlight(entry, config = activeAtlasConfig) {
       body.append(nameLine);
 
       const detailParts = [];
+      if (typeof player.groupRank === 'number') {
+        const scopeLabel = modeConfig.id === 'domestic' ? 'State' : 'Country';
+        detailParts.push(`${scopeLabel} rank #${player.groupRank}`);
+      }
       if (typeof player.rank === 'number') {
-        detailParts.push(`GOAT No. ${player.rank}`);
+        detailParts.push(`Global GOAT No. ${player.rank}`);
       }
       if (typeof player.goatScore === 'number') {
-        detailParts.push(`${scoreFormatter.format(player.goatScore)} GOAT score`);
+        detailParts.push(`${scoreFormatter.format(player.goatScore)} GOAT points`);
       }
       const birthplace = formatLocation(player);
       if (birthplace) {

--- a/tests/test_goat_birth_index.py
+++ b/tests/test_goat_birth_index.py
@@ -1,0 +1,82 @@
+import json
+from math import isfinite
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "public" / "data"
+
+
+@pytest.fixture(scope="module")
+def goat_index():
+    path = DATA_DIR / "goat_birth_index.json"
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture(scope="module")
+def state_legends():
+    path = DATA_DIR / "state_birth_legends.json"
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@pytest.fixture(scope="module")
+def world_legends():
+    path = DATA_DIR / "world_birth_legends.json"
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_goat_birth_index_rank_order(goat_index):
+    players = goat_index.get("players", [])
+    assert players, "GOAT index payload should include players"
+
+    previous_score = float("inf")
+    for position, player in enumerate(players, start=1):
+        assert player["rank"] == position
+        score = player["goatScore"]
+        assert isinstance(score, (int, float)) and isfinite(score)
+        assert score <= 100
+        assert score <= previous_score + 1e-9
+        previous_score = score
+
+
+def _assert_top_group(entries: list[dict]) -> None:
+    assert len(entries) <= 10
+    previous_score = float("inf")
+    for idx, entry in enumerate(entries, start=1):
+        assert entry.get("groupRank") == idx
+        score = entry.get("goatScore")
+        assert isinstance(score, (int, float)) and isfinite(score)
+        assert score <= previous_score + 1e-9
+        previous_score = score
+        franchises = entry.get("franchises") or []
+        assert all(isinstance(team, str) and team for team in franchises)
+
+
+def test_state_legends_top_players(state_legends):
+    states = state_legends.get("states", [])
+    assert states, "State legends payload should include entries"
+    for state in states:
+        top_players = state.get("topPlayers") or []
+        _assert_top_group(top_players)
+
+    michigan = next((item for item in states if item.get("state") == "MI"), None)
+    assert michigan is not None
+    assert michigan["topPlayers"][0]["name"] == "Magic Johnson"
+    assert michigan["topPlayers"][0]["goatScore"] > 80
+
+
+def test_world_legends_top_players(world_legends):
+    countries = world_legends.get("countries", [])
+    assert countries, "World legends payload should include entries"
+    for country in countries:
+        top_players = country.get("topPlayers") or []
+        _assert_top_group(top_players)
+
+    virgin_islands = next((item for item in countries if item.get("country") == "VI"), None)
+    assert virgin_islands is not None
+    assert virgin_islands["topPlayers"][0]["name"] == "Tim Duncan"
+    assert virgin_islands["topPlayers"][0]["goatScore"] > 80


### PR DESCRIPTION
## Summary
- normalize GOAT score ingestion and group birth legends by score so state and country top 10 lists stay accurate
- regenerate GOAT birth datasets with per-region ranks and clearer detail labels for the atlas spotlight
- add regression tests covering GOAT index ordering and birth legend payload structure

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8c2441f348327bd3009ab01269d88