### PR TITLE
Add signature visuals to preseason previews

### DIFF
--- a/public/previews/preseason-pre2025-01.html
+++ b/public/previews/preseason-pre2025-01.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Philadelphia 76ers</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">51.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">104.8</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">104.5</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.3</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:51.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.5%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">25.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:2.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:2.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">9.3</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:82.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.8</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">15.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">32.2</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:44.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>New York Knicks</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">48.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">102.6</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.0</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:74.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.4</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">45.7%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">36.0%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">25.4</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">13.2</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.3</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:96.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">51.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:68.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">22.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-02.html
+++ b/public/previews/preseason-pre2025-02.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,351 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+          <article class="preview-visuals__team">
+            <header class="preview-visuals__team-header">
+              <h3>Melbourne United</h3>
+              <span class="chip preview-visuals__chip">NBL</span>
+            </header>
+            <p class="preview-visuals__empty">We don't have 2024-25 archive visuals for this opponent.</p>
+          </article>
+        
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>New Orleans Pelicans</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.9</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:18.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.1</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:74.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">-1.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.5%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:19.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.6%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:44.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:98.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">22.7</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:62.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.2</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:10.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">49.5</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:57.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">16.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">33.9</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:52.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-03.html
+++ b/public/previews/preseason-pre2025-03.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Phoenix Suns</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">53.3%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">107.7</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:62.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">106.6</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:52.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">+1.1</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.5%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">36.7%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:96.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">32.8</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:41.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">18.9</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">10.7</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:61.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:10.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.0</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:15.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">34.5</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Los Angeles Lakers</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">58.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:93.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">106.7</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">104.5</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">+2.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:85.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">47.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:84.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:34.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">26.6</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:6.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:9.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.1</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:99.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.3</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:43.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.6</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:38.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:17.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-04.html
+++ b/public/previews/preseason-pre2025-04.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>New York Knicks</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">48.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">102.6</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.0</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:74.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.4</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">45.7%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">36.0%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">25.4</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">13.2</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.3</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:96.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">51.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:68.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">22.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Philadelphia 76ers</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">51.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">104.8</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">104.5</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.3</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:51.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.5%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">25.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:2.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:2.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">9.3</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:82.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.8</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">15.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">32.2</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:44.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-05.html
+++ b/public/previews/preseason-pre2025-05.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,351 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+          <article class="preview-visuals__team">
+            <header class="preview-visuals__team-header">
+              <h3>Hapoel Jerusalem B.C.</h3>
+              <span class="chip preview-visuals__chip">Winner League</span>
+            </header>
+            <p class="preview-visuals__empty">We don't have 2024-25 archive visuals for this opponent.</p>
+          </article>
+        
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Brooklyn Nets</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.6%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:4.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.7</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:16.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.9</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:69.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">-2.3</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:7.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.2%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:4.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.1%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:21.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">38.4</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:72.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">20.1</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">12.7</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">43.3</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:17.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.3</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">39.0</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:74.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-06.html
+++ b/public/previews/preseason-pre2025-06.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Orlando Magic</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.3%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:30.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.0</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:11.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">101.8</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:82.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.7</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:34.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">45.6%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:19.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:36.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">42.7</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:97.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">21.9</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:57.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">14.9</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">45.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:30.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:21.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">35.5</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Miami Heat</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">52.6%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:60.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">99.5</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">98.9</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.5</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:36.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">36.1%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:70.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">41.8</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:92.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">21.7</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:55.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.8</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.8</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">37.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-07.html
+++ b/public/previews/preseason-pre2025-07.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Minnesota Timberwolves</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.2%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.4</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:14.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.3</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:73.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">-1.9</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:13.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.6%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.1</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:94.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">23.3</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.6</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:4.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">47.5</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:22.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Denver Nuggets</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">50.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">107.9</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:63.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">108.0</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:44.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.1</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">46.3%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:51.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.1%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:20.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">38.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:75.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">21.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">12.4</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:36.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">56.1</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">18.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:17.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-08.html
+++ b/public/previews/preseason-pre2025-08.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,351 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+          <article class="preview-visuals__team">
+            <header class="preview-visuals__team-header">
+              <h3>South East Melbourne Phoenix</h3>
+              <span class="chip preview-visuals__chip">NBL</span>
+            </header>
+            <p class="preview-visuals__empty">We don't have 2024-25 archive visuals for this opponent.</p>
+          </article>
+        
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>New Orleans Pelicans</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.9</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:18.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.1</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:74.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">-1.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.5%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:19.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.6%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:44.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:98.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">22.7</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:62.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.2</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:10.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">49.5</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:57.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">16.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">33.9</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:52.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-09.html
+++ b/public/previews/preseason-pre2025-09.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Oklahoma City Thunder</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">53.8%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">105.8</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">104.7</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">+1.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:67.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.6%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:62.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.8%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">32.4</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">17.1</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">10.5</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">50.4</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:63.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">16.1</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:59.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Charlotte Hornets</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.2%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:2.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">100.5</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:8.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">103.2</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:73.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">-2.7</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">45.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">35.6%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">41.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:92.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">23.3</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.4</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:7.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">44.9</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:28.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">12.0</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.5</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:59.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-10.html
+++ b/public/previews/preseason-pre2025-10.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Los Angeles Lakers</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">58.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:93.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">106.7</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">104.5</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">+2.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:85.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">47.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:84.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:34.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">26.6</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:6.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:9.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.1</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:99.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.3</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:43.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.6</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:38.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:17.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Golden State Warriors</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">49.1%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">106.9</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">107.1</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:49.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:43.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">46.3%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:51.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">36.2%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:75.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.1</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:3.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">14.3</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:7.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.5</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:92.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">44.3</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:24.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">43.8</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:95.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-11.html
+++ b/public/previews/preseason-pre2025-11.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Milwaukee Bucks</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">52.2%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">105.2</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:43.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">104.0</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:68.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">+1.1</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:67.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">46.5%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:60.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">36.3%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:79.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">32.4</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">17.9</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:30.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">10.5</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">43.4</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:19.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.3</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:18.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">37.0</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Miami Heat</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">52.6%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:60.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">99.5</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">98.9</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.5</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:36.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">36.1%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:70.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">41.8</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:92.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">21.7</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:55.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.8</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.8</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">37.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-12.html
+++ b/public/previews/preseason-pre2025-12.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Atlanta Hawks</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">48.9%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.4</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:29.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.9</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:69.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.6</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.6%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:21.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.7%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:8.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.5</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.3</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:96.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">54.8</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:91.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">17.0</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:72.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">43.9</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:96.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Houston Rockets</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">51.7%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:55.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">105.4</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">104.8</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:63.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.6</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:37.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.5%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">32.8</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:41.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">17.1</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">10.8</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:59.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">51.4</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:69.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">16.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:65.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">33.0</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-13.html
+++ b/public/previews/preseason-pre2025-13.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Detroit Pistons</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">47.2%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:30.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">102.4</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:22.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.2</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:73.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.8</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:32.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.5%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:18.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">35.9%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.0</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:3.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.4</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">8.0</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">52.2</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:75.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">18.4</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:94.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">40.4</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:80.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Memphis Grizzlies</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">43.9%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:11.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">99.7</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.6</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:83.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">-1.9</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:14.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:2.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">34.7%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.2</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:94.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">22.1</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.9</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">54.9</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:92.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">16.4</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:63.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">43.5</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:94.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-14.html
+++ b/public/previews/preseason-pre2025-14.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,351 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+          <article class="preview-visuals__team">
+            <header class="preview-visuals__team-header">
+              <h3>Guangzhou Loong-Lions</h3>
+              <span class="chip preview-visuals__chip">CBA</span>
+            </header>
+            <p class="preview-visuals__empty">We don't have 2024-25 archive visuals for this opponent.</p>
+          </article>
+        
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>San Antonio Spurs</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">41.9%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">112.7</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">3rd percentile</span>
+                </div>
+                <strong class="team-visual__value">115.2</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:0.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">-2.5</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:3.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:43.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.1%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:19.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">43.2</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">28.4</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">27th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.2</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.6</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">16.2</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:60.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">44.7</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-15.html
+++ b/public/previews/preseason-pre2025-15.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Oklahoma City Thunder</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">53.8%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">105.8</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">104.7</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">93rd percentile</span>
+                </div>
+                <strong class="team-visual__value">+1.2</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:67.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.6%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:62.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.8%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:56.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">32.4</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">17.1</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:25.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">10.5</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">50.4</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:63.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">16.1</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:59.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Dallas Mavericks</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">50.4%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.9</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">103.9</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:69.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.0</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:47.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:40.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.9%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:61.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">41.1</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:88.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">21.5</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">12.4</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:36.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">50.6</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">15.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:51.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">39.2</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:75.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-16.html
+++ b/public/previews/preseason-pre2025-16.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Denver Nuggets</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">50.5%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:48.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">107.9</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:63.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">108.0</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:44.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.1</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">46.3%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:51.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.1%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:20.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">38.9</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:75.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">21.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:54.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">12.4</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:36.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">56.1</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">100th percentile</span>
+                </div>
+                <strong class="team-visual__value">18.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:100.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">26.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:17.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Toronto Raptors</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">47.7%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:32.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.5</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:15.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.9</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:81.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">47th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.5</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:39.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">10th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:3.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.5%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">42.0</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:93.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">22.3</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:59.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">14.1</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:12.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">53.7</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:84.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">18.3</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:92.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">37.5</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:67.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-17.html
+++ b/public/previews/preseason-pre2025-17.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -142,6 +192,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Chicago Bulls</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">51.2%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:52.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">102.5</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">102.2</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:79.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.3</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:53.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.1%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:41.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">90th percentile</span>
+                </div>
+                <strong class="team-visual__value">36.5%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:90.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">32.3</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:38.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">17.6</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:28.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">70th percentile</span>
+                </div>
+                <strong class="team-visual__value">10.3</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:67.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">50.5</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:64.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">18.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:95.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">37.1</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Cleveland Cavaliers</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">47.4%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:31.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">23rd percentile</span>
+                </div>
+                <strong class="team-visual__value">101.5</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:15.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">102.3</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:79.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">37th percentile</span>
+                </div>
+                <strong class="team-visual__value">-0.8</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">50th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.0%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:38.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">36.7%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:98.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">33.8</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:47.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">18.3</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">53rd percentile</span>
+                </div>
+                <strong class="team-visual__value">11.0</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:57.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">77th percentile</span>
+                </div>
+                <strong class="team-visual__value">51.3</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:69.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">14.9</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:42.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">39.8</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:78.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-18.html
+++ b/public/previews/preseason-pre2025-18.html
@@ -92,6 +92,56 @@
         margin-bottom: 0.5rem;
       }
 
