### PR TITLE
Update preseason front page schedule highlights

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,41 +3,255 @@
   <head>
     <meta charset="utf-8" />
     <title>NBA Preseason Previews 2025-26</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 2rem auto;
+        max-width: 960px;
+        line-height: 1.5;
+        color: #0b0b0b;
+      }
+      h1,
+      h2,
+      h3 {
+        color: #0f172a;
+      }
+      h1 {
+        margin-bottom: 1rem;
+      }
+      h2 {
+        margin-top: 2rem;
+        border-bottom: 2px solid #cbd5f5;
+        padding-bottom: 0.25rem;
+      }
+      h3 {
+        margin-bottom: 0.25rem;
+      }
+      .schedule {
+        margin-top: 2rem;
+      }
+      .day {
+        margin-bottom: 2rem;
+      }
+      .game-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .game {
+        border-left: 4px solid #3b82f6;
+        padding: 0.75rem 1rem;
+        margin-bottom: 1rem;
+        background: #f8fafc;
+      }
+      .game time {
+        font-weight: bold;
+        display: block;
+      }
+      .meta {
+        font-size: 0.875rem;
+        color: #475569;
+      }
+      .links {
+        font-size: 0.875rem;
+        color: #1d4ed8;
+        letter-spacing: 0.02em;
+      }
+      ol {
+        margin-top: 2rem;
+      }
+    </style>
   </head>
   <body>
     <h1>NBA Preseason Previews 2025-26</h1>
     <p><a href="previews/conviction-board.html">View the conviction board</a></p>
