### PR TITLE
Restyle preseason preview pages

### DIFF
--- a/public/previews/preseason-pre2025-01.html
+++ b/public/previews/preseason-pre2025-01.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         <p class="lead">NBA Abu Dhabi Game</p>
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Philadelphia 76ers vs. New York Knicks</p>
-          <p>Preseason · NBA Abu Dhabi Game</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Philadelphia 76ers vs. New York Knicks</p>
+            <p>Preseason · NBA Abu Dhabi Game</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Philadelphia 76ers face the Knicks at Etihad Arena · Abu Dhabi, United Arab Emirates, opening the 2025-26 preseason with the NBA Abu Dhabi Game showcase designed to stress-test training camp priorities.</p>
-        <p>Philadelphia’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New York focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Philadelphia 76ers turn preseason reps into regular-season trust?</li>
-          <li>How do New York Knicks balance veteran rhythm with developmental minutes during the NBA Abu Dhabi Game showcase?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Philadelphia 76ers face the Knicks at Etihad Arena · Abu Dhabi, United Arab Emirates, opening the 2025-26 preseason with the NBA Abu Dhabi Game showcase designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Philadelphia’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New York focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Philadelphia 76ers turn preseason reps into regular-season trust?</li>
+            <li>How do New York Knicks balance veteran rhythm with developmental minutes during the NBA Abu Dhabi Game showcase?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-02.html
+++ b/public/previews/preseason-pre2025-02.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         <p class="lead">NBA Melbourne Game</p>
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Melbourne United vs. New Orleans Pelicans</p>
-          <p>Preseason · NBA Melbourne Game</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Melbourne United vs. New Orleans Pelicans</p>
+            <p>Preseason · NBA Melbourne Game</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Melbourne United face the Pelicans at Rod Laver Arena · Melbourne, VIC, opening the 2025-26 preseason with the NBA Melbourne Game showcase designed to stress-test training camp priorities.</p>
-        <p>Melbourne United’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New Orleans focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Melbourne United turn preseason reps into regular-season trust?</li>
-          <li>How do New Orleans Pelicans balance veteran rhythm with developmental minutes during the NBA Melbourne Game showcase?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Melbourne United face the Pelicans at Rod Laver Arena · Melbourne, VIC, opening the 2025-26 preseason with the NBA Melbourne Game showcase designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Melbourne United’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New Orleans focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Melbourne United turn preseason reps into regular-season trust?</li>
+            <li>How do New Orleans Pelicans balance veteran rhythm with developmental minutes during the NBA Melbourne Game showcase?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -537,6 +677,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-03.html
+++ b/public/previews/preseason-pre2025-03.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Phoenix Suns vs. Los Angeles Lakers</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Phoenix Suns vs. Los Angeles Lakers</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Phoenix Suns face the Lakers at Crypto.com Arena · Los Angeles, CA, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Phoenix’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Los Angeles focuses on lineup chemistry in front of a Los Angeles crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Phoenix Suns turn preseason reps into regular-season trust?</li>
-          <li>How do Los Angeles Lakers balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Phoenix Suns face the Lakers at Crypto.com Arena · Los Angeles, CA, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Phoenix’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Los Angeles focuses on lineup chemistry in front of a Los Angeles crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Phoenix Suns turn preseason reps into regular-season trust?</li>
+            <li>How do Los Angeles Lakers balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-04.html
+++ b/public/previews/preseason-pre2025-04.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         <p class="lead">NBA Abu Dhabi Game</p>
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>New York Knicks vs. Philadelphia 76ers</p>
-          <p>Preseason · NBA Abu Dhabi Game</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>New York Knicks vs. Philadelphia 76ers</p>
+            <p>Preseason · NBA Abu Dhabi Game</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>New York Knicks face the 76ers at Etihad Arena · Abu Dhabi, United Arab Emirates, opening the 2025-26 preseason with the NBA Abu Dhabi Game showcase designed to stress-test training camp priorities.</p>
-        <p>New York’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Philadelphia focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps New York Knicks turn preseason reps into regular-season trust?</li>
-          <li>How do Philadelphia 76ers balance veteran rhythm with developmental minutes during the NBA Abu Dhabi Game showcase?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">New York Knicks face the 76ers at Etihad Arena · Abu Dhabi, United Arab Emirates, opening the 2025-26 preseason with the NBA Abu Dhabi Game showcase designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">New York’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Philadelphia focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps New York Knicks turn preseason reps into regular-season trust?</li>
+            <li>How do Philadelphia 76ers balance veteran rhythm with developmental minutes during the NBA Abu Dhabi Game showcase?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-05.html
+++ b/public/previews/preseason-pre2025-05.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Hapoel Jerusalem B.C. vs. Brooklyn Nets</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Hapoel Jerusalem B.C. vs. Brooklyn Nets</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Hapoel Jerusalem B.C. face the Nets at Barclays Center · Brooklyn, NY, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Hapoel Jerusalem B.C.’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Brooklyn focuses on lineup chemistry in front of a Brooklyn crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Hapoel Jerusalem B.C. turn preseason reps into regular-season trust?</li>
-          <li>How do Brooklyn Nets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Hapoel Jerusalem B.C. face the Nets at Barclays Center · Brooklyn, NY, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Hapoel Jerusalem B.C.’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Brooklyn focuses on lineup chemistry in front of a Brooklyn crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Hapoel Jerusalem B.C. turn preseason reps into regular-season trust?</li>
+            <li>How do Brooklyn Nets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -537,6 +677,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-06.html
+++ b/public/previews/preseason-pre2025-06.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Orlando Magic vs. Miami Heat</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Orlando Magic vs. Miami Heat</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Orlando Magic face the Heat at Kaseya Center · Miami, FL, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Orlando’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Miami focuses on lineup chemistry in front of a Miami crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Orlando Magic turn preseason reps into regular-season trust?</li>
-          <li>How do Miami Heat balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Orlando Magic face the Heat at Kaseya Center · Miami, FL, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Orlando’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Miami focuses on lineup chemistry in front of a Miami crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Orlando Magic turn preseason reps into regular-season trust?</li>
+            <li>How do Miami Heat balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-07.html
+++ b/public/previews/preseason-pre2025-07.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Minnesota Timberwolves vs. Denver Nuggets</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Minnesota Timberwolves vs. Denver Nuggets</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Minnesota Timberwolves face the Nuggets at Ball Arena · Denver, CO, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Minnesota’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Denver focuses on lineup chemistry in front of a Denver crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Minnesota Timberwolves turn preseason reps into regular-season trust?</li>
-          <li>How do Denver Nuggets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Minnesota Timberwolves face the Nuggets at Ball Arena · Denver, CO, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Minnesota’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Denver focuses on lineup chemistry in front of a Denver crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Minnesota Timberwolves turn preseason reps into regular-season trust?</li>
+            <li>How do Denver Nuggets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-08.html
+++ b/public/previews/preseason-pre2025-08.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         <p class="lead">NBA Melbourne Game</p>
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>South East Melbourne Phoenix vs. New Orleans Pelicans</p>
-          <p>Preseason · NBA Melbourne Game</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>South East Melbourne Phoenix vs. New Orleans Pelicans</p>
+            <p>Preseason · NBA Melbourne Game</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>South East Melbourne Phoenix face the Pelicans at John Cain Arena · Melbourne, VIC, opening the 2025-26 preseason with the NBA Melbourne Game showcase designed to stress-test training camp priorities.</p>
-        <p>South East Melbourne Phoenix’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New Orleans focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps South East Melbourne Phoenix turn preseason reps into regular-season trust?</li>
-          <li>How do New Orleans Pelicans balance veteran rhythm with developmental minutes during the NBA Melbourne Game showcase?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">South East Melbourne Phoenix face the Pelicans at John Cain Arena · Melbourne, VIC, opening the 2025-26 preseason with the NBA Melbourne Game showcase designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">South East Melbourne Phoenix’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New Orleans focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps South East Melbourne Phoenix turn preseason reps into regular-season trust?</li>
+            <li>How do New Orleans Pelicans balance veteran rhythm with developmental minutes during the NBA Melbourne Game showcase?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -537,6 +677,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-09.html
+++ b/public/previews/preseason-pre2025-09.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Oklahoma City Thunder vs. Charlotte Hornets</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Oklahoma City Thunder vs. Charlotte Hornets</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Oklahoma City Thunder face the Hornets at Spectrum Center · Charlotte, NC, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Oklahoma City’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Charlotte focuses on lineup chemistry in front of a Charlotte crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Oklahoma City Thunder turn preseason reps into regular-season trust?</li>
-          <li>How do Charlotte Hornets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Oklahoma City Thunder face the Hornets at Spectrum Center · Charlotte, NC, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Oklahoma City’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Charlotte focuses on lineup chemistry in front of a Charlotte crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Oklahoma City Thunder turn preseason reps into regular-season trust?</li>
+            <li>How do Charlotte Hornets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-10.html
+++ b/public/previews/preseason-pre2025-10.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Los Angeles Lakers vs. Golden State Warriors</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Los Angeles Lakers vs. Golden State Warriors</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Los Angeles Lakers face the Warriors at Chase Center · San Francisco, CA, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Los Angeles’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Golden State focuses on lineup chemistry in front of a Golden State crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Los Angeles Lakers turn preseason reps into regular-season trust?</li>
-          <li>How do Golden State Warriors balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Los Angeles Lakers face the Warriors at Chase Center · San Francisco, CA, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Los Angeles’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Golden State focuses on lineup chemistry in front of a Golden State crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Los Angeles Lakers turn preseason reps into regular-season trust?</li>
+            <li>How do Golden State Warriors balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-11.html
+++ b/public/previews/preseason-pre2025-11.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Milwaukee Bucks vs. Miami Heat</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Milwaukee Bucks vs. Miami Heat</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Milwaukee Bucks face the Heat at Kaseya Center · Miami, FL, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Milwaukee’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Miami focuses on lineup chemistry in front of a Miami crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Milwaukee Bucks turn preseason reps into regular-season trust?</li>
-          <li>How do Miami Heat balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Milwaukee Bucks face the Heat at Kaseya Center · Miami, FL, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Milwaukee’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Miami focuses on lineup chemistry in front of a Miami crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Milwaukee Bucks turn preseason reps into regular-season trust?</li>
+            <li>How do Miami Heat balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-12.html
+++ b/public/previews/preseason-pre2025-12.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Atlanta Hawks vs. Houston Rockets</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Atlanta Hawks vs. Houston Rockets</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Atlanta Hawks face the Rockets at Toyota Center · Houston, TX, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Atlanta’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Houston focuses on lineup chemistry in front of a Houston crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Atlanta Hawks turn preseason reps into regular-season trust?</li>
-          <li>How do Houston Rockets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Atlanta Hawks face the Rockets at Toyota Center · Houston, TX, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Atlanta’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Houston focuses on lineup chemistry in front of a Houston crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Atlanta Hawks turn preseason reps into regular-season trust?</li>
+            <li>How do Houston Rockets balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-13.html
+++ b/public/previews/preseason-pre2025-13.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Detroit Pistons vs. Memphis Grizzlies</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Detroit Pistons vs. Memphis Grizzlies</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Detroit Pistons face the Grizzlies at FedExForum · Memphis, TN, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Detroit’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Memphis focuses on lineup chemistry in front of a Memphis crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Detroit Pistons turn preseason reps into regular-season trust?</li>
-          <li>How do Memphis Grizzlies balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Detroit Pistons face the Grizzlies at FedExForum · Memphis, TN, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Detroit’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Memphis focuses on lineup chemistry in front of a Memphis crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Detroit Pistons turn preseason reps into regular-season trust?</li>
+            <li>How do Memphis Grizzlies balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-14.html
+++ b/public/previews/preseason-pre2025-14.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Guangzhou Loong-Lions vs. San Antonio Spurs</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Guangzhou Loong-Lions vs. San Antonio Spurs</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Guangzhou Loong-Lions face the Spurs at Frost Bank Center · San Antonio, TX, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Guangzhou Loong-Lions’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while San Antonio focuses on lineup chemistry in front of a San Antonio crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Guangzhou Loong-Lions turn preseason reps into regular-season trust?</li>
-          <li>How do San Antonio Spurs balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Guangzhou Loong-Lions face the Spurs at Frost Bank Center · San Antonio, TX, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Guangzhou Loong-Lions’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while San Antonio focuses on lineup chemistry in front of a San Antonio crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Guangzhou Loong-Lions turn preseason reps into regular-season trust?</li>
+            <li>How do San Antonio Spurs balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -537,6 +677,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-15.html
+++ b/public/previews/preseason-pre2025-15.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Oklahoma City Thunder vs. Dallas Mavericks</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Oklahoma City Thunder vs. Dallas Mavericks</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Oklahoma City Thunder face the Mavericks at American Airlines Center · Dallas, TX, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Oklahoma City’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Dallas focuses on lineup chemistry in front of a Dallas crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Oklahoma City Thunder turn preseason reps into regular-season trust?</li>
-          <li>How do Dallas Mavericks balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Oklahoma City Thunder face the Mavericks at American Airlines Center · Dallas, TX, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Oklahoma City’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Dallas focuses on lineup chemistry in front of a Dallas crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Oklahoma City Thunder turn preseason reps into regular-season trust?</li>
+            <li>How do Dallas Mavericks balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-16.html
+++ b/public/previews/preseason-pre2025-16.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Denver Nuggets vs. Toronto Raptors</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Denver Nuggets vs. Toronto Raptors</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Denver Nuggets face the Raptors at Scotiabank Arena · Toronto, ON, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Denver’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Toronto focuses on lineup chemistry in front of a Toronto crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Denver Nuggets turn preseason reps into regular-season trust?</li>
-          <li>How do Toronto Raptors balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Denver Nuggets face the Raptors at Scotiabank Arena · Toronto, ON, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Denver’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Toronto focuses on lineup chemistry in front of a Toronto crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Denver Nuggets turn preseason reps into regular-season trust?</li>
+            <li>How do Toronto Raptors balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-17.html
+++ b/public/previews/preseason-pre2025-17.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,29 +305,36 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Chicago Bulls vs. Cleveland Cavaliers</p>
-          <p>Preseason</p>
-        </section>
-        
-        
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Chicago Bulls vs. Cleveland Cavaliers</p>
+            <p>Preseason</p>
+          </section>
+          
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Chicago Bulls face the Cavaliers at Rocket Mortgage FieldHouse · Cleveland, OH, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Chicago’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Cleveland focuses on lineup chemistry in front of a Cleveland crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Chicago Bulls turn preseason reps into regular-season trust?</li>
-          <li>How do Cleveland Cavaliers balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Chicago Bulls face the Cavaliers at Rocket Mortgage FieldHouse · Cleveland, OH, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Chicago’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Cleveland focuses on lineup chemistry in front of a Cleveland crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Chicago Bulls turn preseason reps into regular-season trust?</li>
+            <li>How do Cleveland Cavaliers balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -850,6 +990,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/public/previews/preseason-pre2025-18.html
+++ b/public/previews/preseason-pre2025-18.html
@@ -11,100 +11,231 @@
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -128,7 +259,8 @@
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -154,6 +286,7 @@
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -172,35 +305,42 @@
         
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>Indiana Pacers vs. Minnesota Timberwolves</p>
-          <p>Preseason</p>
-        </section>
-        
-          <section class="preview-meta__section">
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>Indiana Pacers vs. Minnesota Timberwolves</p>
+            <p>Preseason</p>
+          </section>
+          
+          <section class="preview-summary__card">
             <h2>Coverage</h2>
             <p><strong>TV:</strong> FanDuel Sports Network - Indiana</p>
             <p><strong>Radio:</strong> 93.5/107.5 The Fan</p>
           </section>
         
