### PR TITLE
Add ranks to player GOAT scores in scouting atlas

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -96,8 +96,10 @@
                         class="player-card__goat-value"
                         data-player-goat-recent
                         aria-label="GOAT score over the last three seasons"
-                        >—</span
                       >
+                        <span class="player-card__goat-number" data-player-goat-recent-score>—</span>
+                        <span class="player-card__goat-rank" data-player-goat-recent-rank>No. —</span>
+                      </span>
                       <span class="player-card__goat-context">Last 3 seasons (2022-23 to 2024-25)</span>
                     </div>
                     <div class="player-card__goat-entry">
@@ -105,8 +107,10 @@
                         class="player-card__goat-value"
                         data-player-goat-historic
                         aria-label="Career GOAT score"
-                        >—</span
                       >
+                        <span class="player-card__goat-number" data-player-goat-historic-score>—</span>
+                        <span class="player-card__goat-rank" data-player-goat-historic-rank>No. —</span>
+                      </span>
                       <span class="player-card__goat-context">All-time GOAT resume</span>
                     </div>
                   </div>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -4048,9 +4048,21 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   justify-items: end;
 }
 .player-card__goat-value {
+  display: grid;
+  gap: 0.15rem;
+  justify-items: end;
+}
+.player-card__goat-number {
   font-size: clamp(1.5rem, 3vw, 1.9rem);
   font-weight: 700;
   color: color-mix(in srgb, var(--royal) 65%, var(--navy) 35%);
+}
+.player-card__goat-rank {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-subtle) 60%, var(--navy) 40%);
 }
 .player-card__goat-context {
   font-size: 0.78rem;


### PR DESCRIPTION
## Summary
- render numeric GOAT values with rank callouts in the player scouting atlas card
- compute recent and historical ranks from the GOAT system data and expose both values in the UI
- adjust layout and styling of the GOAT score box to accommodate rank text and improve accessibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98127bee88327b679f1c268d4792a