+      .preview-visuals {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .preview-visuals__header {
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-visuals__grid {
+        display: grid;
+        gap: clamp(1rem, 3vw, 1.5rem);
+      }
+
+      @media (min-width: 900px) {
+        .preview-visuals__grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .preview-visuals__team {
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .preview-visuals__team-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+
+      .preview-visuals__team-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+      }
+
+      .preview-visuals__chip {
+        font-size: 0.7rem;
+        letter-spacing: 0.08em;
+      }
+
+      .preview-visuals__empty {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
       footer {
         display: flex;
         justify-content: space-between;
@@ -148,6 +198,664 @@
           <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
         </ul>
       </article>
+
+      
+        <section class="preview-visuals">
+          <div class="preview-visuals__header">
+            <h2>Signature visual read</h2>
+            <p>
+              Twelve precanned visuals benchmark each rotation using the completed 2024-25 campaign so
+              coaches can steer the 2025-26 preseason focus.
+            </p>
+          </div>
+          <div class="preview-visuals__grid">
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Indiana Pacers</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">50.1%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:46.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">103.3</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:29.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">73rd percentile</span>
+                </div>
+                <strong class="team-visual__value">103.0</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:74.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">67th percentile</span>
+                </div>
+                <strong class="team-visual__value">+0.3</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:52.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">80th percentile</span>
+                </div>
+                <strong class="team-visual__value">46.3%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:52.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">36.4%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:83.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">38.1</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:71.3%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">63rd percentile</span>
+                </div>
+                <strong class="team-visual__value">20.8</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:49.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">33rd percentile</span>
+                </div>
+                <strong class="team-visual__value">12.6</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:34.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">60th percentile</span>
+                </div>
+                <strong class="team-visual__value">49.5</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:57.5%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">16.8</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:70.0%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">83rd percentile</span>
+                </div>
+                <strong class="team-visual__value">40.6</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:81.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+            
+        <article class="preview-visuals__team">
+          <header class="preview-visuals__team-header">
+            <h3>Minnesota Timberwolves</h3>
+            <span class="chip preview-visuals__chip">NBA</span>
+          </header>
+          <div class="team-detail__visuals">
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Win percentage</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">7th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.2%</strong>
+              </header>
+              <p class="team-visual__description">Share of games won across the tracked 2024-25 sample.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:1.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>41.9%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>59.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points for</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">101.4</strong>
+              </header>
+              <p class="team-visual__description">Average points scored per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:14.6%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>99.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>112.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points allowed</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">57th percentile</span>
+                </div>
+                <strong class="team-visual__value">103.3</strong>
+              </header>
+              <p class="team-visual__description">Average points conceded per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:73.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>98.9</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>115.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Net margin</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">-1.9</strong>
+              </header>
+              <p class="team-visual__description">Average scoring differential versus opponents.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:13.8%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>-2.7</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>+3.0</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Field goal accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">30th percentile</span>
+                </div>
+                <strong class="team-visual__value">45.6%</strong>
+              </header>
+              <p class="team-visual__description">Overall shooting efficiency from the floor.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:23.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>45.1%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>47.5%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Three-point accuracy</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">17th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4%</strong>
+              </header>
+              <p class="team-visual__description">Conversion rate on perimeter attempts.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:33.2%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>34.7%</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>36.7%</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Rebounds</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">87th percentile</span>
+                </div>
+                <strong class="team-visual__value">42.1</strong>
+              </header>
+              <p class="team-visual__description">Average total rebounds secured per night.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:94.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>25.4</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>43.2</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Assists</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">97th percentile</span>
+                </div>
+                <strong class="team-visual__value">23.3</strong>
+              </header>
+              <p class="team-visual__description">Average assists generated each game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:66.4%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>13.2</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>28.4</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Turnovers</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">13th percentile</span>
+                </div>
+                <strong class="team-visual__value">14.6</strong>
+              </header>
+              <p class="team-visual__description">Average turnovers committed per outing (lower is stronger).</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:4.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>8.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>14.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Points in the paint</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">43rd percentile</span>
+                </div>
+                <strong class="team-visual__value">47.5</strong>
+              </header>
+              <p class="team-visual__description">Interior scoring output per contest.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:45.1%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>40.5</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>56.1</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Fast-break points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">20th percentile</span>
+                </div>
+                <strong class="team-visual__value">13.5</strong>
+              </header>
+              <p class="team-visual__description">Transition scoring per game.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:22.7%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>12.0</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>18.9</dd>
+                </div>
+              </dl>
+            </article>
+          
+            
+            <article class="team-visual">
+              <header class="team-visual__header">
+                <div class="team-visual__heading">
+                  <span class="team-visual__label">Bench points</span>
+                  <span class="team-visual__percentile" title="Percentile rank across the league">40th percentile</span>
+                </div>
+                <strong class="team-visual__value">35.4</strong>
+              </header>
+              <p class="team-visual__description">Second-unit scoring production.</p>
+              <div class="team-visual__meter" role="presentation">
+                <div class="team-visual__meter-track"></div>
+                <div class="team-visual__meter-fill" style="--fill:58.9%"></div>
+              </div>
+              <dl class="team-visual__range">
+                <div>
+                  <dt>League low</dt>
+                  <dd>22.1</dd>
+                </div>
+                <div>
+                  <dt>League high</dt>
+                  <dd>44.7</dd>
+                </div>
+              </dl>
+            </article>
+          
+          </div>
+        </article>
+      
+          </div>
+        </section>
+      
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>


### PR DESCRIPTION
## Summary
- extend the preseason preview generator to load team profile metrics, compute signature visual stats, and embed a visuals section in each matchup page
- regenerate every preseason preview so both clubs show the twelve curated metric cards (or an archival placeholder for guest teams)

## Testing
- pnpm previews *(fails to fetch remote rosters because the environment blocks external requests; generation completed using existing data)*

------
https://chatgpt.com/codex/tasks/task_e_68d994f22fa88327a3688e24add366ca