-        
+          
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        <p>Indiana Pacers face the Timberwolves at Target Center · Minneapolis, MN, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
-        <p>Indiana’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Minnesota focuses on lineup chemistry in front of a Minnesota crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
-        <ul>
-          <li>Which emerging contributor helps Indiana Pacers turn preseason reps into regular-season trust?</li>
-          <li>How do Minnesota Timberwolves balance veteran rhythm with developmental minutes during this preseason matchup?</li>
-          <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          <p class="preview-story__lead">Indiana Pacers face the Timberwolves at Target Center · Minneapolis, MN, opening the 2025-26 preseason with this preseason matchup designed to stress-test training camp priorities.</p>
+        <p class="preview-story__paragraph">Indiana’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while Minnesota focuses on lineup chemistry in front of a Minnesota crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ul class="preview-story__list">
+            <li>Which emerging contributor helps Indiana Pacers turn preseason reps into regular-season trust?</li>
+            <li>How do Minnesota Timberwolves balance veteran rhythm with developmental minutes during this preseason matchup?</li>
+            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+          </ul>
+        </article>
 
-      
-        <section class="preview-visuals">
+        
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -856,6 +996,7 @@
           </div>
         </section>
       
+      </div>
 
       <footer>
         <span>Season context: 2025-26 preseason schedule.</span>