+
+    <section class="schedule" aria-labelledby="preseason-schedule">
+      <h2 id="preseason-schedule">Preseason Schedule Highlights</h2>
+
+      <article class="day" aria-labelledby="day-october-2">
+        <h3 id="day-october-2">Thursday, October 2</h3>
+        <p class="meta">1 Game</p>
+        <ul class="game-list">
+          <li class="game">
+            <time datetime="2025-10-02T12:00-04:00">12:00 PM ET</time>
+            <p><strong>Philadelphia 76ers</strong> vs. <strong>New York Knicks</strong></p>
+            <p class="meta">PRESEASON &bull; NBA ABU DHABI GAME: NEUTRAL SITE</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+        </ul>
+      </article>
+
+      <article class="day" aria-labelledby="day-october-3">
+        <h3 id="day-october-3">Friday, October 3</h3>
+        <p class="meta">2 Games</p>
+        <ul class="game-list">
+          <li class="game">
+            <time datetime="2025-10-03T05:30-04:00">5:30 AM ET</time>
+            <p><strong>Melbourne United</strong> vs. <strong>New Orleans Pelicans</strong></p>
+            <p class="meta">PRESEASON &bull; NBA MELBOURNE GAME</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-03T22:00-04:00">10:00 PM ET</time>
+            <p><strong>Phoenix Suns</strong> vs. <strong>Los Angeles Lakers</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+        </ul>
+      </article>
+
+      <article class="day" aria-labelledby="day-october-4">
+        <h3 id="day-october-4">Saturday, October 4</h3>
+        <p class="meta">5 Games</p>
+        <ul class="game-list">
+          <li class="game">
+            <time datetime="2025-10-04T11:00-04:00">11:00 AM ET</time>
+            <p><strong>New York Knicks</strong> vs. <strong>Philadelphia 76ers</strong></p>
+            <p class="meta">PRESEASON &bull; NBA ABU DHABI GAME: NEUTRAL SITE</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-04T20:00-04:00">8:00 PM ET</time>
+            <p><strong>Hapoel Jerusalem B.C.</strong> vs. <strong>Brooklyn Nets</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-04T20:00-04:00">8:00 PM ET</time>
+            <p><strong>Orlando Magic</strong> vs. <strong>Miami Heat</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-04T21:00-04:00">9:00 PM ET</time>
+            <p><strong>Minnesota Timberwolves</strong> vs. <strong>Denver Nuggets</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-04T23:00-04:00">11:00 PM ET</time>
+            <p><strong>South East Melbourne Phoenix</strong> vs. <strong>New Orleans Pelicans</strong></p>
+            <p class="meta">PRESEASON &bull; NBA MELBOURNE GAME</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+        </ul>
+      </article>
+
+      <article class="day" aria-labelledby="day-october-5">
+        <h3 id="day-october-5">Sunday, October 5</h3>
+        <p class="meta">2 Games</p>
+        <ul class="game-list">
+          <li class="game">
+            <time datetime="2025-10-05T17:00-04:00">5:00 PM ET</time>
+            <p><strong>Oklahoma City Thunder</strong> vs. <strong>Charlotte Hornets</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-05T20:30-04:00">8:30 PM ET</time>
+            <p><strong>Los Angeles Lakers</strong> vs. <strong>Golden State Warriors</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+        </ul>
+      </article>
+
+      <article class="day" aria-labelledby="day-october-6">
+        <h3 id="day-october-6">Monday, October 6</h3>
+        <p class="meta">6 Games</p>
+        <ul class="game-list">
+          <li class="game">
+            <time datetime="2025-10-06T19:30-04:00">7:30 PM ET</time>
+            <p><strong>Milwaukee Bucks</strong> vs. <strong>Miami Heat</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-06T20:00-04:00">8:00 PM ET</time>
+            <p><strong>Atlanta Hawks</strong> vs. <strong>Houston Rockets</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-06T20:00-04:00">8:00 PM ET</time>
+            <p><strong>Detroit Pistons</strong> vs. <strong>Memphis Grizzlies</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-06T20:00-04:00">8:00 PM ET</time>
+            <p><strong>Guangzhou Loong-Lions</strong> vs. <strong>San Antonio Spurs</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-06T20:30-04:00">8:30 PM ET</time>
+            <p><strong>Oklahoma City Thunder</strong> vs. <strong>Dallas Mavericks</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-06T22:00-04:00">10:00 PM ET</time>
+            <p><strong>Denver Nuggets</strong> vs. <strong>Toronto Raptors</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+        </ul>
+      </article>
+
+      <article class="day" aria-labelledby="day-october-7">
+        <h3 id="day-october-7">Tuesday, October 7</h3>
+        <p class="meta">2 Games</p>
+        <ul class="game-list">
+          <li class="game">
+            <time datetime="2025-10-07T19:00-04:00">7:00 PM ET</time>
+            <p><strong>Chicago Bulls</strong> vs. <strong>Cleveland Cavaliers</strong></p>
+            <p class="meta">PRESEASON</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+          <li class="game">
+            <time datetime="2025-10-07T20:00-04:00">8:00 PM ET</time>
+            <p><strong>Indiana Pacers</strong> vs. <strong>Minnesota Timberwolves</strong></p>
+            <p class="meta">PRESEASON &bull; TV: FANDUEL SPORTS NETWORK - INDIANA &bull; RADIO: 93.5/107.5 THE FAN</p>
+            <p class="links">Preview &bull; Game Charts &bull; Tickets</p>
+          </li>
+        </ul>
+      </article>
+    </section>
+
+    <h2>Team Previews</h2>
     <ol>
