### PR TITLE
Fix Spurs legacy data for franchise footprint

### DIFF
--- a/public/data/team_profiles.json
+++ b/public/data/team_profiles.json
@@ -806,7 +806,11 @@
       },
       "gamesSampled": 86,
       "wins": 36,
-      "losses": 50
+      "losses": 50,
+      "legacy": {
+        "titles": 5,
+        "hallOfFamers": 8
+      }
     },
     {
       "abbreviation": "TOR",


### PR DESCRIPTION
## Summary
- add missing legacy data for the San Antonio Spurs franchise in the team profiles dataset so their footprint score reflects championships and Hall of Fame alumni

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8c9306be0832781f8520c1794b2a1