--- a/scripts/generate/preseason_previews.ts
+++ b/scripts/generate/preseason_previews.ts
@@ -582,7 +582,7 @@ function renderVisualsSection(
     return "";
   }
   return `
-        <section class="preview-visuals">
+        <section class="preview-visuals preview-card preview-card--visuals">
           <div class="preview-visuals__header">
             <h2>Signature visual read</h2>
             <p>
@@ -623,7 +623,7 @@ function renderGamePage(
 
   const coverageSection = hasCoverage
     ? `
-          <section class="preview-meta__section">
+          <section class="preview-summary__card">
             <h2>Coverage</h2>
             ${game.coverage?.tv?.length ? `<p><strong>TV:</strong> ${game.coverage.tv.join(", ")}</p>` : ""}
             ${game.coverage?.radio?.length ? `<p><strong>Radio:</strong> ${game.coverage.radio.join(", ")}</p>` : ""}
@@ -633,14 +633,21 @@ function renderGamePage(
 
   const notesSection = notes.length
     ? `
-          <section class="preview-meta__section">
+          <section class="preview-summary__card">
             <h2>Notes</h2>
-            <ul>
+            <ul class="preview-summary__list">
               ${notes.map((note) => `<li>${note}</li>`).join("\n              ")}
             </ul>
           </section>
         `
     : "";
+
+  const storyParagraphs = story
+    .map((paragraph, index) => {
+      const className = index === 0 ? "preview-story__lead" : "preview-story__paragraph";
+      return `<p class="${className}">${paragraph}</p>`;
+    })
+    .join("\n        ");
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -655,100 +662,231 @@ function renderGamePage(
         padding: clamp(1.5rem, 4vw, 3rem);
         display: flex;
         justify-content: center;
-        background: color-mix(in srgb, var(--surface) 92%, rgba(14, 34, 68, 0.06) 8%);
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(239, 61, 91, 0.08)),
+          color-mix(in srgb, var(--surface) 88%, rgba(14, 34, 68, 0.08) 12%);
       }
 
       .preview-shell {
-        width: min(1100px, 100%);
+        width: min(1150px, 100%);
         display: grid;
-        gap: clamp(1.5rem, 3vw, 2.5rem);
-        background: color-mix(in srgb, var(--surface) 80%, rgba(14, 34, 68, 0.05) 20%);
+        gap: clamp(1.5rem, 3vw, 2.75rem);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.92) 28%);
         border-radius: var(--radius-xl);
