### PR TITLE
Add hardwood court background to hub styles

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -12,6 +12,8 @@
   --surface-alt: #f2f6ff;
   --surface-soft: #faf4e8;
   --surface-muted: rgba(255, 255, 255, 0.86);
+  --court-floor-base: #d6a261;
+  --court-floor-pattern: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27960%27%20height%3D%27960%27%20viewBox%3D%270%200%20960%20960%27%3E%0A%20%20%3Cdefs%3E%0A%20%20%20%20%3ClinearGradient%20id%3D%27grain%27%20x1%3D%270%27%20y1%3D%270%27%20x2%3D%271%27%20y2%3D%271%27%3E%0A%20%20%20%20%20%20%3Cstop%20offset%3D%270%25%27%20stop-color%3D%27%23d8a15d%27/%3E%0A%20%20%20%20%20%20%3Cstop%20offset%3D%27100%25%27%20stop-color%3D%27%23c7823b%27/%3E%0A%20%20%20%20%3C/linearGradient%3E%0A%20%20%20%20%3Cpattern%20id%3D%27planks%27%20width%3D%27240%27%20height%3D%27240%27%20patternUnits%3D%27userSpaceOnUse%27%3E%0A%20%20%20%20%20%20%3Crect%20width%3D%27240%27%20height%3D%27240%27%20fill%3D%27url%28%23grain%29%27/%3E%0A%20%20%20%20%20%20%3Crect%20x%3D%270%27%20y%3D%270%27%20width%3D%27240%27%20height%3D%27240%27%20fill%3D%27rgba%28255%2C255%2C255%2C0.05%29%27/%3E%0A%20%20%20%20%20%20%3Cg%20stroke%3D%27%23b6752a%27%20stroke-width%3D%273%27%20opacity%3D%270.5%27%3E%0A%20%20%20%20%20%20%20%20%3Cline%20x1%3D%270%27%20y1%3D%270%27%20x2%3D%27240%27%20y2%3D%270%27/%3E%0A%20%20%20%20%20%20%20%20%3Cline%20x1%3D%270%27%20y1%3D%27240%27%20x2%3D%27240%27%20y2%3D%27240%27/%3E%0A%20%20%20%20%20%20%3C/g%3E%0A%20%20%20%20%20%20%3Cg%20stroke%3D%27%23b6752a%27%20stroke-width%3D%274%27%20opacity%3D%270.4%27%3E%0A%20%20%20%20%20%20%20%20%3Cline%20x1%3D%270%27%20y1%3D%27120%27%20x2%3D%27240%27%20y2%3D%27120%27/%3E%0A%20%20%20%20%20%20%3C/g%3E%0A%20%20%20%20%20%20%3Cg%20stroke%3D%27%23cb8d4c%27%20stroke-width%3D%272%27%20opacity%3D%270.35%27%3E%0A%20%20%20%20%20%20%20%20%3Cline%20x1%3D%2780%27%20y1%3D%270%27%20x2%3D%2780%27%20y2%3D%27240%27/%3E%0A%20%20%20%20%20%20%20%20%3Cline%20x1%3D%27160%27%20y1%3D%270%27%20x2%3D%27160%27%20y2%3D%27240%27/%3E%0A%20%20%20%20%20%20%3C/g%3E%0A%20%20%20%20%3C/pattern%3E%0A%20%20%3C/defs%3E%0A%20%20%3Crect%20width%3D%27960%27%20height%3D%27960%27%20fill%3D%27url%28%23planks%29%27/%3E%0A%20%20%3Cg%20fill%3D%27none%27%20stroke%3D%27%23a86824%27%20stroke-width%3D%2712%27%20opacity%3D%270.45%27%3E%0A%20%20%20%20%3Crect%20x%3D%2780%27%20y%3D%2780%27%20width%3D%27800%27%20height%3D%27800%27%20rx%3D%2790%27/%3E%0A%20%20%20%20%3Cline%20x1%3D%27480%27%20y1%3D%2780%27%20x2%3D%27480%27%20y2%3D%27880%27/%3E%0A%20%20%20%20%3Ccircle%20cx%3D%27480%27%20cy%3D%27480%27%20r%3D%27180%27/%3E%0A%20%20%20%20%3Crect%20x%3D%2780%27%20y%3D%27280%27%20width%3D%27140%27%20height%3D%27400%27%20rx%3D%2732%27/%3E%0A%20%20%20%20%3Crect%20x%3D%27740%27%20y%3D%27280%27%20width%3D%27140%27%20height%3D%27400%27%20rx%3D%2732%27/%3E%0A%20%20%20%20%3Ccircle%20cx%3D%27220%27%20cy%3D%27480%27%20r%3D%2760%27/%3E%0A%20%20%20%20%3Ccircle%20cx%3D%27740%27%20cy%3D%27480%27%20r%3D%2760%27/%3E%0A%20%20%3C/g%3E%0A%20%20%3Cg%20fill%3D%27none%27%20stroke%3D%27%23f4d7a1%27%20stroke-width%3D%276%27%20opacity%3D%270.25%27%3E%0A%20%20%20%20%3Ccircle%20cx%3D%27480%27%20cy%3D%27480%27%20r%3D%2780%27/%3E%0A%20%20%20%20%3Crect%20x%3D%27260%27%20y%3D%27260%27%20width%3D%27440%27%20height%3D%27440%27%20rx%3D%2770%27/%3E%0A%20%20%3C/g%3E%0A%3C/svg%3E");
   --text-strong: #0b2545;
   --text-subtle: #42526c;
   --border: #d6deec;
@@ -56,11 +58,38 @@ body {
   margin: 0;
   min-height: 100vh;
   padding: 0 1.25rem 3rem;
-  background:
-    linear-gradient(160deg, rgba(17, 86, 214, 0.14), rgba(244, 181, 63, 0.12)) fixed,
-    var(--surface-soft);
   display: flex;
   flex-direction: column;
+  position: relative;
+  z-index: 0;
+  color: var(--text-strong);
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -2;
+}
+
+body::before {
+  background: var(--court-floor-base);
+  background-image: var(--court-floor-pattern);
+  background-size: 720px 720px;
+  background-repeat: repeat;
+  background-position: center;
+  filter: saturate(1.05) brightness(1.02);
+}
+
+body::after {
+  z-index: -1;
+  background:
+    radial-gradient(circle at 12% 12%, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0) 45%),
+    radial-gradient(circle at 88% 18%, rgba(255, 255, 255, 0.75) 0%, rgba(255, 255, 255, 0) 40%),
+    linear-gradient(160deg, rgba(17, 86, 214, 0.16), rgba(244, 181, 63, 0.14));
+  backdrop-filter: blur(0.5px);
 }
 
 a { color: var(--royal); }


### PR DESCRIPTION
## Summary
- add a reusable hardwood court SVG pattern to the shared hub stylesheet
- layer the wood texture behind all site content with fixed pseudo-elements and light gradient overlays

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9820af36883278fb95bf2aab3ad6d