-<li><a href="previews/BOS.md">Boston Celtics</a></li>
-<li><a href="previews/OKC.md">Oklahoma City Thunder</a></li>
-<li><a href="previews/MIN.md">Minnesota Timberwolves</a></li>
-<li><a href="previews/DEN.md">Denver Nuggets</a></li>
-<li><a href="previews/NYK.md">New York Knicks</a></li>
-<li><a href="previews/DAL.md">Dallas Mavericks</a></li>
-<li><a href="previews/LAC.md">Los Angeles Clippers</a></li>
-<li><a href="previews/NOP.md">New Orleans Pelicans</a></li>
-<li><a href="previews/PHI.md">Philadelphia 76ers</a></li>
-<li><a href="previews/CLE.md">Cleveland Cavaliers</a></li>
-<li><a href="previews/MIL.md">Milwaukee Bucks</a></li>
-<li><a href="previews/SAC.md">Sacramento Kings</a></li>
-<li><a href="previews/IND.md">Indiana Pacers</a></li>
-<li><a href="previews/LAL.md">Los Angeles Lakers</a></li>
-<li><a href="previews/PHX.md">Phoenix Suns</a></li>
-<li><a href="previews/ORL.md">Orlando Magic</a></li>
-<li><a href="previews/GSW.md">Golden State Warriors</a></li>
-<li><a href="previews/MIA.md">Miami Heat</a></li>
-<li><a href="previews/HOU.md">Houston Rockets</a></li>
-<li><a href="previews/CHI.md">Chicago Bulls</a></li>
-<li><a href="previews/ATL.md">Atlanta Hawks</a></li>
-<li><a href="previews/BKN.md">Brooklyn Nets</a></li>
-<li><a href="previews/UTA.md">Utah Jazz</a></li>
-<li><a href="previews/MEM.md">Memphis Grizzlies</a></li>
-<li><a href="previews/TOR.md">Toronto Raptors</a></li>
-<li><a href="previews/POR.md">Portland Trail Blazers</a></li>
-<li><a href="previews/CHA.md">Charlotte Hornets</a></li>
-<li><a href="previews/SAS.md">San Antonio Spurs</a></li>
-<li><a href="previews/WAS.md">Washington Wizards</a></li>
-<li><a href="previews/DET.md">Detroit Pistons</a></li>
+      <li><a href="previews/BOS.md">Boston Celtics</a></li>
+      <li><a href="previews/OKC.md">Oklahoma City Thunder</a></li>
+      <li><a href="previews/MIN.md">Minnesota Timberwolves</a></li>
+      <li><a href="previews/DEN.md">Denver Nuggets</a></li>
+      <li><a href="previews/NYK.md">New York Knicks</a></li>
+      <li><a href="previews/DAL.md">Dallas Mavericks</a></li>
+      <li><a href="previews/LAC.md">Los Angeles Clippers</a></li>
+      <li><a href="previews/NOP.md">New Orleans Pelicans</a></li>
+      <li><a href="previews/PHI.md">Philadelphia 76ers</a></li>
+      <li><a href="previews/CLE.md">Cleveland Cavaliers</a></li>
+      <li><a href="previews/MIL.md">Milwaukee Bucks</a></li>
+      <li><a href="previews/SAC.md">Sacramento Kings</a></li>
+      <li><a href="previews/IND.md">Indiana Pacers</a></li>
+      <li><a href="previews/LAL.md">Los Angeles Lakers</a></li>
+      <li><a href="previews/PHX.md">Phoenix Suns</a></li>
+      <li><a href="previews/ORL.md">Orlando Magic</a></li>
+      <li><a href="previews/GSW.md">Golden State Warriors</a></li>
+      <li><a href="previews/MIA.md">Miami Heat</a></li>
+      <li><a href="previews/HOU.md">Houston Rockets</a></li>
+      <li><a href="previews/CHI.md">Chicago Bulls</a></li>
+      <li><a href="previews/ATL.md">Atlanta Hawks</a></li>
+      <li><a href="previews/BKN.md">Brooklyn Nets</a></li>
+      <li><a href="previews/UTA.md">Utah Jazz</a></li>
+      <li><a href="previews/MEM.md">Memphis Grizzlies</a></li>
+      <li><a href="previews/TOR.md">Toronto Raptors</a></li>
+      <li><a href="previews/POR.md">Portland Trail Blazers</a></li>
+      <li><a href="previews/CHA.md">Charlotte Hornets</a></li>
+      <li><a href="previews/SAS.md">San Antonio Spurs</a></li>
+      <li><a href="previews/WAS.md">Washington Wizards</a></li>
+      <li><a href="previews/DET.md">Detroit Pistons</a></li>
     </ol>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add styled preseason schedule highlights to the static front page
- populate the October 2-7 slate with team matchups, times, and context details
- retain existing team preview links for quick navigation

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d9906569908327abce4164a79f0577