-        border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
-        padding: clamp(1.75rem, 3vw, 2.5rem);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        padding: clamp(1.85rem, 3.4vw, 2.9rem);
         box-shadow: var(--shadow-soft);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .preview-shell::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          160deg,
+          rgba(17, 86, 214, 0.14),
+          rgba(244, 181, 63, 0.12) 55%,
+          rgba(239, 61, 91, 0.1)
+        );
+        opacity: 0.55;
+        pointer-events: none;
+      }
+
+      .preview-shell > * {
+        position: relative;
       }
 
       .preview-header {
         display: grid;
-        gap: 0.75rem;
+        gap: 0.65rem;
       }
 
       .preview-header time {
         font-weight: 600;
-        color: color-mix(in srgb, var(--navy) 80%, rgba(14, 34, 68, 0.4) 20%);
+        color: color-mix(in srgb, var(--navy) 78%, rgba(14, 34, 68, 0.42) 22%);
       }
 
-      .chip {
-        display: inline-block;
-        padding: 0.25rem 0.6rem;
-        border-radius: 999px;
-        background: rgba(14, 34, 68, 0.08);
-        color: rgba(14, 34, 68, 0.88);
-        font-size: 0.75rem;
-        letter-spacing: 0.08em;
-        text-transform: uppercase;
-        font-weight: 600;
-      }
-
-      .preview-meta {
-        display: grid;
-        gap: 1.5rem;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      }
-
-      .preview-meta__section {
-        display: grid;
-        gap: 0.4rem;
-      }
-
-      .preview-meta__section h2 {
+      .preview-header p {
         margin: 0;
-        font-size: 0.95rem;
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
-        color: rgba(14, 34, 68, 0.72);
+        color: var(--text-subtle);
       }
 
-      .preview-meta__section p,
-      .preview-meta__section ul {
+      .preview-header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4.8vw, 2.65rem);
+        color: var(--navy);
+      }
+
+      .preview-summary {
+        display: grid;
+        gap: clamp(1rem, 2.6vw, 1.6rem);
+      }
+
+      .preview-summary__header {
+        display: grid;
+        gap: 0.35rem;
+      }
+
+      .preview-summary__title {
+        margin: 0;
+        font-size: 0.82rem;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: color-mix(in srgb, var(--navy) 70%, rgba(14, 34, 68, 0.4) 30%);
+      }
+
+      .preview-summary__tagline {
         margin: 0;
         font-size: 0.95rem;
         color: var(--text-subtle);
-        padding-left: 1rem;
+        max-width: 56ch;
       }
 
