### PR TITLE
Fix player atlas search not updating after data load

### DIFF
--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -1198,6 +1198,13 @@ function initPlayerAtlas() {
         }
         searchInput.disabled = true;
         setClearVisibility(false);
+      } else {
+        const pendingQuery = searchInput.value.trim();
+        if (pendingQuery) {
+          renderResults(pendingQuery);
+        } else {
+          resetStatusMessages();
+        }
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- re-render player atlas results after the profile data finishes loading so early queries show matches
- restore the default hint messaging when the atlas loads with no pending search term

## Testing
- Not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d97fc255f08327bfbb07ea43803402