### PR TITLE
Fix Joel Embiid injury pulse MVP label

### DIFF
--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -165,7 +165,7 @@ const injuryAvailabilityPulse = [
   {
     team: 'Philadelphia 76ers',
     player: 'Joel Embiid',
-    role: 'C · MVP 2024',
+    role: 'C · MVP 2023',
     statusLabel: 'Cleared for camp',
     statusLevel: 'ready',
     readiness: 88,


### PR DESCRIPTION
## Summary
- correct the Joel Embiid injury availability pulse role label to note his 2023 MVP award

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98876a9788327b348a693b112d588