### PR TITLE
chore(ci): ensure pnpm installed before cache

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -21,16 +21,16 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.1.0
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.1.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- set up pnpm prior to using the Node cache so the pnpm binary exists when caching is configured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a5aeec188327b32eabcdfae7b95a