### PR TITLE
Align GOAT rankings across player experiences

### DIFF
--- a/public/data/goat_recent.json
+++ b/public/data/goat_recent.json
@@ -1,0 +1,107 @@
+{
+  "generatedAt": "2025-09-30T00:00:00Z",
+  "window": "2022-23 to 2024-25",
+  "metric": "Rolling three-year GOAT index",
+  "players": [
+    {
+      "rank": 1,
+      "personId": "203999",
+      "name": "Nikola Jokic",
+      "displayName": "Nikola Joki\u0107",
+      "team": "Nuggets",
+      "franchise": "DEN",
+      "score": 97.4,
+      "blurb": "Two MVPs and a title run fueled by an all-time efficiency blend of scoring and playmaking."
+    },
+    {
+      "rank": 2,
+      "personId": "203507",
+      "name": "Giannis Antetokounmpo",
+      "displayName": "Giannis Antetokounmpo",
+      "team": "Bucks",
+      "franchise": "MIL",
+      "score": 94.3,
+      "blurb": "Still the league's most relentless downhill force, anchoring elite two-way metrics."
+    },
+    {
+      "rank": 3,
+      "personId": "1629029",
+      "name": "Luka Doncic",
+      "displayName": "Luka Don\u010di\u0107",
+      "team": "Mavericks",
+      "franchise": "DAL",
+      "score": 92.8,
+      "blurb": "Carrying Dallas with historic usage, triple-double pace, and deep playoff shotmaking."
+    },
+    {
+      "rank": 4,
+      "personId": "203954",
+      "name": "Joel Embiid",
+      "displayName": "Joel Embiid",
+      "team": "76ers",
+      "franchise": "PHI",
+      "score": 91.5,
+      "blurb": "The reigning scoring champ whose interior gravity warps defenses every trip."
+    },
+    {
+      "rank": 5,
+      "personId": "1628983",
+      "name": "Shai Gilgeous-Alexander",
+      "displayName": "Shai Gilgeous-Alexander",
+      "team": "Thunder",
+      "franchise": "OKC",
+      "score": 90.2,
+      "blurb": "Efficiency monster with elite drives, rim pressure, and clutch steal rates."
+    },
+    {
+      "rank": 6,
+      "personId": "1628369",
+      "name": "Jayson Tatum",
+      "displayName": "Jayson Tatum",
+      "team": "Celtics",
+      "franchise": "BOS",
+      "score": 88.9,
+      "blurb": "Versatile wing engine spearheading Boston's top-tier net ratings on both ends."
+    },
+    {
+      "rank": 7,
+      "personId": "201939",
+      "name": "Stephen Curry",
+      "displayName": "Stephen Curry",
+      "team": "Warriors",
+      "franchise": "GSW",
+      "score": 87.4,
+      "blurb": "The original gravity well, still bending defenses with pull-up threes and movement."
+    },
+    {
+      "rank": 8,
+      "personId": "203076",
+      "name": "Anthony Davis",
+      "displayName": "Anthony Davis",
+      "team": "Lakers",
+      "franchise": "LAL",
+      "score": 86.5,
+      "blurb": "Premier rim protector posting 25/12 lines while switching across schemes."
+    },
+    {
+      "rank": 9,
+      "personId": "201142",
+      "name": "Kevin Durant",
+      "displayName": "Kevin Durant",
+      "team": "Suns",
+      "franchise": "PHX",
+      "score": 85.9,
+      "blurb": "Still an elite shotmaker with 50/40/90 efficiency powering Phoenix's half-court sets."
+    },
+    {
+      "rank": 10,
+      "personId": "1626164",
+      "name": "Devin Booker",
+      "displayName": "Devin Booker",
+      "team": "Suns",
+      "franchise": "PHX",
+      "score": 84.6,
+      "blurb": "High-usage creator blending three-level scoring with a growing playmaking portfolio."
+    }
+  ]
+}

--- a/public/players.html
+++ b/public/players.html
@@ -153,78 +153,10 @@
               seasons, here's how we stack the game's current apex performers.
             </p>
           </div>
-          <ol class="players-rankings__list">
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">1</span>
-              <div class="players-rankings__body">
-                <strong>Nikola Jokić — Nuggets</strong>
-                <span>Two MVPs and a title run fueled by an all-time efficiency blend of scoring and playmaking.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">2</span>
-              <div class="players-rankings__body">
-                <strong>Giannis Antetokounmpo — Bucks</strong>
-                <span>Still the league's most relentless downhill force, anchoring elite two-way metrics.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">3</span>
-              <div class="players-rankings__body">
-                <strong>Luka Dončić — Mavericks</strong>
-                <span>Carrying Dallas with historic usage, triple-double pace, and deep playoff shotmaking.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">4</span>
-              <div class="players-rankings__body">
-                <strong>Joel Embiid — 76ers</strong>
-                <span>The reigning scoring champ whose interior gravity warps defenses every trip.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">5</span>
-              <div class="players-rankings__body">
-                <strong>Shai Gilgeous-Alexander — Thunder</strong>
-                <span>Efficiency monster with elite drives, rim pressure, and clutch steal rates.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">6</span>
-              <div class="players-rankings__body">
-                <strong>Jayson Tatum — Celtics</strong>
-                <span>Versatile wing engine spearheading Boston's top-tier net ratings on both ends.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">7</span>
-              <div class="players-rankings__body">
-                <strong>Stephen Curry — Warriors</strong>
-                <span>The original gravity well, still bending defenses with pull-up threes and movement.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">8</span>
-              <div class="players-rankings__body">
-                <strong>Anthony Davis — Lakers</strong>
-                <span>Premier rim protector posting 25/12 lines while switching across schemes.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">9</span>
-              <div class="players-rankings__body">
-                <strong>Kevin Durant — Suns</strong>
-                <span>Still an elite shotmaker with 50/40/90 efficiency powering Phoenix's half-court sets.</span>
-              </div>
-            </li>
-            <li class="players-rankings__item">
-              <span class="players-rankings__rank">10</span>
-              <div class="players-rankings__body">
-                <strong>Devin Booker — Suns</strong>
-                <span>High-usage creator blending three-level scoring with a growing playmaking portfolio.</span>
-              </div>
-            </li>
-          </ol>
+          <ol class="players-rankings__list" data-recent-leaderboard aria-live="polite"></ol>
+          <p class="players-rankings__empty" data-recent-placeholder hidden>
+            Recent GOAT rankings are warming up. Refresh to try again soon.
+          </p>
         </section>
 
         <section class="players-lab__section">


### PR DESCRIPTION
## Summary
- add a rolling three-year GOAT data set that captures the "Who's the Man" rankings with person IDs and scores
- point the player atlas at the all-time GOAT index plus the new rolling data so both historic and recent ranks share a single source of truth
- render the "Who's the Man" list dynamically from the shared data and surface placeholders when data is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d98717df948327b6264cc235bf6f41