-      .preview-story {
+      .preview-summary__grid {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 3vw, 1.6rem);
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      }
+
+      .preview-summary__card {
+        display: grid;
+        gap: 0.6rem;
+        padding: clamp(1rem, 2.6vw, 1.4rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 14%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.92) 68%, rgba(242, 246, 255, 0.88) 32%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-summary__card h2 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--navy);
+      }
+
+      .preview-summary__card p {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+      }
+
+      .preview-summary__list li {
+        margin: 0;
+      }
+
+      .preview-body {
+        display: grid;
+        gap: clamp(1.2rem, 3vw, 1.9rem);
+      }
+
+      @media (min-width: 960px) {
+        .preview-body {
+          grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+          align-items: start;
+        }
+      }
+
+      .preview-card {
+        display: grid;
+        gap: clamp(0.85rem, 2.4vw, 1.4rem);
+        padding: clamp(1.2rem, 2.8vw, 1.85rem);
+        border-radius: var(--radius-lg);
+        border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+        background: color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .preview-card--story {
+        background:
+          linear-gradient(155deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.08)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 68%, rgba(242, 246, 255, 0.9) 32%);
+      }
+
+      .preview-card--visuals {
+        background:
+          linear-gradient(150deg, rgba(17, 86, 214, 0.09), rgba(239, 61, 91, 0.07)),
+          color-mix(in srgb, rgba(255, 255, 255, 0.93) 66%, rgba(242, 246, 255, 0.92) 34%);
       }
 
       .preview-story h2 {
         margin: 0;
+        font-size: 1.35rem;
+        color: var(--navy);
       }
 
