### PR TITLE
Fix preseason tour preview links

### DIFF
--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -480,7 +480,8 @@ function renderPreseasonTour(openersData) {
         const matchupLabel = [displayHome?.name, displayRoad?.name].filter(Boolean).join(' vs. ');
 
         if (hasPreview) {
-          card.href = `previews/preseason-${game.gameId}.html`;
+          const previewId = String(game.gameId || '').toLowerCase();
+          card.href = `previews/preseason-${previewId}.html`;
           card.setAttribute(
             'aria-label',
             `${matchupLabel || 'Preseason opener'} preseason opener preview`,
@@ -543,7 +544,7 @@ function renderPreseasonTour(openersData) {
         note.className = 'tour-board__note';
         const label = (game.label ?? '').trim();
         const labelText = label ? label : 'Preseason opener';
-        note.textContent = `${labelText} · Preview hub coming soon.`;
+        note.textContent = labelText;
 
         const venue = document.createElement('p');
         venue.className = 'tour-board__meta';


### PR DESCRIPTION
## Summary
- ensure preseason opener cards link directly to their preseason preview pages
- remove the outdated "Preview hub coming soon" messaging from the tour cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d992a1b3848327b0a230d439fc983d