### PR TITLE
Update AGENTS guidelines for season context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,5 @@
 - Run `ruff check .` and `pytest` before submitting changes that touch Python code.
 - Keep helper scripts importable (avoid top-level work at import time) so they stay testable.
 - Use UTF-8 encoding for text files and include trailing newlines.
+- Treat the 2025-2026 NBA season as the current active season and the 2024-2025 campaign as the most recent completed season; ensure all data summaries, visualizations, and narratives call out this distinction explicitly.
+- Never add or commit binary files to the repository.


### PR DESCRIPTION
## Summary
- clarify the repository guidelines so 2025-2026 is treated as the active season and 2024-2025 as the prior campaign
- note that all data presentations must highlight the current vs. prior season distinction
- prohibit adding or committing binary files

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d967ef037083279705aff789123388