### PR TITLE
Fix pnpm installation in previews workflow

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
-      - name: Enable corepack
-        run: corepack enable
-      - name: Use pnpm 9
-        run: corepack prepare pnpm@9.1.0 --activate
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.1.0
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Stamp date


### PR DESCRIPTION
## Summary
- replace the manual corepack setup with pnpm/action-setup to ensure pnpm is available in CI before running previews

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a3787df08327b6223afd1ec0223a