### PR TITLE
Add dual GOAT scoring to player scouting atlas

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -89,8 +89,27 @@
                   <p class="player-card__meta" data-player-meta></p>
                 </div>
                 <div class="player-card__goat">
-                  <span class="player-card__goat-label">GOAT score</span>
-                  <span class="player-card__goat-value" data-player-goat>—</span>
+                  <span class="player-card__goat-label">GOAT scores</span>
+                  <div class="player-card__goat-grid">
+                    <div class="player-card__goat-entry">
+                      <span
+                        class="player-card__goat-value"
+                        data-player-goat-recent
+                        aria-label="GOAT score over the last three seasons"
+                        >—</span
+                      >
+                      <span class="player-card__goat-context">Last 3 seasons (2022-23 to 2024-25)</span>
+                    </div>
+                    <div class="player-card__goat-entry">
+                      <span
+                        class="player-card__goat-value"
+                        data-player-goat-historic
+                        aria-label="Career GOAT score"
+                        >—</span
+                      >
+                      <span class="player-card__goat-context">All-time GOAT resume</span>
+                    </div>
+                  </div>
                 </div>
               </header>
               <div class="player-card__body">

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -4024,13 +4024,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-card__meta { margin: 0; font-size: 0.95rem; color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%); }
 .player-card__goat {
   display: grid;
-  gap: 0.2rem;
-  align-items: center;
-  justify-items: end;
+  gap: 0.45rem;
+  align-items: start;
+  justify-items: stretch;
   padding: 0.65rem 0.85rem;
   border-radius: var(--radius-md);
   background: linear-gradient(140deg, rgba(17, 86, 214, 0.16), rgba(244, 181, 63, 0.18));
-  min-width: 120px;
+  min-width: 220px;
 }
 .player-card__goat-label {
   font-size: 0.72rem;
@@ -4038,10 +4038,25 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   letter-spacing: 0.12em;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
+.player-card__goat-grid {
+  display: grid;
+  gap: 0.65rem;
+}
+.player-card__goat-entry {
+  display: grid;
+  gap: 0.2rem;
+  justify-items: end;
+}
 .player-card__goat-value {
   font-size: clamp(1.5rem, 3vw, 1.9rem);
   font-weight: 700;
   color: color-mix(in srgb, var(--royal) 65%, var(--navy) 35%);
+}
+.player-card__goat-context {
+  font-size: 0.78rem;
+  line-height: 1.3;
+  color: color-mix(in srgb, var(--text-subtle) 72%, var(--navy) 28%);
+  text-align: right;
 }
 .player-card__body { display: grid; gap: 1.1rem; }
 .player-card__bio {
@@ -4224,7 +4239,9 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 @media (max-width: 640px) {
   .player-card__header { flex-direction: column; align-items: flex-start; }
-  .player-card__goat { justify-items: flex-start; }
+  .player-card__goat { justify-items: stretch; }
+  .player-card__goat-entry { justify-items: start; }
+  .player-card__goat-context { text-align: left; }
 }
 .franchise-footprint {
   display: grid;


### PR DESCRIPTION
## Summary
- load GOAT system data so active players expose both all-time and recent GOAT scores in the scouting atlas
- refresh the player card UI to display the last three seasons and all-time scores with responsive styling

## Testing
- Manual verification in browser (players atlas)


------
https://chatgpt.com/codex/tasks/task_e_68d97b66b36483278a68fc38e681c603