### PR TITLE
Add last-three-season GOAT context to player atlas

### DIFF
--- a/public/data/player_profiles.json
+++ b/public/data/player_profiles.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-28T19:23:48+00:00",
+  "generatedAt": "2025-09-28T21:37:59+00:00",
   "metrics": [
     {
       "id": "offensive-creation",
@@ -91,7 +91,9 @@
         "san jose",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 63.1,
+      "goatRecentRank": 44
     },
     {
       "id": "aaron-holiday-1628988",
@@ -123,7 +125,9 @@
         "rotation",
         "ruston"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.4,
+      "goatRecentRank": 151
     },
     {
       "id": "aaron-nesmith-1630174",
@@ -153,7 +157,9 @@
         "nesmith",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.6,
+      "goatRecentRank": 116
     },
     {
       "id": "abdel-nader-1627846",
@@ -185,7 +191,9 @@
         "rotation",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 458
     },
     {
       "id": "adam-mokoka-1629690",
@@ -216,7 +224,9 @@
         "mokoka",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 492
     },
     {
       "id": "al-horford-201143",
@@ -251,7 +261,9 @@
         "puerto plata",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.9,
+      "goatRecentRank": 61
     },
     {
       "id": "al-farouq-aminu-202329",
@@ -283,7 +295,9 @@
         "goat",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 526
     },
     {
       "id": "alec-burks-202692",
@@ -316,7 +330,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.6,
+      "goatRecentRank": 198
     },
     {
       "id": "aleksej-pokusevski-1630197",
@@ -348,7 +364,9 @@
         "serbia",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 24.2,
+      "goatRecentRank": 286
     },
     {
       "id": "alen-smailagic-1629346",
@@ -381,7 +399,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 478
     },
     {
       "id": "alex-caruso-1627936",
@@ -414,7 +434,9 @@
         "starter",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.5,
+      "goatRecentRank": 79
     },
     {
       "id": "alex-len-203458",
@@ -446,7 +468,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 38.7,
+      "goatRecentRank": 203
     },
     {
       "id": "alfonzo-mckinnie-1628035",
@@ -479,7 +503,9 @@
         "mckinnie",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 483
     },
     {
       "id": "alize-johnson-1628993",
@@ -509,7 +535,9 @@
         "rotation",
         "williamsport"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.2,
+      "goatRecentRank": 402
     },
     {
       "id": "amida-brimah-1628578",
@@ -540,7 +568,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 13.6,
+      "goatRecentRank": 374
     },
     {
       "id": "amir-coffey-1629599",
@@ -573,7 +603,9 @@
         "minnesota",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.2,
+      "goatRecentRank": 214
     },
     {
       "id": "anderson-varejao-2760",
@@ -605,7 +637,9 @@
         "starter",
         "varejao"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 521
     },
     {
       "id": "andre-drummond-203083",
@@ -638,7 +672,9 @@
         "new york",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 61.2,
+      "goatRecentRank": 53
     },
     {
       "id": "andre-iguodala-2738",
@@ -674,7 +710,9 @@
         "of",
         "springfield"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 12.0,
+      "goatRecentRank": 380
     },
     {
       "id": "andre-roberson-203460",
@@ -709,7 +747,9 @@
         "roberson",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 509
     },
     {
       "id": "andrew-wiggins-203952",
@@ -742,7 +782,9 @@
         "warriors",
         "wiggins"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.9,
+      "goatRecentRank": 136
     },
     {
       "id": "anfernee-simons-1629014",
@@ -773,7 +815,9 @@
         "simons",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 43.1,
+      "goatRecentRank": 169
     },
     {
       "id": "anthony-davis-203076",
@@ -806,7 +850,9 @@
         "lakers",
         "los"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 78.1,
+      "goatRecentRank": 6
     },
     {
       "id": "anthony-edwards-1630162",
@@ -836,7 +882,9 @@
         "minnesota",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 74.0,
+      "goatRecentRank": 12
     },
     {
       "id": "anthony-gill-1630264",
@@ -864,7 +912,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.7,
+      "goatRecentRank": 260
     },
     {
       "id": "anthony-lamb-1630237",
@@ -895,7 +945,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.8,
+      "goatRecentRank": 289
     },
     {
       "id": "anthony-tolliver-201229",
@@ -926,7 +978,9 @@
         "tolliver",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 518
     },
     {
       "id": "anzejs-pasecniks-1628394",
@@ -961,7 +1015,9 @@
         "riga",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 6.6,
+      "goatRecentRank": 406
     },
     {
       "id": "armoni-brooks-1629717",
@@ -992,7 +1048,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 10.6,
+      "goatRecentRank": 389
     },
     {
       "id": "aron-baynes-203382",
@@ -1026,7 +1084,9 @@
         "starter",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 544
     },
     {
       "id": "ashton-hagans-1630204",
@@ -1060,7 +1120,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 6.8,
+      "goatRecentRank": 405
     },
     {
       "id": "austin-rivers-203085",
@@ -1092,7 +1154,9 @@
         "santa monica",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.1,
+      "goatRecentRank": 346
     },
     {
       "id": "avery-bradley-202340",
@@ -1124,7 +1188,9 @@
         "tacoma",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 466
     },
     {
       "id": "axel-toupane-1626253",
@@ -1157,7 +1223,9 @@
         "rotation",
         "toupane"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 508
     },
     {
       "id": "bam-adebayo-1628389",
@@ -1187,7 +1255,9 @@
         "new jersey",
         "newark"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 67.9,
+      "goatRecentRank": 25
     },
     {
       "id": "ben-mclemore-203463",
@@ -1220,7 +1290,9 @@
         "rotation",
         "st. louis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 539
     },
     {
       "id": "ben-simmons-1627732",
@@ -1250,7 +1322,9 @@
         "simmons",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 36.7,
+      "goatRecentRank": 215
     },
     {
       "id": "bismack-biyombo-202687",
@@ -1282,7 +1356,9 @@
         "lubumbashi",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 35.9,
+      "goatRecentRank": 218
     },
     {
       "id": "blake-griffin-201933",
@@ -1314,7 +1390,9 @@
         "oklahoma",
         "oklahoma city"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.4,
+      "goatRecentRank": 301
     },
     {
       "id": "boban-marjanovic-1626246",
@@ -1346,7 +1424,9 @@
         "rotation",
         "serbia (frmr yugoslavia)"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.7,
+      "goatRecentRank": 309
     },
     {
       "id": "bobby-portis-1626171",
@@ -1378,7 +1458,9 @@
         "portis",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.4,
+      "goatRecentRank": 49
     },
     {
       "id": "bogdan-bogdanovic-203992",
@@ -1411,7 +1493,9 @@
         "serbia",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.5,
+      "goatRecentRank": 130
     },
     {
       "id": "bojan-bogdanovic-202711",
@@ -1443,7 +1527,9 @@
         "starter",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 28.8,
+      "goatRecentRank": 255
     },
     {
       "id": "bol-bol-1629626",
@@ -1474,7 +1560,9 @@
         "rotation",
         "sudan"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.8,
+      "goatRecentRank": 170
     },
     {
       "id": "brad-wanamaker-202954",
@@ -1506,7 +1594,9 @@
         "rotation",
         "wanamaker"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 528
     },
     {
       "id": "bradley-beal-203078",
@@ -1538,7 +1628,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 45.4,
+      "goatRecentRank": 158
     },
     {
       "id": "brandon-clarke-1629634",
@@ -1570,7 +1662,9 @@
         "rotation",
         "vancouver"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.6,
+      "goatRecentRank": 184
     },
     {
       "id": "brandon-goodwin-1629164",
@@ -1602,7 +1696,9 @@
         "norcross",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 470
     },
     {
       "id": "brandon-ingram-1627742",
@@ -1635,7 +1731,9 @@
         "pelicans",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 43.7,
+      "goatRecentRank": 167
     },
     {
       "id": "brian-bowen-ii-1628968",
@@ -1670,7 +1768,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 516
     },
     {
       "id": "brodric-thomas-1630271",
@@ -1701,7 +1801,9 @@
         "thomas",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 9.0,
+      "goatRecentRank": 394
     },
     {
       "id": "brook-lopez-201572",
@@ -1731,7 +1833,9 @@
         "milwaukee",
         "north hollywood"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 61.0,
+      "goatRecentRank": 55
     },
     {
       "id": "bruce-brown-1628971",
@@ -1763,7 +1867,9 @@
         "nets",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.3,
+      "goatRecentRank": 134
     },
     {
       "id": "bruno-caboclo-203998",
@@ -1796,7 +1902,9 @@
         "osasco",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 432
     },
     {
       "id": "bruno-fernando-1628981",
@@ -1830,7 +1938,9 @@
         "luanda",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 33.1,
+      "goatRecentRank": 228
     },
     {
       "id": "bryn-forbes-1627854",
@@ -1862,7 +1972,9 @@
         "milwaukee",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 13.7,
+      "goatRecentRank": 372
     },
     {
       "id": "buddy-hield-1627741",
@@ -1894,7 +2006,9 @@
         "sacramento",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.6,
+      "goatRecentRank": 77
     },
     {
       "id": "caleb-martin-1628997",
@@ -1926,7 +2040,9 @@
         "north carolina",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 43.3,
+      "goatRecentRank": 168
     },
     {
       "id": "cam-reddish-1629629",
@@ -1956,7 +2072,9 @@
         "reddish",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.4,
+      "goatRecentRank": 262
     },
     {
       "id": "cam-reynolds-1629244",
@@ -1987,7 +2105,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 512
     },
     {
       "id": "cameron-johnson-1629661",
@@ -2019,7 +2139,9 @@
         "starter",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.1,
+      "goatRecentRank": 195
     },
     {
       "id": "cameron-oliver-1628419",
@@ -2050,7 +2172,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 461
     },
     {
       "id": "cameron-payne-1626166",
@@ -2082,7 +2206,9 @@
         "suns",
         "tennessee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.0,
+      "goatRecentRank": 69
     },
     {
       "id": "caris-levert-1627747",
@@ -2114,7 +2240,9 @@
         "pacers",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 57.1,
+      "goatRecentRank": 74
     },
     {
       "id": "carmelo-anthony-2546",
@@ -2147,7 +2275,9 @@
         "portland",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 496
     },
     {
       "id": "carsen-edwards-1629035",
@@ -2179,7 +2309,9 @@
         "rotation",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 445
     },
     {
       "id": "cassius-stanley-1630199",
@@ -2210,7 +2342,9 @@
         "stanley",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 535
     },
     {
       "id": "cassius-winston-1630216",
@@ -2241,7 +2375,9 @@
         "winston",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 435
     },
     {
       "id": "cedi-osman-1626224",
@@ -2273,7 +2409,9 @@
         "osman",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 34.3,
+      "goatRecentRank": 223
     },
     {
       "id": "chandler-hutchison-1628990",
@@ -2306,7 +2444,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 510
     },
     {
       "id": "charlie-brown-jr-1629718",
@@ -2339,7 +2479,9 @@
         "thunder",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 13.6,
+      "goatRecentRank": 375
     },
     {
       "id": "chasson-randle-1626184",
@@ -2371,7 +2513,9 @@
         "rock island",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.0,
+      "goatRecentRank": 306
     },
     {
       "id": "chimezie-metu-1629002",
@@ -2405,7 +2549,9 @@
         "rotation",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.3,
+      "goatRecentRank": 213
     },
     {
       "id": "chris-boucher-1628449",
@@ -2435,7 +2581,9 @@
         "saint lucia",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.0,
+      "goatRecentRank": 145
     },
     {
       "id": "chris-chiozza-1629185",
@@ -2467,7 +2615,9 @@
         "rotation",
         "tennessee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.3,
+      "goatRecentRank": 414
     },
     {
       "id": "chris-paul-101108",
@@ -2499,7 +2649,9 @@
         "suns",
         "winston-salem"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.1,
+      "goatRecentRank": 80
     },
     {
       "id": "chris-silva-1629735",
@@ -2530,7 +2682,9 @@
         "reserve",
         "silva"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.4,
+      "goatRecentRank": 300
     },
     {
       "id": "christian-wood-1626174",
@@ -2560,7 +2714,9 @@
         "rotation",
         "wood"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.2,
+      "goatRecentRank": 202
     },
     {
       "id": "chuma-okeke-1629643",
@@ -2591,7 +2747,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.9,
+      "goatRecentRank": 288
     },
     {
       "id": "cj-elleby-1629604",
@@ -2625,7 +2783,9 @@
         "trail",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.1,
+      "goatRecentRank": 303
     },
     {
       "id": "cj-mccollum-203468",
@@ -2656,7 +2816,9 @@
         "starter",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.1,
+      "goatRecentRank": 87
     },
     {
       "id": "clint-capela-203991",
@@ -2688,7 +2850,9 @@
         "starter",
         "switzerland"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 57.8,
+      "goatRecentRank": 71
     },
     {
       "id": "coby-white-1629632",
@@ -2720,7 +2884,9 @@
         "starter",
         "white"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.5,
+      "goatRecentRank": 85
     },
     {
       "id": "cody-martin-1628998",
@@ -2752,7 +2918,9 @@
         "north carolina",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.7,
+      "goatRecentRank": 321
     },
     {
       "id": "cody-zeller-203469",
@@ -2786,7 +2954,9 @@
         "washington",
         "zeller"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.0,
+      "goatRecentRank": 268
     },
     {
       "id": "cole-anthony-1630175",
@@ -2816,7 +2986,9 @@
         "orlando",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 59.2,
+      "goatRecentRank": 60
     },
     {
       "id": "collin-sexton-1629012",
@@ -2846,7 +3018,9 @@
         "sexton",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.6,
+      "goatRecentRank": 115
     },
     {
       "id": "cory-joseph-202709",
@@ -2878,7 +3052,9 @@
         "pistons",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 30.2,
+      "goatRecentRank": 241
     },
     {
       "id": "cristiano-felicio-1626245",
@@ -2912,7 +3088,9 @@
         "pouso alegre",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 457
     },
     {
       "id": "d-angelo-russell-1626156",
@@ -2942,7 +3120,9 @@
         "starter",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.2,
+      "goatRecentRank": 51
     },
     {
       "id": "d-j-augustin-201571",
@@ -2974,7 +3154,9 @@
         "rockets",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 418
     },
     {
       "id": "d-j-wilson-1628391",
@@ -3006,7 +3188,9 @@
         "rotation",
         "wilson"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.6,
+      "goatRecentRank": 353
     },
     {
       "id": "dakota-mathias-1629751",
@@ -3038,7 +3222,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 497
     },
     {
       "id": "damian-jones-1627745",
@@ -3070,7 +3256,9 @@
         "rotation",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.4,
+      "goatRecentRank": 297
     },
     {
       "id": "damian-lillard-203081",
@@ -3101,7 +3289,9 @@
         "portland",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 64.3,
+      "goatRecentRank": 42
     },
     {
       "id": "damion-lee-1627814",
@@ -3132,7 +3322,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.5,
+      "goatRecentRank": 261
     },
     {
       "id": "damyean-dotson-1628422",
@@ -3164,7 +3356,9 @@
         "rotation",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 481
     },
     {
       "id": "daniel-gafford-1629655",
@@ -3194,7 +3388,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.1,
+      "goatRecentRank": 39
     },
     {
       "id": "daniel-oturu-1630187",
@@ -3226,7 +3422,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 542
     },
     {
       "id": "daniel-theis-1628464",
@@ -3256,7 +3454,9 @@
         "starter",
         "theis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.7,
+      "goatRecentRank": 247
     },
     {
       "id": "danilo-gallinari-201568",
@@ -3288,7 +3488,9 @@
         "saint'angelo lodigiano",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.7,
+      "goatRecentRank": 350
     },
     {
       "id": "danny-green-201980",
@@ -3320,7 +3522,9 @@
         "north babylon",
         "philadelphia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 14.0,
+      "goatRecentRank": 370
     },
     {
       "id": "dante-exum-203957",
@@ -3352,7 +3556,9 @@
         "rockets",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.9,
+      "goatRecentRank": 244
     },
     {
       "id": "danuel-house-jr-1627863",
@@ -3386,7 +3592,9 @@
         "starter",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 26.9,
+      "goatRecentRank": 269
     },
     {
       "id": "daquan-jeffries-1629610",
@@ -3419,7 +3627,9 @@
         "oklahoma",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.7,
+      "goatRecentRank": 361
     },
     {
       "id": "dario-saric-203967",
@@ -3449,7 +3659,9 @@
         "starter",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.3,
+      "goatRecentRank": 191
     },
     {
       "id": "darius-bazley-1629647",
@@ -3482,7 +3694,9 @@
         "rotation",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.2,
+      "goatRecentRank": 327
     },
     {
       "id": "darius-garland-1629636",
@@ -3512,7 +3726,9 @@
         "indiana",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.8,
+      "goatRecentRank": 34
     },
     {
       "id": "darius-miller-203121",
@@ -3545,7 +3761,9 @@
         "miller",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 529
     },
     {
       "id": "david-nwaba-1628021",
@@ -3578,7 +3796,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.9,
+      "goatRecentRank": 360
     },
     {
       "id": "davis-bertans-202722",
@@ -3610,7 +3830,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.6,
+      "goatRecentRank": 293
     },
     {
       "id": "de-aaron-fox-1628368",
@@ -3640,7 +3862,9 @@
         "sacramento",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 68.9,
+      "goatRecentRank": 22
     },
     {
       "id": "de-andre-hunter-1629631",
@@ -3672,7 +3896,9 @@
         "philadelphia",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.0,
+      "goatRecentRank": 153
     },
     {
       "id": "de-anthony-melton-1629001",
@@ -3702,7 +3928,9 @@
         "north hollywood",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.4,
+      "goatRecentRank": 177
     },
     {
       "id": "dean-wade-1629731",
@@ -3732,7 +3960,9 @@
         "wade",
         "wichita"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.3,
+      "goatRecentRank": 189
     },
     {
       "id": "deandre-ayton-1629028",
@@ -3764,7 +3994,9 @@
         "starter",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.5,
+      "goatRecentRank": 140
     },
     {
       "id": "deandre-jordan-201599",
@@ -3796,7 +4028,9 @@
         "nets",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 44.0,
+      "goatRecentRank": 165
     },
     {
       "id": "deandre-bembry-1627761",
@@ -3830,7 +4064,9 @@
         "rotation",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 527
     },
     {
       "id": "deividas-sirvydis-1629686",
@@ -3863,7 +4099,9 @@
         "reserve",
         "sirvydis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 11.2,
+      "goatRecentRank": 385
     },
     {
       "id": "dejounte-murray-1627749",
@@ -3894,7 +4132,9 @@
         "starter",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.6,
+      "goatRecentRank": 84
     },
     {
       "id": "delon-wright-1626153",
@@ -3926,7 +4166,9 @@
         "starter",
         "wright"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.7,
+      "goatRecentRank": 208
     },
     {
       "id": "demar-derozan-201942",
@@ -3957,7 +4199,9 @@
         "san",
         "spurs"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.4,
+      "goatRecentRank": 50
     },
     {
       "id": "demarcus-cousins-202326",
@@ -3990,7 +4234,9 @@
         "los",
         "mobile"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 462
     },
     {
       "id": "deni-avdija-1630166",
@@ -4018,7 +4264,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 54.0,
+      "goatRecentRank": 92
     },
     {
       "id": "dennis-schroder-203471",
@@ -4051,7 +4299,9 @@
         "los",
         "schroder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.5,
+      "goatRecentRank": 96
     },
     {
       "id": "dennis-smith-jr-1628372",
@@ -4084,7 +4334,9 @@
         "smith",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.7,
+      "goatRecentRank": 246
     },
     {
       "id": "denzel-valentine-1627756",
@@ -4116,7 +4368,9 @@
         "rotation",
         "valentine"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 475
     },
     {
       "id": "derrick-favors-202324",
@@ -4148,7 +4402,9 @@
         "starter",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.5,
+      "goatRecentRank": 294
     },
     {
       "id": "derrick-jones-jr-1627884",
@@ -4180,7 +4436,9 @@
         "starter",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.1,
+      "goatRecentRank": 118
     },
     {
       "id": "derrick-rose-201565",
@@ -4213,7 +4471,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.0,
+      "goatRecentRank": 330
     },
     {
       "id": "derrick-white-1628401",
@@ -4244,7 +4504,9 @@
         "starter",
         "white"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 66.4,
+      "goatRecentRank": 28
     },
     {
       "id": "desmond-bane-1630217",
@@ -4272,7 +4534,9 @@
         "memphis",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.0,
+      "goatRecentRank": 81
     },
     {
       "id": "devin-booker-1626164",
@@ -4302,7 +4566,9 @@
         "phoenix",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 66.0,
+      "goatRecentRank": 32
     },
     {
       "id": "devin-cannady-1629962",
@@ -4334,7 +4600,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.0,
+      "goatRecentRank": 329
     },
     {
       "id": "devin-vassell-1630170",
@@ -4363,7 +4631,9 @@
         "starter",
         "vassell"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.7,
+      "goatRecentRank": 182
     },
     {
       "id": "devon-dotson-1629653",
@@ -4394,7 +4664,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.6,
+      "goatRecentRank": 400
     },
     {
       "id": "devontae-cacok-1629719",
@@ -4426,7 +4698,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.1,
+      "goatRecentRank": 416
     },
     {
       "id": "devonte-graham-1628984",
@@ -4458,7 +4732,9 @@
         "raleigh",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.3,
+      "goatRecentRank": 264
     },
     {
       "id": "dewayne-dedmon-203473",
@@ -4490,7 +4766,9 @@
         "miami",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.5,
+      "goatRecentRank": 311
     },
     {
       "id": "didi-louzada-1629712",
@@ -4522,7 +4800,9 @@
         "pelicans",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 543
     },
     {
       "id": "dillon-brooks-1628415",
@@ -4552,7 +4832,9 @@
         "mississaugua",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.4,
+      "goatRecentRank": 124
     },
     {
       "id": "domantas-sabonis-1627734",
@@ -4582,7 +4864,9 @@
         "portland",
         "sabonis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 78.0,
+      "goatRecentRank": 7
     },
     {
       "id": "donovan-mitchell-1628378",
@@ -4612,7 +4896,9 @@
         "new york",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 73.8,
+      "goatRecentRank": 13
     },
     {
       "id": "donta-hall-1629743",
@@ -4643,7 +4929,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 511
     },
     {
       "id": "donte-divincenzo-1628978",
@@ -4673,7 +4961,9 @@
         "newark",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.7,
+      "goatRecentRank": 63
     },
     {
       "id": "dorian-finney-smith-1627827",
@@ -4703,7 +4993,9 @@
         "starter",
         "virginia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 38.0,
+      "goatRecentRank": 205
     },
     {
       "id": "doug-mcdermott-203926",
@@ -4733,7 +5025,9 @@
         "pacers",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 33.7,
+      "goatRecentRank": 225
     },
     {
       "id": "draymond-green-203110",
@@ -4764,7 +5058,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.0,
+      "goatRecentRank": 52
     },
     {
       "id": "drew-eubanks-1629234",
@@ -4797,7 +5093,9 @@
         "spurs",
         "starkville"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.8,
+      "goatRecentRank": 101
     },
     {
       "id": "duncan-robinson-1629130",
@@ -4827,7 +5125,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 45.8,
+      "goatRecentRank": 155
     },
     {
       "id": "dwayne-bacon-1628407",
@@ -4861,7 +5161,9 @@
         "orlando",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.3,
+      "goatRecentRank": 413
     },
     {
       "id": "dwight-howard-2730",
@@ -4897,7 +5199,9 @@
         "of",
         "philadelphia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 531
     },
     {
       "id": "dwight-powell-203939",
@@ -4931,7 +5235,9 @@
         "starter",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.2,
+      "goatRecentRank": 152
     },
     {
       "id": "dylan-windler-1629685",
@@ -4964,7 +5270,9 @@
         "usa",
         "windler"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.3,
+      "goatRecentRank": 365
     },
     {
       "id": "e-twaun-moore-202734",
@@ -4996,7 +5304,9 @@
         "starter",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 460
     },
     {
       "id": "ed-davis-202334",
@@ -5030,7 +5340,9 @@
         "timberwolves",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 536
     },
     {
       "id": "edmond-sumner-1628410",
@@ -5062,7 +5374,9 @@
         "rotation",
         "sumner"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.7,
+      "goatRecentRank": 290
     },
     {
       "id": "elfrid-payton-203901",
@@ -5095,7 +5409,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.0,
+      "goatRecentRank": 404
     },
     {
       "id": "elijah-bryant-1629091",
@@ -5126,7 +5442,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 438
     },
     {
       "id": "elijah-hughes-1630190",
@@ -5157,7 +5475,9 @@
         "usa",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 473
     },
     {
       "id": "enes-freedom-202683",
@@ -5190,7 +5510,9 @@
         "trail",
         "zürich"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 540
     },
     {
       "id": "eric-bledsoe-202339",
@@ -5223,7 +5545,9 @@
         "pelicans",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 517
     },
     {
       "id": "eric-gordon-201569",
@@ -5253,7 +5577,9 @@
         "rockets",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.3,
+      "goatRecentRank": 212
     },
     {
       "id": "eric-paschall-1629672",
@@ -5286,7 +5612,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.9,
+      "goatRecentRank": 307
     },
     {
       "id": "ersan-ilyasova-101141",
@@ -5318,7 +5646,9 @@
         "turkey",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 477
     },
     {
       "id": "evan-fournier-203095",
@@ -5352,7 +5682,9 @@
         "saint-quentin",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.9,
+      "goatRecentRank": 335
     },
     {
       "id": "facundo-campazzo-1630267",
@@ -5383,7 +5715,9 @@
         "nuggets",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 8.5,
+      "goatRecentRank": 395
     },
     {
       "id": "frank-jackson-1628402",
@@ -5415,7 +5749,9 @@
         "rotation",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 8.0,
+      "goatRecentRank": 397
     },
     {
       "id": "frank-kaminsky-1626163",
@@ -5449,7 +5785,9 @@
         "suns",
         "winfield"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.0,
+      "goatRecentRank": 349
     },
     {
       "id": "frank-mason-iii-1628412",
@@ -5482,7 +5820,9 @@
         "rotation",
         "virginia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 490
     },
     {
       "id": "frank-ntilikina-1628373",
@@ -5515,7 +5855,9 @@
         "rotation",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.6,
+      "goatRecentRank": 362
     },
     {
       "id": "fred-vanvleet-1627832",
@@ -5545,7 +5887,9 @@
         "toronto",
         "vanvleet"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.9,
+      "goatRecentRank": 62
     },
     {
       "id": "freddie-gillespie-1630273",
@@ -5576,7 +5920,9 @@
         "toronto",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 441
     },
     {
       "id": "furkan-korkmaz-1627788",
@@ -5610,7 +5956,9 @@
         "rotation",
         "turkey"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 26.8,
+      "goatRecentRank": 270
     },
     {
       "id": "ga-bitadze-1629048",
@@ -5644,7 +5992,9 @@
         "rotation",
         "sagarejo"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 51.7,
+      "goatRecentRank": 107
     },
     {
       "id": "gabe-vincent-1629216",
@@ -5676,7 +6026,9 @@
         "rotation",
         "vincent"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.5,
+      "goatRecentRank": 209
     },
     {
       "id": "gabriel-deck-1630466",
@@ -5708,7 +6060,9 @@
         "reserve",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 498
     },
     {
       "id": "garrett-temple-202066",
@@ -5738,7 +6092,9 @@
         "starter",
         "temple"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.4,
+      "goatRecentRank": 312
     },
     {
       "id": "garrison-mathews-1629726",
@@ -5768,7 +6124,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 32.5,
+      "goatRecentRank": 233
     },
     {
       "id": "gary-clark-1629109",
@@ -5800,7 +6158,9 @@
         "rotation",
         "smithfield"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 421
     },
     {
       "id": "gary-harris-203914",
@@ -5832,7 +6192,9 @@
         "orlando",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 31.5,
+      "goatRecentRank": 239
     },
     {
       "id": "gary-payton-ii-1627780",
@@ -5866,7 +6228,9 @@
         "seattle",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.5,
+      "goatRecentRank": 176
     },
     {
       "id": "gary-trent-jr-1629018",
@@ -5899,7 +6263,9 @@
         "toronto",
         "trent"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 45.4,
+      "goatRecentRank": 157
     },
     {
       "id": "george-hill-201588",
@@ -5931,7 +6297,9 @@
         "indianapolis",
         "philadelphia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 19.4,
+      "goatRecentRank": 333
     },
     {
       "id": "georges-niang-1627777",
@@ -5963,7 +6331,9 @@
         "starter",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.8,
+      "goatRecentRank": 121
     },
     {
       "id": "giannis-antetokounmpo-203507",
@@ -5993,7 +6363,9 @@
         "greece",
         "milwaukee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 88.9,
+      "goatRecentRank": 3
     },
     {
       "id": "glenn-robinson-iii-203922",
@@ -6027,7 +6399,9 @@
         "robinson",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 446
     },
     {
       "id": "goran-dragic-201609",
@@ -6059,7 +6433,9 @@
         "slovenia (frmr yugoslavia)",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 21.4,
+      "goatRecentRank": 316
     },
     {
       "id": "gordon-hayward-202330",
@@ -6091,7 +6467,9 @@
         "indianapolis",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.6,
+      "goatRecentRank": 249
     },
     {
       "id": "gorgui-dieng-203476",
@@ -6124,7 +6502,9 @@
         "spurs",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 9.9,
+      "goatRecentRank": 392
     },
     {
       "id": "grant-riller-1630203",
@@ -6155,7 +6535,9 @@
         "riller",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 444
     },
     {
       "id": "grant-williams-1629684",
@@ -6185,7 +6567,9 @@
         "texas",
         "williams"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.3,
+      "goatRecentRank": 190
     },
     {
       "id": "grayson-allen-1628960",
@@ -6217,7 +6601,9 @@
         "memphis",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.7,
+      "goatRecentRank": 128
     },
     {
       "id": "greg-whittington-204222",
@@ -6249,7 +6635,9 @@
         "usa",
         "whittington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 472
     },
     {
       "id": "hamidou-diallo-1628977",
@@ -6281,7 +6669,9 @@
         "queens",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.6,
+      "goatRecentRank": 351
     },
     {
       "id": "harrison-barnes-203084",
@@ -6311,7 +6701,9 @@
         "kings",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.4,
+      "goatRecentRank": 150
     },
     {
       "id": "harry-giles-iii-1628385",
@@ -6346,7 +6738,9 @@
         "trail",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.6,
+      "goatRecentRank": 352
     },
     {
       "id": "hassan-whiteside-202355",
@@ -6378,7 +6772,9 @@
         "starter",
         "whiteside"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 501
     },
     {
       "id": "henry-ellenson-1627740",
@@ -6413,7 +6809,9 @@
         "rotation",
         "wisconsin"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 502
     },
     {
       "id": "ignas-brazdeikis-1629649",
@@ -6444,7 +6842,9 @@
         "orlando",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 469
     },
     {
       "id": "iman-shumpert-202697",
@@ -6477,7 +6877,9 @@
         "shumpert",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 494
     },
     {
       "id": "immanuel-quickley-1630193",
@@ -6509,7 +6911,9 @@
         "usa",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.7,
+      "goatRecentRank": 114
     },
     {
       "id": "isaac-bonga-1629067",
@@ -6541,7 +6945,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 455
     },
     {
       "id": "isaac-okoro-1630171",
@@ -6574,7 +6980,9 @@
         "starter",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.0,
+      "goatRecentRank": 154
     },
     {
       "id": "isaiah-hartenstein-1628392",
@@ -6608,7 +7016,9 @@
         "oregon",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 66.3,
+      "goatRecentRank": 29
     },
     {
       "id": "isaiah-joe-1630198",
@@ -6639,7 +7049,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.6,
+      "goatRecentRank": 78
     },
     {
       "id": "isaiah-roby-1629676",
@@ -6672,7 +7084,9 @@
         "rotation",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 13.6,
+      "goatRecentRank": 373
     },
     {
       "id": "isaiah-stewart-1630191",
@@ -6702,7 +7116,9 @@
         "rotation",
         "stewart"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.2,
+      "goatRecentRank": 200
     },
     {
       "id": "isaiah-thomas-202738",
@@ -6735,7 +7151,9 @@
         "thomas",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 13.9,
+      "goatRecentRank": 371
     },
     {
       "id": "ish-smith-202397",
@@ -6765,7 +7183,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.6,
+      "goatRecentRank": 291
     },
     {
       "id": "ivica-zubac-1627826",
@@ -6796,7 +7216,9 @@
         "starter",
         "zubac"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.5,
+      "goatRecentRank": 37
     },
     {
       "id": "ja-morant-1629630",
@@ -6826,7 +7248,9 @@
         "south carolina",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.2,
+      "goatRecentRank": 98
     },
     {
       "id": "jabari-parker-203953",
@@ -6858,7 +7282,9 @@
         "parker",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 495
     },
     {
       "id": "jaden-mcdaniels-1630183",
@@ -6886,7 +7312,9 @@
         "starter",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.2,
+      "goatRecentRank": 105
     },
     {
       "id": "jae-crowder-203109",
@@ -6916,7 +7344,9 @@
         "suns",
         "villa rica"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.5,
+      "goatRecentRank": 295
     },
     {
       "id": "jae-sean-tate-1630256",
@@ -6946,7 +7376,9 @@
         "rotation",
         "tate"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.3,
+      "goatRecentRank": 210
     },
     {
       "id": "jahlil-okafor-1626143",
@@ -6980,7 +7412,9 @@
         "pistons",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 2.7,
+      "goatRecentRank": 410
     },
     {
       "id": "jahmi-us-ramsey-1630186",
@@ -7011,7 +7445,9 @@
         "sacramento",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.6,
+      "goatRecentRank": 399
     },
     {
       "id": "jakarr-sampson-203960",
@@ -7043,7 +7479,9 @@
         "rotation",
         "sampson"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 426
     },
     {
       "id": "jake-layman-1627774",
@@ -7075,7 +7513,9 @@
         "timberwolves",
         "wrentham"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.5,
+      "goatRecentRank": 250
     },
     {
       "id": "jakob-poeltl-1627751",
@@ -7106,7 +7546,9 @@
         "starter",
         "vienna"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.0,
+      "goatRecentRank": 99
     },
     {
       "id": "jalen-brunson-1628973",
@@ -7136,7 +7578,9 @@
         "new jersey",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 73.3,
+      "goatRecentRank": 14
     },
     {
       "id": "jalen-harris-1630223",
@@ -7167,7 +7611,9 @@
         "toronto",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.1,
+      "goatRecentRank": 304
     },
     {
       "id": "jalen-lecque-1629665",
@@ -7199,7 +7645,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 488
     },
     {
       "id": "jalen-mcdaniels-1629667",
@@ -7233,7 +7681,9 @@
         "rotation",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 32.0,
+      "goatRecentRank": 235
     },
     {
       "id": "jalen-smith-1630188",
@@ -7263,7 +7713,9 @@
         "smith",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.3,
+      "goatRecentRank": 67
     },
     {
       "id": "jamal-murray-1627750",
@@ -7293,7 +7745,9 @@
         "murray",
         "nuggets"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 71.4,
+      "goatRecentRank": 17
     },
     {
       "id": "james-ennis-iii-203516",
@@ -7325,7 +7779,9 @@
         "starter",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 422
     },
     {
       "id": "james-harden-201935",
@@ -7357,7 +7813,9 @@
         "nets",
         "of"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 74.9,
+      "goatRecentRank": 10
     },
     {
       "id": "james-johnson-201949",
@@ -7388,7 +7846,9 @@
         "starter",
         "wyoming"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.1,
+      "goatRecentRank": 342
     },
     {
       "id": "james-nunnally-203263",
@@ -7420,7 +7880,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 506
     },
     {
       "id": "james-wiseman-1630164",
@@ -7452,7 +7914,9 @@
         "warriors",
         "wiseman"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.1,
+      "goatRecentRank": 253
     },
     {
       "id": "jamychal-green-203210",
@@ -7486,7 +7950,9 @@
         "nuggets",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.0,
+      "goatRecentRank": 280
     },
     {
       "id": "jared-dudley-201162",
@@ -7519,7 +7985,9 @@
         "san diego",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 491
     },
     {
       "id": "jared-harper-1629607",
@@ -7551,7 +8019,9 @@
         "usa",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 450
     },
     {
       "id": "jaren-jackson-jr-1628991",
@@ -7582,7 +8052,9 @@
         "plainfield",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.8,
+      "goatRecentRank": 35
     },
     {
       "id": "jarred-vanderbilt-1629020",
@@ -7614,7 +8086,9 @@
         "timberwolves",
         "vanderbilt"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.6,
+      "goatRecentRank": 173
     },
     {
       "id": "jarrell-brantley-1629714",
@@ -7645,7 +8119,9 @@
         "usa",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 2.7,
+      "goatRecentRank": 409
     },
     {
       "id": "jarrett-allen-1628386",
@@ -7675,7 +8151,9 @@
         "san diego",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 69.1,
+      "goatRecentRank": 20
     },
     {
       "id": "jarrett-culver-1629633",
@@ -7709,7 +8187,9 @@
         "texas",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 12.1,
+      "goatRecentRank": 379
     },
     {
       "id": "javale-mcgee-201580",
@@ -7743,7 +8223,9 @@
         "nuggets",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 35.8,
+      "goatRecentRank": 219
     },
     {
       "id": "javonte-green-1629750",
@@ -7775,7 +8257,9 @@
         "rotation",
         "virginia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.6,
+      "goatRecentRank": 248
     },
     {
       "id": "jaxson-hayes-1629637",
@@ -7806,7 +8290,9 @@
         "pelicans",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.6,
+      "goatRecentRank": 147
     },
     {
       "id": "jay-scrubb-1630206",
@@ -7836,7 +8322,9 @@
         "scrubb",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 11.8,
+      "goatRecentRank": 382
     },
     {
       "id": "jaylen-adams-1629121",
@@ -7868,7 +8356,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 427
     },
     {
       "id": "jaylen-brown-1627759",
@@ -7898,7 +8388,9 @@
         "jaylen",
         "marietta"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 72.9,
+      "goatRecentRank": 15
     },
     {
       "id": "jaylen-hoard-1629658",
@@ -7930,7 +8422,9 @@
         "rotation",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 487
     },
     {
       "id": "jaylen-nowell-1629669",
@@ -7962,7 +8456,9 @@
         "timberwolves",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.3,
+      "goatRecentRank": 263
     },
     {
       "id": "jayson-tatum-1628369",
@@ -7992,7 +8488,9 @@
         "st. louis",
         "tatum"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 83.9,
+      "goatRecentRank": 4
     },
     {
       "id": "jeff-green-201145",
@@ -8024,7 +8522,9 @@
         "maryland",
         "nets"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.9,
+      "goatRecentRank": 188
     },
     {
       "id": "jeff-teague-201952",
@@ -8056,7 +8556,9 @@
         "milwaukee",
         "teague"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 520
     },
     {
       "id": "jerami-grant-203924",
@@ -8086,7 +8588,9 @@
         "portland",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.9,
+      "goatRecentRank": 196
     },
     {
       "id": "jeremiah-martin-1629725",
@@ -8118,7 +8622,9 @@
         "reserve",
         "tennessee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 513
     },
     {
       "id": "jeremy-lamb-203087",
@@ -8152,7 +8658,9 @@
         "starter",
         "virginia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 4.8,
+      "goatRecentRank": 408
     },
     {
       "id": "jerome-robinson-1629010",
@@ -8185,7 +8693,9 @@
         "robinson",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.7,
+      "goatRecentRank": 308
     },
     {
       "id": "jevon-carter-1628975",
@@ -8217,7 +8727,9 @@
         "rotation",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 44.0,
+      "goatRecentRank": 164
     },
     {
       "id": "jimmy-butler-202710",
@@ -8249,7 +8761,9 @@
         "miami",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.4,
+      "goatRecentRank": 38
     },
     {
       "id": "jj-redick-200755",
@@ -8281,7 +8795,9 @@
         "starter",
         "tennessee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 420
     },
     {
       "id": "joe-harris-203925",
@@ -8315,7 +8831,9 @@
         "starter",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.1,
+      "goatRecentRank": 302
     },
     {
       "id": "joe-ingles-204060",
@@ -8347,7 +8865,9 @@
         "starter",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.3,
+      "goatRecentRank": 211
     },
     {
       "id": "joel-embiid-203954",
@@ -8381,7 +8901,9 @@
         "philadelphia",
         "yaounde"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.7,
+      "goatRecentRank": 47
     },
     {
       "id": "john-collins-1628381",
@@ -8413,7 +8935,9 @@
         "starter",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.4,
+      "goatRecentRank": 132
     },
     {
       "id": "john-konchar-1629723",
@@ -8445,7 +8969,9 @@
         "memphis",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.7,
+      "goatRecentRank": 183
     },
     {
       "id": "john-wall-202322",
@@ -8477,7 +9003,9 @@
         "rockets",
         "wall"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.2,
+      "goatRecentRank": 339
     },
     {
       "id": "jonas-valanciunas-202685",
@@ -8509,7 +9037,9 @@
         "utena",
         "valanciunas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 69.1,
+      "goatRecentRank": 21
     },
     {
       "id": "jonathan-isaac-1628371",
@@ -8541,7 +9071,9 @@
         "orlando",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.4,
+      "goatRecentRank": 149
     },
     {
       "id": "jontay-porter-1629007",
@@ -8574,7 +9106,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 11.1,
+      "goatRecentRank": 387
     },
     {
       "id": "jordan-bell-1628395",
@@ -8607,7 +9141,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 530
     },
     {
       "id": "jordan-bone-1629648",
@@ -8640,7 +9176,9 @@
         "reserve",
         "tennessee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 456
     },
     {
       "id": "jordan-clarkson-203903",
@@ -8672,7 +9210,9 @@
         "tampa",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.9,
+      "goatRecentRank": 180
     },
     {
       "id": "jordan-mclaughlin-1629162",
@@ -8702,7 +9242,9 @@
         "rotation",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.2,
+      "goatRecentRank": 186
     },
     {
       "id": "jordan-nwora-1629670",
@@ -8733,7 +9275,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 31.9,
+      "goatRecentRank": 236
     },
     {
       "id": "jordan-poole-1629673",
@@ -8764,7 +9308,9 @@
         "warriors",
         "wisconsin"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 59.8,
+      "goatRecentRank": 59
     },
     {
       "id": "josh-green-1630182",
@@ -8792,7 +9338,9 @@
         "mavericks",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 36.5,
+      "goatRecentRank": 216
     },
     {
       "id": "josh-hall-1630221",
@@ -8824,7 +9372,9 @@
         "thunder",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 505
     },
     {
       "id": "josh-hart-1628404",
@@ -8855,7 +9405,9 @@
         "silver spring",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 57.4,
+      "goatRecentRank": 73
     },
     {
       "id": "josh-jackson-1628367",
@@ -8889,7 +9441,9 @@
         "san diego",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.5,
+      "goatRecentRank": 363
     },
     {
       "id": "josh-okogie-1629006",
@@ -8921,7 +9475,9 @@
         "rotation",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 44.8,
+      "goatRecentRank": 162
     },
     {
       "id": "josh-richardson-1626196",
@@ -8951,7 +9507,9 @@
         "richardson",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.3,
+      "goatRecentRank": 251
     },
     {
       "id": "jrue-holiday-201950",
@@ -8981,7 +9539,9 @@
         "jrue",
         "milwaukee"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.6,
+      "goatRecentRank": 36
     },
     {
       "id": "juan-toscano-anderson-1629308",
@@ -9014,7 +9574,9 @@
         "toscano-anderson",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.3,
+      "goatRecentRank": 345
     },
     {
       "id": "juancho-hernangomez-1627823",
@@ -9043,7 +9605,9 @@
         "spain",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.1,
+      "goatRecentRank": 348
     },
     {
       "id": "julius-randle-203944",
@@ -9076,7 +9640,9 @@
         "texas",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 66.3,
+      "goatRecentRank": 30
     },
     {
       "id": "justin-holiday-203200",
@@ -9110,7 +9676,9 @@
         "pacers",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.0,
+      "goatRecentRank": 267
     },
     {
       "id": "justin-jackson-1628382",
@@ -9140,7 +9708,9 @@
         "rotation",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 19.0,
+      "goatRecentRank": 334
     },
     {
       "id": "justin-james-1629713",
@@ -9174,7 +9744,9 @@
         "rotation",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 489
     },
     {
       "id": "justin-patton-1628383",
@@ -9207,7 +9779,9 @@
         "riverdale",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 468
     },
     {
       "id": "justin-robinson-1629620",
@@ -9239,7 +9813,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 434
     },
     {
       "id": "justise-winslow-1626159",
@@ -9273,7 +9849,9 @@
         "texas",
         "winslow"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.0,
+      "goatRecentRank": 358
     },
     {
       "id": "jusuf-nurkic-203994",
@@ -9306,7 +9884,9 @@
         "trail",
         "tuzla"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.7,
+      "goatRecentRank": 76
     },
     {
       "id": "juwan-morgan-1629752",
@@ -9338,7 +9918,9 @@
         "utah",
         "waynesville"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 533
     },
     {
       "id": "karim-mane-1630211",
@@ -9370,7 +9952,9 @@
         "reserve",
         "senegal"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 479
     },
     {
       "id": "karl-anthony-towns-1626157",
@@ -9400,7 +9984,9 @@
         "timberwolves",
         "towns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 66.8,
+      "goatRecentRank": 27
     },
     {
       "id": "kawhi-leonard-202695",
@@ -9433,7 +10019,9 @@
         "los",
         "los angeles"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.0,
+      "goatRecentRank": 70
     },
     {
       "id": "keita-bates-diop-1628966",
@@ -9464,7 +10052,9 @@
         "san",
         "spurs"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 30.2,
+      "goatRecentRank": 242
     },
     {
       "id": "kelan-martin-1629103",
@@ -9496,7 +10086,9 @@
         "pacers",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 11.6,
+      "goatRecentRank": 383
     },
     {
       "id": "keldon-johnson-1629640",
@@ -9527,7 +10119,9 @@
         "starter",
         "virginia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.5,
+      "goatRecentRank": 131
     },
     {
       "id": "keljin-blevins-1629833",
@@ -9559,7 +10153,9 @@
         "trail",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 523
     },
     {
       "id": "kelly-olynyk-203482",
@@ -9591,7 +10187,9 @@
         "starter",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.7,
+      "goatRecentRank": 123
     },
     {
       "id": "kelly-oubre-jr-1626162",
@@ -9623,7 +10221,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 44.7,
+      "goatRecentRank": 163
     },
     {
       "id": "kemba-walker-202689",
@@ -9655,7 +10255,9 @@
         "new york",
         "walker"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 14.3,
+      "goatRecentRank": 368
     },
     {
       "id": "kendrick-nunn-1629134",
@@ -9687,7 +10289,9 @@
         "nunn",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.6,
+      "goatRecentRank": 310
     },
     {
       "id": "kenrich-williams-1629026",
@@ -9720,7 +10324,9 @@
         "waco",
         "williams"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.4,
+      "goatRecentRank": 97
     },
     {
       "id": "kent-bazemore-203145",
@@ -9755,7 +10361,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.8,
+      "goatRecentRank": 258
     },
     {
       "id": "kentavious-caldwell-pope-203484",
@@ -9786,7 +10394,9 @@
         "starter",
         "thomaston"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.3,
+      "goatRecentRank": 135
     },
     {
       "id": "kenyon-martin-jr-1630231",
@@ -9818,7 +10428,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.9,
+      "goatRecentRank": 207
     },
     {
       "id": "kevin-durant-201142",
@@ -9850,7 +10462,9 @@
         "of",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 67.0,
+      "goatRecentRank": 26
     },
     {
       "id": "kevin-huerter-1628989",
@@ -9880,7 +10494,9 @@
         "kevin",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 51.2,
+      "goatRecentRank": 111
     },
     {
       "id": "kevin-knox-ii-1628995",
@@ -9910,7 +10526,9 @@
         "rotation",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.4,
+      "goatRecentRank": 298
     },
     {
       "id": "kevin-love-201567",
@@ -9942,7 +10560,9 @@
         "love",
         "santa monica"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.8,
+      "goatRecentRank": 120
     },
     {
       "id": "kevin-porter-jr-1629645",
@@ -9975,7 +10595,9 @@
         "starter",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.5,
+      "goatRecentRank": 175
     },
     {
       "id": "kevon-looney-1626172",
@@ -10006,7 +10628,9 @@
         "warriors",
         "wisconsin"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 63.1,
+      "goatRecentRank": 45
     },
     {
       "id": "khem-birch-203920",
@@ -10038,7 +10662,9 @@
         "rotation",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 14.8,
+      "goatRecentRank": 367
     },
     {
       "id": "khris-middleton-203114",
@@ -10070,7 +10696,9 @@
         "milwaukee",
         "south carolina"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 45.0,
+      "goatRecentRank": 159
     },
     {
       "id": "khyri-thomas-1629017",
@@ -10102,7 +10730,9 @@
         "rockets",
         "thomas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 486
     },
     {
       "id": "killian-hayes-1630165",
@@ -10133,7 +10763,9 @@
         "pistons",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 28.8,
+      "goatRecentRank": 256
     },
     {
       "id": "killian-tillie-1629681",
@@ -10166,7 +10798,9 @@
         "rotation",
         "tillie"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 524
     },
     {
       "id": "kira-lewis-jr-1630184",
@@ -10199,7 +10833,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.7,
+      "goatRecentRank": 337
     },
     {
       "id": "klay-thompson-202691",
@@ -10232,7 +10868,9 @@
         "thompson",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 54.7,
+      "goatRecentRank": 90
     },
     {
       "id": "kostas-antetokounmpo-1628961",
@@ -10265,7 +10903,9 @@
         "los",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 12.6,
+      "goatRecentRank": 377
     },
     {
       "id": "kris-dunn-1627739",
@@ -10295,7 +10935,9 @@
         "new london",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 43.8,
+      "goatRecentRank": 166
     },
     {
       "id": "kristaps-porzingis-204001",
@@ -10327,7 +10969,9 @@
         "porzingis",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.6,
+      "goatRecentRank": 48
     },
     {
       "id": "kyle-anderson-203937",
@@ -10359,7 +11003,9 @@
         "new york city",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 60.3,
+      "goatRecentRank": 58
     },
     {
       "id": "kyle-guy-1629657",
@@ -10389,7 +11035,9 @@
         "reserve",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 453
     },
     {
       "id": "kyle-kuzma-1628398",
@@ -10420,7 +11068,9 @@
         "michigan",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.5,
+      "goatRecentRank": 117
     },
     {
       "id": "kyle-lowry-200768",
@@ -10450,7 +11100,9 @@
         "raptors",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.4,
+      "goatRecentRank": 179
     },
     {
       "id": "kyrie-irving-202681",
@@ -10480,7 +11132,9 @@
         "nets",
         "sydney"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 60.3,
+      "goatRecentRank": 57
     },
     {
       "id": "kz-okpala-1629644",
@@ -10514,7 +11168,9 @@
         "orange county",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.8,
+      "goatRecentRank": 343
     },
     {
       "id": "lamar-stevens-1630205",
@@ -10545,7 +11201,9 @@
         "stevens",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 33.5,
+      "goatRecentRank": 226
     },
     {
       "id": "lamarcus-aldridge-200746",
@@ -10580,7 +11238,9 @@
         "lamarcus",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 454
     },
     {
       "id": "lamelo-ball-1630163",
@@ -10608,7 +11268,9 @@
         "lamelo",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 38.6,
+      "goatRecentRank": 204
     },
     {
       "id": "landry-shamet-1629013",
@@ -10638,7 +11300,9 @@
         "shamet",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 32.8,
+      "goatRecentRank": 231
     },
     {
       "id": "langston-galloway-204038",
@@ -10670,7 +11334,9 @@
         "starter",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 10.2,
+      "goatRecentRank": 390
     },
     {
       "id": "larry-nance-jr-1626204",
@@ -10703,7 +11369,9 @@
         "ohio",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.8,
+      "goatRecentRank": 181
     },
     {
       "id": "lauri-markkanen-1628374",
@@ -10733,7 +11401,9 @@
         "starter",
         "vantaa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.4,
+      "goatRecentRank": 141
     },
     {
       "id": "lebron-james-2544",
@@ -10767,7 +11437,9 @@
         "los",
         "ohio"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 77.8,
+      "goatRecentRank": 8
     },
     {
       "id": "lonnie-walker-iv-1629022",
@@ -10799,7 +11471,9 @@
         "spurs",
         "walker"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 35.2,
+      "goatRecentRank": 221
     },
     {
       "id": "lonzo-ball-1628366",
@@ -10830,7 +11504,9 @@
         "pelicans",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 19.6,
+      "goatRecentRank": 332
     },
     {
       "id": "lou-williams-101150",
@@ -10862,7 +11538,9 @@
         "tennessee",
         "williams"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 515
     },
     {
       "id": "louis-king-1629663",
@@ -10894,7 +11572,9 @@
         "sacramento",
         "secaucus"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 24.1,
+      "goatRecentRank": 287
     },
     {
       "id": "luca-vildoza-1630492",
@@ -10926,7 +11606,9 @@
         "vildoza",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.6,
+      "goatRecentRank": 412
     },
     {
       "id": "luguentz-dort-1629652",
@@ -10957,7 +11639,9 @@
         "starter",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.9,
+      "goatRecentRank": 100
     },
     {
       "id": "luka-doncic-1629029",
@@ -10991,7 +11675,9 @@
         "mavericks",
         "slovenia (frmr yugoslavia)"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 81.4,
+      "goatRecentRank": 5
     },
     {
       "id": "luka-samanic-1629677",
@@ -11024,7 +11710,9 @@
         "spurs",
         "zagreb"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.5,
+      "goatRecentRank": 344
     },
     {
       "id": "luke-kennard-1628379",
@@ -11057,7 +11745,9 @@
         "ohio",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.3,
+      "goatRecentRank": 192
     },
     {
       "id": "luke-kornet-1628436",
@@ -11087,7 +11777,9 @@
         "luke",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 62.9,
+      "goatRecentRank": 46
     },
     {
       "id": "malachi-flynn-1630201",
@@ -11118,7 +11810,9 @@
         "toronto",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 33.4,
+      "goatRecentRank": 227
     },
     {
       "id": "malcolm-brogdon-1627763",
@@ -11150,7 +11844,9 @@
         "pacers",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.6,
+      "goatRecentRank": 174
     },
     {
       "id": "malik-beasley-1627736",
@@ -11182,7 +11878,9 @@
         "starter",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.0,
+      "goatRecentRank": 119
     },
     {
       "id": "malik-fitts-1630238",
@@ -11214,7 +11912,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 1.8,
+      "goatRecentRank": 411
     },
     {
       "id": "malik-monk-1628370",
@@ -11244,7 +11944,9 @@
         "monk",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 63.3,
+      "goatRecentRank": 43
     },
     {
       "id": "mamadi-diakite-1629603",
@@ -11275,7 +11977,9 @@
         "milwaukee",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.8,
+      "goatRecentRank": 320
     },
     {
       "id": "marc-gasol-201188",
@@ -11308,7 +12012,9 @@
         "marc",
         "spain"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 442
     },
     {
       "id": "marcus-morris-sr-202694",
@@ -11341,7 +12047,9 @@
         "starter",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.7,
+      "goatRecentRank": 245
     },
     {
       "id": "marcus-smart-203935",
@@ -11373,7 +12081,9 @@
         "smart",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.1,
+      "goatRecentRank": 194
     },
     {
       "id": "markelle-fultz-1628365",
@@ -11405,7 +12115,9 @@
         "prince george's county",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 37.9,
+      "goatRecentRank": 206
     },
     {
       "id": "markieff-morris-202693",
@@ -11438,7 +12150,9 @@
         "philadelphia",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 24.8,
+      "goatRecentRank": 283
     },
     {
       "id": "markus-howard-1630210",
@@ -11469,7 +12183,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 538
     },
     {
       "id": "marques-bolden-1629716",
@@ -11501,7 +12217,9 @@
         "reserve",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 9.8,
+      "goatRecentRank": 393
     },
     {
       "id": "marquese-chriss-1627737",
@@ -11534,7 +12252,9 @@
         "rotation",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 500
     },
     {
       "id": "marvin-bagley-iii-1628963",
@@ -11567,7 +12287,9 @@
         "sacramento",
         "tempe"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 31.8,
+      "goatRecentRank": 237
     },
     {
       "id": "mason-jones-1630222",
@@ -11596,7 +12318,9 @@
         "mason",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 11.5,
+      "goatRecentRank": 384
     },
     {
       "id": "mason-plumlee-203486",
@@ -11628,7 +12352,9 @@
         "plumlee",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.0,
+      "goatRecentRank": 88
     },
     {
       "id": "matisse-thybulle-1629680",
@@ -11662,7 +12388,9 @@
         "scottsdale",
         "thybulle"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 33.0,
+      "goatRecentRank": 230
     },
     {
       "id": "matt-thomas-1629744",
@@ -11694,7 +12422,9 @@
         "thomas",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 443
     },
     {
       "id": "matthew-dellavedova-203521",
@@ -11726,7 +12456,9 @@
         "matthew",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.3,
+      "goatRecentRank": 325
     },
     {
       "id": "maurice-harkless-203090",
@@ -11760,7 +12492,9 @@
         "sacramento",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 484
     },
     {
       "id": "max-strus-1629622",
@@ -11790,7 +12524,9 @@
         "starter",
         "strus"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.8,
+      "goatRecentRank": 112
     },
     {
       "id": "maxi-kleber-1628467",
@@ -11820,7 +12556,9 @@
         "rotation",
         "wurzburg"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 28.0,
+      "goatRecentRank": 257
     },
     {
       "id": "meyers-leonard-203086",
@@ -11855,7 +12593,9 @@
         "virginia",
         "woodbridge"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.2,
+      "goatRecentRank": 355
     },
     {
       "id": "mfiondu-kabengele-1629662",
@@ -11887,7 +12627,9 @@
         "mfiondu",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.1,
+      "goatRecentRank": 357
     },
     {
       "id": "michael-carter-williams-203487",
@@ -11919,7 +12661,9 @@
         "orlando",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 6.4,
+      "goatRecentRank": 407
     },
     {
       "id": "michael-porter-jr-1629008",
@@ -11950,7 +12694,9 @@
         "porter",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 60.7,
+      "goatRecentRank": 56
     },
     {
       "id": "mikal-bridges-1628969",
@@ -11980,7 +12726,9 @@
         "starter",
         "suns"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 54.9,
+      "goatRecentRank": 89
     },
     {
       "id": "mike-conley-201144",
@@ -12010,7 +12758,9 @@
         "mike",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.5,
+      "goatRecentRank": 65
     },
     {
       "id": "mike-james-1628455",
@@ -12041,7 +12791,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 423
     },
     {
       "id": "mike-muscala-203488",
@@ -12076,7 +12828,9 @@
         "starter",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.0,
+      "goatRecentRank": 254
     },
     {
       "id": "mike-scott-203118",
@@ -12108,7 +12862,9 @@
         "starter",
         "virginia"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 429
     },
     {
       "id": "miles-bridges-1628970",
@@ -12138,7 +12894,9 @@
         "miles",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 34.1,
+      "goatRecentRank": 224
     },
     {
       "id": "mitchell-robinson-1629011",
@@ -12173,7 +12931,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.8,
+      "goatRecentRank": 171
     },
     {
       "id": "miye-oni-1629671",
@@ -12206,7 +12966,9 @@
         "usa",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 12.0,
+      "goatRecentRank": 381
     },
     {
       "id": "mo-bamba-1628964",
@@ -12236,7 +12998,9 @@
         "orlando",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.4,
+      "goatRecentRank": 178
     },
     {
       "id": "monte-morris-1628420",
@@ -12266,7 +13030,9 @@
         "nuggets",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.2,
+      "goatRecentRank": 201
     },
     {
       "id": "montrezl-harrell-1626149",
@@ -12301,7 +13067,9 @@
         "starter",
         "tarboro"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.3,
+      "goatRecentRank": 265
     },
     {
       "id": "moritz-wagner-1629021",
@@ -12335,7 +13103,9 @@
         "rotation",
         "wagner"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.2,
+      "goatRecentRank": 106
     },
     {
       "id": "moses-brown-1629650",
@@ -12368,7 +13138,9 @@
         "rotation",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.4,
+      "goatRecentRank": 276
     },
     {
       "id": "mychal-mulder-1628539",
@@ -12400,7 +13172,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.8,
+      "goatRecentRank": 398
     },
     {
       "id": "myles-turner-1626167",
@@ -12430,7 +13204,9 @@
         "texas",
         "turner"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 68.0,
+      "goatRecentRank": 24
     },
     {
       "id": "naji-marshall-1630230",
@@ -12462,7 +13238,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 51.4,
+      "goatRecentRank": 110
     },
     {
       "id": "nassir-little-1629642",
@@ -12497,7 +13275,9 @@
         "rotation",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 26.7,
+      "goatRecentRank": 271
     },
     {
       "id": "nate-darling-1630268",
@@ -12525,7 +13305,9 @@
         "nate",
         "reserve"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 8.2,
+      "goatRecentRank": 396
     },
     {
       "id": "nate-hinton-1630207",
@@ -12558,7 +13340,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.5,
+      "goatRecentRank": 354
     },
     {
       "id": "nathan-knight-1630233",
@@ -12591,7 +13375,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.7,
+      "goatRecentRank": 323
     },
     {
       "id": "naz-reid-1629675",
@@ -12621,7 +13407,9 @@
         "starter",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.8,
+      "goatRecentRank": 33
     },
     {
       "id": "nemanja-bjelica-202357",
@@ -12653,7 +13441,9 @@
         "serbia (frmr yugoslavia)",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 525
     },
     {
       "id": "nerlens-noel-203457",
@@ -12688,7 +13478,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.1,
+      "goatRecentRank": 403
     },
     {
       "id": "nic-claxton-1629651",
@@ -12718,7 +13510,9 @@
         "south carolina",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.2,
+      "goatRecentRank": 68
     },
     {
       "id": "nick-richards-1630208",
@@ -12746,7 +13540,9 @@
         "richards",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 45.0,
+      "goatRecentRank": 160
     },
     {
       "id": "nickeil-alexander-walker-1629638",
@@ -12779,7 +13575,9 @@
         "starter",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 51.7,
+      "goatRecentRank": 108
     },
     {
       "id": "nico-mannion-1630185",
@@ -12811,7 +13609,9 @@
         "state",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 452
     },
     {
       "id": "nicolas-batum-201587",
@@ -12844,7 +13644,9 @@
         "los",
         "nicolas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.0,
+      "goatRecentRank": 144
     },
     {
       "id": "nicolo-melli-1629740",
@@ -12876,7 +13678,9 @@
         "reggio emilia",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 440
     },
     {
       "id": "nikola-jokic-203999",
@@ -12908,7 +13712,9 @@
         "serbia (frmr yugoslavia)",
         "sombor"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 100.0,
+      "goatRecentRank": 1
     },
     {
       "id": "nikola-vucevic-202696",
@@ -12938,7 +13744,9 @@
         "switzerland",
         "vucevic"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 66.2,
+      "goatRecentRank": 31
     },
     {
       "id": "noah-vonleh-203943",
@@ -12971,7 +13779,9 @@
         "salem",
         "vonleh"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.7,
+      "goatRecentRank": 322
     },
     {
       "id": "norman-powell-1626181",
@@ -13002,7 +13812,9 @@
         "starter",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.5,
+      "goatRecentRank": 103
     },
     {
       "id": "norvel-pelle-203658",
@@ -13035,7 +13847,9 @@
         "st. john's",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 507
     },
     {
       "id": "obi-toppin-1630167",
@@ -13066,7 +13880,9 @@
         "toppin",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.6,
+      "goatRecentRank": 64
     },
     {
       "id": "og-anunoby-1628384",
@@ -13096,7 +13912,9 @@
         "starter",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 54.2,
+      "goatRecentRank": 91
     },
     {
       "id": "omer-yurtseven-1630209",
@@ -13127,7 +13945,9 @@
         "turkey",
         "yurtseven"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 21.1,
+      "goatRecentRank": 318
     },
     {
       "id": "onyeka-okongwu-1630168",
@@ -13155,7 +13975,9 @@
         "onyeka",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 56.9,
+      "goatRecentRank": 75
     },
     {
       "id": "oshae-brissett-1629052",
@@ -13188,7 +14010,9 @@
         "pacers",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 36.2,
+      "goatRecentRank": 217
     },
     {
       "id": "otto-porter-jr-203490",
@@ -13220,7 +14044,9 @@
         "starter",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 14.1,
+      "goatRecentRank": 369
     },
     {
       "id": "p-j-tucker-200782",
@@ -13252,7 +14078,9 @@
         "raleigh",
         "tucker"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 24.8,
+      "goatRecentRank": 284
     },
     {
       "id": "p-j-washington-1629023",
@@ -13280,7 +14108,9 @@
         "starter",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 51.4,
+      "goatRecentRank": 109
     },
     {
       "id": "pascal-siakam-1627783",
@@ -13310,7 +14140,9 @@
         "siakam",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 68.4,
+      "goatRecentRank": 23
     },
     {
       "id": "pat-connaughton-1626192",
@@ -13342,7 +14174,9 @@
         "pat",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.4,
+      "goatRecentRank": 185
     },
     {
       "id": "patrick-beverley-201976",
@@ -13375,7 +14209,9 @@
         "patrick",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 35.2,
+      "goatRecentRank": 222
     },
     {
       "id": "patrick-mccaw-1627775",
@@ -13408,7 +14244,9 @@
         "rotation",
         "st. louis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 514
     },
     {
       "id": "patrick-patterson-202335",
@@ -13441,7 +14279,9 @@
         "starter",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 439
     },
     {
       "id": "patrick-williams-1630172",
@@ -13469,7 +14309,9 @@
         "rotation",
         "williams"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 41.2,
+      "goatRecentRank": 187
     },
     {
       "id": "patty-mills-201988",
@@ -13500,7 +14342,9 @@
         "spurs",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.5,
+      "goatRecentRank": 275
     },
     {
       "id": "paul-george-202331",
@@ -13531,7 +14375,9 @@
         "palmdale",
         "paul"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.8,
+      "goatRecentRank": 83
     },
     {
       "id": "paul-millsap-200794",
@@ -13563,7 +14409,9 @@
         "nuggets",
         "paul"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 493
     },
     {
       "id": "paul-reed-1630194",
@@ -13591,7 +14439,9 @@
         "reed",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 65.0,
+      "goatRecentRank": 40
     },
     {
       "id": "paul-watson-1628778",
@@ -13623,7 +14473,9 @@
         "toronto",
         "watson"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 532
     },
     {
       "id": "payton-pritchard-1630202",
@@ -13653,7 +14505,9 @@
         "pritchard",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 61.1,
+      "goatRecentRank": 54
     },
     {
       "id": "pj-dozier-1628408",
@@ -13683,7 +14537,9 @@
         "rotation",
         "south carolina"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.3,
+      "goatRecentRank": 338
     },
     {
       "id": "precious-achiuwa-1630173",
@@ -13713,7 +14569,9 @@
         "precious",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.2,
+      "goatRecentRank": 104
     },
     {
       "id": "quinn-cook-1626188",
@@ -13746,7 +14604,9 @@
         "rotation",
         "washington"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.8,
+      "goatRecentRank": 273
     },
     {
       "id": "quinndary-weatherspoon-1629683",
@@ -13779,7 +14639,9 @@
         "spurs",
         "weatherspoon"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 19.8,
+      "goatRecentRank": 331
     },
     {
       "id": "r-j-hampton-1630181",
@@ -13810,7 +14672,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.0,
+      "goatRecentRank": 366
     },
     {
       "id": "rajon-rondo-200765",
@@ -13845,7 +14709,9 @@
         "rajon",
         "rondo"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 419
     },
     {
       "id": "raul-neto-203526",
@@ -13877,7 +14743,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 22.3,
+      "goatRecentRank": 313
     },
     {
       "id": "ray-spalding-1629034",
@@ -13909,7 +14777,9 @@
         "spalding",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 471
     },
     {
       "id": "rayjon-tucker-1629730",
@@ -13940,7 +14810,9 @@
         "tucker",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 519
     },
     {
       "id": "reggie-bullock-203493",
@@ -13975,7 +14847,9 @@
         "starter",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 24.9,
+      "goatRecentRank": 282
     },
     {
       "id": "reggie-jackson-202704",
@@ -14006,7 +14880,9 @@
         "reggie",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.9,
+      "goatRecentRank": 137
     },
     {
       "id": "reggie-perry-1629617",
@@ -14039,7 +14915,9 @@
         "rotation",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 451
     },
     {
       "id": "richaun-holmes-1626158",
@@ -14071,7 +14949,9 @@
         "rotation",
         "sacramento"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 31.6,
+      "goatRecentRank": 238
     },
     {
       "id": "ricky-rubio-201937",
@@ -14103,7 +14983,9 @@
         "starter",
         "timberwolves"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 21.6,
+      "goatRecentRank": 314
     },
     {
       "id": "rj-barrett-1629628",
@@ -14134,7 +15016,9 @@
         "toronto",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 52.6,
+      "goatRecentRank": 102
     },
     {
       "id": "robert-covington-203496",
@@ -14167,7 +15051,9 @@
         "starter",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.7,
+      "goatRecentRank": 259
     },
     {
       "id": "robert-franks-1629606",
@@ -14197,7 +15083,9 @@
         "robert",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 417
     },
     {
       "id": "robert-williams-iii-1629057",
@@ -14226,7 +15114,9 @@
         "starter",
         "williams"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 30.0,
+      "goatRecentRank": 243
     },
     {
       "id": "robert-woodard-ii-1630218",
@@ -14258,7 +15148,9 @@
         "usa",
         "woodard"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.2,
+      "goatRecentRank": 415
     },
     {
       "id": "robin-lopez-201577",
@@ -14290,7 +15182,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.4,
+      "goatRecentRank": 299
     },
     {
       "id": "rodions-kurucs-1629066",
@@ -14322,7 +15216,9 @@
         "rodions",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 541
     },
     {
       "id": "rodney-hood-203918",
@@ -14356,7 +15252,9 @@
         "starter",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 482
     },
     {
       "id": "rodney-mcgruder-203585",
@@ -14388,7 +15286,9 @@
         "rodney",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 7.3,
+      "goatRecentRank": 401
     },
     {
       "id": "romeo-langford-1629641",
@@ -14422,7 +15322,9 @@
         "romeo",
         "rotation"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 13.2,
+      "goatRecentRank": 376
     },
     {
       "id": "rondae-hollis-jefferson-1626178",
@@ -14455,7 +15357,9 @@
         "rotation",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 425
     },
     {
       "id": "royce-o-neale-1626220",
@@ -14487,7 +15391,9 @@
         "texas",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.8,
+      "goatRecentRank": 122
     },
     {
       "id": "rudy-gay-200752",
@@ -14522,7 +15428,9 @@
         "san",
         "spurs"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 21.5,
+      "goatRecentRank": 315
     },
     {
       "id": "rudy-gobert-203497",
@@ -14552,7 +15460,9 @@
         "saint-quentin",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 64.6,
+      "goatRecentRank": 41
     },
     {
       "id": "rui-hachimura-1629060",
@@ -14582,7 +15492,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.1,
+      "goatRecentRank": 126
     },
     {
       "id": "russell-westbrook-201566",
@@ -14616,7 +15528,9 @@
         "westbrook",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 70.4,
+      "goatRecentRank": 18
     },
     {
       "id": "ryan-arcidiacono-1627853",
@@ -14647,7 +15561,9 @@
         "ryan",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.1,
+      "goatRecentRank": 341
     },
     {
       "id": "saben-lee-1630240",
@@ -14678,7 +15594,9 @@
         "saben",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.2,
+      "goatRecentRank": 277
     },
     {
       "id": "saddiq-bey-1630180",
@@ -14709,7 +15627,9 @@
         "starter",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 33.1,
+      "goatRecentRank": 229
     },
     {
       "id": "sam-merrill-1630241",
@@ -14739,7 +15659,9 @@
         "rotation",
         "sam"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.5,
+      "goatRecentRank": 199
     },
     {
       "id": "sean-mcdermott-1630253",
@@ -14770,7 +15692,9 @@
         "sean",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 485
     },
     {
       "id": "sekou-doumbouya-1629635",
@@ -14802,7 +15726,9 @@
         "rotation",
         "sekou"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 499
     },
     {
       "id": "semi-ojeleye-1628400",
@@ -14834,7 +15760,9 @@
         "rotation",
         "semi"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 465
     },
     {
       "id": "serge-ibaka-201586",
@@ -14865,7 +15793,9 @@
         "republic of the congo",
         "serge"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.0,
+      "goatRecentRank": 359
     },
     {
       "id": "seth-curry-203552",
@@ -14897,7 +15827,9 @@
         "seth",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 35.7,
+      "goatRecentRank": 220
     },
     {
       "id": "shai-gilgeous-alexander-1628983",
@@ -14928,7 +15860,9 @@
         "thunder",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 91.6,
+      "goatRecentRank": 2
     },
     {
       "id": "shake-milton-1629003",
@@ -14960,7 +15894,9 @@
         "shake",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 46.5,
+      "goatRecentRank": 148
     },
     {
       "id": "shaquille-harrison-1627885",
@@ -14992,7 +15928,9 @@
         "rotation",
         "shaquille"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 11.2,
+      "goatRecentRank": 386
     },
     {
       "id": "sindarius-thornwell-1628414",
@@ -15024,7 +15962,9 @@
         "south carolina",
         "thornwell"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 449
     },
     {
       "id": "skylar-mays-1630219",
@@ -15052,7 +15992,9 @@
         "rotation",
         "skylar"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 16.1,
+      "goatRecentRank": 356
     },
     {
       "id": "solomon-hill-203524",
@@ -15084,7 +16026,9 @@
         "solomon",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 430
     },
     {
       "id": "spencer-dinwiddie-203915",
@@ -15116,7 +16060,9 @@
         "spencer",
         "starter"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.6,
+      "goatRecentRank": 95
     },
     {
       "id": "stanley-johnson-1626169",
@@ -15146,7 +16092,9 @@
         "stanley",
         "toronto"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 10.2,
+      "goatRecentRank": 391
     },
     {
       "id": "stephen-curry-201939",
@@ -15179,7 +16127,9 @@
         "stephen",
         "warriors"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 74.3,
+      "goatRecentRank": 11
     },
     {
       "id": "sterling-brown-1628425",
@@ -15213,7 +16163,9 @@
         "rotation",
         "sterling"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 12.1,
+      "goatRecentRank": 378
     },
     {
       "id": "steven-adams-203500",
@@ -15246,7 +16198,9 @@
         "starter",
         "steven"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 40.2,
+      "goatRecentRank": 193
     },
     {
       "id": "svi-mykhailiuk-1629004",
@@ -15277,7 +16231,9 @@
         "svi",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 30.9,
+      "goatRecentRank": 240
     },
     {
       "id": "t-j-leaf-1628388",
@@ -15310,7 +16266,9 @@
         "tel aviv",
         "trail"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 476
     },
     {
       "id": "t-j-mcconnell-204456",
@@ -15340,7 +16298,9 @@
         "starter",
         "t.j."
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 72.3,
+      "goatRecentRank": 16
     },
     {
       "id": "t-j-warren-203933",
@@ -15372,7 +16332,9 @@
         "t.j.",
         "warren"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.8,
+      "goatRecentRank": 274
     },
     {
       "id": "tacko-fall-1629605",
@@ -15404,7 +16366,9 @@
         "senegal",
         "tacko"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 474
     },
     {
       "id": "taj-gibson-201959",
@@ -15437,7 +16401,9 @@
         "taj",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.2,
+      "goatRecentRank": 279
     },
     {
       "id": "talen-horton-tucker-1629659",
@@ -15468,7 +16434,9 @@
         "rotation",
         "talen"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 49.1,
+      "goatRecentRank": 125
     },
     {
       "id": "taurean-prince-1627752",
@@ -15498,7 +16466,9 @@
         "taurean",
         "texas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 44.9,
+      "goatRecentRank": 161
     },
     {
       "id": "terance-mann-1629611",
@@ -15531,7 +16501,9 @@
         "starter",
         "terance"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.7,
+      "goatRecentRank": 138
     },
     {
       "id": "terence-davis-1629056",
@@ -15563,7 +16535,9 @@
         "southaven",
         "terence"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 29.1,
+      "goatRecentRank": 252
     },
     {
       "id": "terrance-ferguson-1628390",
@@ -15596,7 +16570,9 @@
         "terrance",
         "tulsa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 503
     },
     {
       "id": "terrence-ross-203082",
@@ -15630,7 +16606,9 @@
         "starter",
         "terrence"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.6,
+      "goatRecentRank": 324
     },
     {
       "id": "terry-rozier-1626179",
@@ -15662,7 +16640,9 @@
         "terry",
         "youngstown"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.0,
+      "goatRecentRank": 146
     },
     {
       "id": "thaddeus-young-201152",
@@ -15694,7 +16674,9 @@
         "thaddeus",
         "young"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 26.6,
+      "goatRecentRank": 272
     },
     {
       "id": "thanasis-antetokounmpo-203648",
@@ -15726,7 +16708,9 @@
         "rotation",
         "thanasis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.6,
+      "goatRecentRank": 292
     },
     {
       "id": "theo-maledon-1630177",
@@ -15758,7 +16742,9 @@
         "theo",
         "thunder"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.2,
+      "goatRecentRank": 340
     },
     {
       "id": "theo-pinson-1629033",
@@ -15793,7 +16779,9 @@
         "theo",
         "york"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 17.1,
+      "goatRecentRank": 347
     },
     {
       "id": "thomas-bryant-1628418",
@@ -15825,7 +16813,9 @@
         "washington",
         "wizards"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.7,
+      "goatRecentRank": 94
     },
     {
       "id": "thon-maker-1627748",
@@ -15860,7 +16850,9 @@
         "thon",
         "wau"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 431
     },
     {
       "id": "tim-frazier-204025",
@@ -15891,7 +16883,9 @@
         "tim",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 433
     },
     {
       "id": "tim-hardaway-jr-203501",
@@ -15922,7 +16916,9 @@
         "starter",
         "tim"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.7,
+      "goatRecentRank": 139
     },
     {
       "id": "timothe-luwawu-cabarrot-1627789",
@@ -15956,7 +16952,9 @@
         "rotation",
         "timothe"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 10.6,
+      "goatRecentRank": 388
     },
     {
       "id": "tobias-harris-202699",
@@ -15986,7 +16984,9 @@
         "philadelphia",
         "tobias"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 57.8,
+      "goatRecentRank": 72
     },
     {
       "id": "tomas-satoransky-203107",
@@ -16018,7 +17018,9 @@
         "starter",
         "tomas"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 504
     },
     {
       "id": "tony-bradley-1628396",
@@ -16053,7 +17055,9 @@
         "thunder",
         "tony"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 21.2,
+      "goatRecentRank": 317
     },
     {
       "id": "tony-snell-203503",
@@ -16085,7 +17089,9 @@
         "tony",
         "watts"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 537
     },
     {
       "id": "torrey-craig-1628470",
@@ -16117,7 +17123,9 @@
         "suns",
         "torrey"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 39.8,
+      "goatRecentRank": 197
     },
     {
       "id": "trae-young-1629027",
@@ -16147,7 +17155,9 @@
         "trae",
         "young"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 69.6,
+      "goatRecentRank": 19
     },
     {
       "id": "tre-jones-1630200",
@@ -16178,7 +17188,9 @@
         "spurs",
         "tre"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.4,
+      "goatRecentRank": 142
     },
     {
       "id": "tremont-waters-1629682",
@@ -16210,7 +17222,9 @@
         "tremont",
         "waters"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 467
     },
     {
       "id": "trent-forrest-1630235",
@@ -16241,7 +17255,9 @@
         "usa",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.1,
+      "goatRecentRank": 328
     },
     {
       "id": "trevor-ariza-2772",
@@ -16272,7 +17288,9 @@
         "miami",
         "trevor"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 480
     },
     {
       "id": "trey-burke-203504",
@@ -16304,7 +17322,9 @@
         "starter",
         "trey"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 463
     },
     {
       "id": "trey-lyles-1626168",
@@ -16337,7 +17357,9 @@
         "starter",
         "trey"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.4,
+      "goatRecentRank": 133
     },
     {
       "id": "tristan-thompson-202684",
@@ -16367,7 +17389,9 @@
         "thompson",
         "tristan"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 32.6,
+      "goatRecentRank": 232
     },
     {
       "id": "troy-brown-jr-1628972",
@@ -16402,7 +17426,9 @@
         "rotation",
         "troy"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 32.1,
+      "goatRecentRank": 234
     },
     {
       "id": "ty-jerome-1629660",
@@ -16435,7 +17461,9 @@
         "thunder",
         "ty"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 42.7,
+      "goatRecentRank": 172
     },
     {
       "id": "ty-shon-alexander-1630234",
@@ -16466,7 +17494,9 @@
         "ty-shon",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 436
     },
     {
       "id": "tyler-bey-1630189",
@@ -16497,7 +17527,9 @@
         "tyler",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 545
     },
     {
       "id": "tyler-cook-1629076",
@@ -16528,7 +17560,9 @@
         "tyler",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 437
     },
     {
       "id": "tyler-herro-1629639",
@@ -16558,7 +17592,9 @@
         "tyler",
         "wisconsin"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.9,
+      "goatRecentRank": 82
     },
     {
       "id": "tyler-johnson-204020",
@@ -16589,7 +17625,9 @@
         "tyler",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 464
     },
     {
       "id": "tyrell-terry-1630179",
@@ -16620,7 +17658,9 @@
         "tyrell",
         "usa"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 534
     },
     {
       "id": "tyrese-haliburton-1630169",
@@ -16648,7 +17688,9 @@
         "sacramento",
         "tyrese"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 77.4,
+      "goatRecentRank": 9
     },
     {
       "id": "tyrese-maxey-1630178",
@@ -16676,7 +17718,9 @@
         "starter",
         "tyrese"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 58.4,
+      "goatRecentRank": 66
     },
     {
       "id": "tyus-jones-1626145",
@@ -16706,7 +17750,9 @@
         "starter",
         "tyus"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 55.3,
+      "goatRecentRank": 86
     },
     {
       "id": "udoka-azubuike-1628962",
@@ -16739,7 +17785,9 @@
         "udoka",
         "utah"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.4,
+      "goatRecentRank": 296
     },
     {
       "id": "udonis-haslem-2617",
@@ -16770,7 +17818,9 @@
         "miami",
         "udonis"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 15.3,
+      "goatRecentRank": 364
     },
     {
       "id": "vernon-carey-jr-1630176",
@@ -16802,7 +17852,9 @@
         "usa",
         "vernon"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 18.7,
+      "goatRecentRank": 336
     },
     {
       "id": "victor-oladipo-203506",
@@ -16834,7 +17886,9 @@
         "starter",
         "victor"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.9,
+      "goatRecentRank": 319
     },
     {
       "id": "vincent-poirier-1629738",
@@ -16869,7 +17923,9 @@
         "rotation",
         "vincent"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 522
     },
     {
       "id": "vlatko-cancar-1628427",
@@ -16899,7 +17955,9 @@
         "slovenia",
         "vlatko"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.2,
+      "goatRecentRank": 278
     },
     {
       "id": "wayne-ellington-201961",
@@ -16931,7 +17989,9 @@
         "wayne",
         "wynnewood"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 459
     },
     {
       "id": "wendell-carter-jr-1628976",
@@ -16962,7 +18022,9 @@
         "starter",
         "wendell"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.6,
+      "goatRecentRank": 129
     },
     {
       "id": "wenyen-gabriel-1629117",
@@ -16994,7 +18056,9 @@
         "south sudan",
         "wenyen"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 27.2,
+      "goatRecentRank": 266
     },
     {
       "id": "wes-iwundu-1628411",
@@ -17027,7 +18091,9 @@
         "texas",
         "wes"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 447
     },
     {
       "id": "wesley-matthews-202083",
@@ -17060,7 +18126,9 @@
         "texas",
         "wesley"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 23.0,
+      "goatRecentRank": 305
     },
     {
       "id": "will-barton-203115",
@@ -17092,7 +18160,9 @@
         "starter",
         "will"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 20.3,
+      "goatRecentRank": 326
     },
     {
       "id": "will-magnay-1630266",
@@ -17124,7 +18194,9 @@
         "reserve",
         "will"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 428
     },
     {
       "id": "willie-cauley-stein-1626161",
@@ -17156,7 +18228,9 @@
         "starter",
         "willie"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 448
     },
     {
       "id": "willy-hernangomez-1626195",
@@ -17191,7 +18265,9 @@
         "spain",
         "willy"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 24.5,
+      "goatRecentRank": 285
     },
     {
       "id": "xavier-tillman-1630214",
@@ -17221,7 +18297,9 @@
         "tillman",
         "xavier"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 45.5,
+      "goatRecentRank": 156
     },
     {
       "id": "yogi-ferrell-1627812",
@@ -17254,7 +18332,9 @@
         "rotation",
         "yogi"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 0.0,
+      "goatRecentRank": 424
     },
     {
       "id": "yuta-watanabe-1629139",
@@ -17288,7 +18368,9 @@
         "yokohama",
         "yuta"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 25.0,
+      "goatRecentRank": 281
     },
     {
       "id": "zach-collins-1628380",
@@ -17321,7 +18403,9 @@
         "trail",
         "zach"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 53.8,
+      "goatRecentRank": 93
     },
     {
       "id": "zach-lavine-203897",
@@ -17351,7 +18435,9 @@
         "washington",
         "zach"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 48.7,
+      "goatRecentRank": 127
     },
     {
       "id": "zeke-nnaji-1630192",
@@ -17381,7 +18467,9 @@
         "rotation",
         "zeke"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 47.3,
+      "goatRecentRank": 143
     },
     {
       "id": "zion-williamson-1629627",
@@ -17410,7 +18498,9 @@
         "williamson",
         "zion"
       ],
-      "metrics": {}
+      "metrics": {},
+      "goatRecentScore": 50.7,
+      "goatRecentRank": 113
     }
   ]
 }


### PR DESCRIPTION
## Summary
- derive last-three-season GOAT scores for every active player using the PlayerStatistics archive
- attach the rolling score and rank to each player profile so the atlas payload exposes the new fields
- surface the recent GOAT values on the player scouting atlas card, falling back to profile data when API lookups miss

## Testing
- ruff check scripts/build_player_profiles.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d9a852681883278f32adb13edd09e4