-      .preview-story ul {
+      .preview-story__lead {
         margin: 0;
-        padding-left: 1.1rem;
+        font-size: 1.05rem;
+        color: var(--text-strong);
       }
 
-      .preview-story li {
-        margin-bottom: 0.5rem;
+      .preview-story__paragraph {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      .preview-story__list li {
+        margin: 0;
+        position: relative;
+        padding-left: 1.6rem;
+        font-weight: 600;
+        color: var(--text-strong);
+      }
+
+      .preview-story__list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.35rem;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(244, 181, 63, 0.85));
+        box-shadow: 0 0 0 4px color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.9) 40%);
       }
 
       .preview-visuals {
         display: grid;
-        gap: 1.25rem;
+        gap: clamp(1rem, 2.8vw, 1.6rem);
       }
 
       .preview-visuals__header {
         display: grid;
-        gap: 0.4rem;
+        gap: 0.5rem;
+      }
+
+      .preview-visuals__header h2 {
+        margin: 0;
+      }
+
+      .preview-visuals__header p {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.95rem;
       }
 
       .preview-visuals__grid {
         display: grid;
-        gap: clamp(1rem, 3vw, 1.5rem);
+        gap: clamp(1rem, 3vw, 1.6rem);
       }
 
       @media (min-width: 900px) {
@@ -772,7 +910,8 @@ function renderGamePage(
 
       .preview-visuals__team-header h3 {
         margin: 0;
-        font-size: 1.2rem;
+        font-size: 1.15rem;
+        color: var(--navy);
       }
 
       .preview-visuals__chip {
@@ -798,6 +937,7 @@ function renderGamePage(
       footer a {
         color: var(--royal);
         text-decoration: none;
+        font-weight: 600;
       }
 
       footer a:hover {
@@ -816,25 +956,33 @@ function renderGamePage(
         ${game.subLabel ? `<p class="lead">${game.subLabel}</p>` : ""}
       </header>
 
-      <section class="preview-meta">
-        <section class="preview-meta__section">
-          <h2>Matchup snapshot</h2>
-          <p>${away.displayName} vs. ${home.displayName}</p>
-          <p>${labelLine(game)}</p>
-        </section>
-        ${coverageSection}
-        ${notesSection}
+      <section class="preview-summary">
+        <header class="preview-summary__header">
+          <h2 class="preview-summary__title">Game essentials</h2>
+          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+        </header>
+        <div class="preview-summary__grid">
+          <section class="preview-summary__card">
+            <h2>Matchup snapshot</h2>
+            <p>${away.displayName} vs. ${home.displayName}</p>
+            <p>${labelLine(game)}</p>
+          </section>
+          ${coverageSection}
+          ${notesSection}
+        </div>
       </section>
 
-      <article class="preview-story">
-        <h2>Camp storylines to monitor</h2>
-        ${story.map((paragraph) => `<p>${paragraph}</p>`).join("\n        ")}
-        <ul>
-          ${bullets.map((bullet) => `<li>${bullet}</li>`).join("\n          ")}
-        </ul>
-      </article>
+      <div class="preview-body">
+        <article class="preview-story preview-card preview-card--story">
+          <h2>Camp storylines to monitor</h2>
+          ${storyParagraphs}
+          <ul class="preview-story__list">
+            ${bullets.map((bullet) => `<li>${bullet}</li>`).join("\n            ")}
+          </ul>
+        </article>
 
-      ${visualsSection}
+        ${visualsSection}
+      </div>
 
       <footer>
         <span>Season context: ${SEASON} preseason schedule.</span>


### PR DESCRIPTION
## Summary
- redesign the preseason preview template with a hub-aligned layout and richer card styling
- regenerate every preseason preview page to apply the refreshed structure and typography

## Testing
- pnpm previews *(fails to fetch remote roster data in the sandbox environment but generation completed)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b82f4b008327ab3dd8f5fbe7888a