### PR TITLE
Remove players page hero intro copy

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -29,12 +29,6 @@
         </div>
         <div class="hero">
           <span class="eyebrow">Player Intelligence</span>
-          <h1>View the NBA's most immersive player observatory</h1>
-          <p>
-            Welcome to the lab where biometrics, geography, and legendary performances collide.
-            Each panel below pulls from the repository's player archives and refracts them into
-            visual stories you won't find on the corporate dashboards.
-          </p>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the hero heading and welcome copy from the players page so the atlas sits directly beneath the Player Intelligence banner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9949cde4c8327ac750a29e57aa053