### PR TITLE
Fix preview workflow pnpm installation

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -18,11 +18,12 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: true
+      - name: Enable corepack
+        run: corepack enable
+      - name: Use pnpm 9
+        run: corepack prepare pnpm@9.1.0 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Stamp date
         id: metadata
         run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.1.0",
+  "packageManager": "pnpm@9.1.0",
   "scripts": {
     "build:data": "tsx scripts/data/build_canonical.ts && tsx scripts/data/build_preseason_schedule.ts",
     "gen:previews": "tsx scripts/generate/preseason_previews.ts && tsx scripts/generate/previews.ts",


### PR DESCRIPTION
## Summary
- ensure the previews workflow provisions pnpm via corepack before running preview generation
- declare the repository's pnpm toolchain version so actions use the expected release

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d99e54edfc8327b35e2d647607edd2