### PR TITLE
Add manual override for Melbourne preseason preview

### DIFF
--- a/data/2025-26/canonical/preseason_preview_overrides.json
+++ b/data/2025-26/canonical/preseason_preview_overrides.json
@@ -1,0 +1,70 @@
+{
+  "generatedAt": "2025-09-28T22:53:47.714Z",
+  "season": "2025-26",
+  "overrides": {
+    "PRE2025-02": {
+      "header": {
+        "subLabel": "NBA Melbourne Game (NBA × NBL Showcase)",
+        "venueLine": "Rod Laver Arena — Melbourne, VIC (Neutral Site)"
+      },
+      "summary": {
+        "tagline": "This isn’t just a glorified scrimmage. It’s the NBA’s first-ever exhibition game on Australian soil.",
+        "description": [
+          "Melbourne United and the Pelicans clash in a spotlighted environment, where both sides use the platform to test rotations, evaluate young contributors, and assert identity before the real season begins."
+        ],
+        "cards": [
+          {
+            "title": "Matchup Snapshot",
+            "bullets": [
+              "Melbourne United (NBL power) vs. New Orleans Pelicans (NBA franchise)",
+              "Preseason / Exhibition",
+              "Significance: symbolic, developmental, and revealing — especially given the global stage and novelty of NBA games in Australia."
+            ]
+          }
+        ]
+      },
+      "story": {
+        "sections": [
+          {
+            "heading": "Historical Weight & International Ambition",
+            "paragraphs": [
+              "This game is more than two squads warming up. It’s a milestone: the first time an NBA team will play (even if in exhibition form) in Australia.",
+              "For Melbourne, it’s a chance to be taken seriously on a global stage. For New Orleans, it’s a branding, fan-engagement, and scouting venture. Off-court events (fan nights, practice sessions) accompany the game."
+            ]
+          },
+          {
+            "heading": "Melbourne United: Local Pride Meets Global Pressure",
+            "paragraphs": [
+              "Melbourne comes off a strong 2024–25 NBL season (19–10, reached the grand final) under coach Dean Vickerman.",
+              "They’ll want to show they can hang with NBA talent—especially in front of home fans. Expect heavy usage of established NBL contributors, import players, and veteran leadership to stabilize play when it matters."
+            ]
+          },
+          {
+            "heading": "Pelicans Overhaul & Young Talent Watch",
+            "paragraphs": [
+              "The Pelicans enter with a retooled roster. Their offseason changes included new faces, more emphasis on youth, and role adjustments."
+            ],
+            "bullets": [
+              "Jeremiah Fears, recent draft pick, is reportedly being mentored by veteran point guards in camp.",
+              "Zion Williamson comes in leaner and more focused on consistency and health.",
+              "The absence of key players or injury flags could tilt experimental opportunities in Melbourne."
+            ]
+          },
+          {
+            "heading": "Chemistry vs. Minutes: How Aggressive Should They Go?",
+            "paragraphs": [
+              "Will coaches treat this as an extension of practice—slow, controlled, with substitutions galore—or approach it as a miniature dress rehearsal?",
+              "Melbourne may adhere more to its systems, but the Pelicans might push to simulate game pressure, defensive communication, and lineups (even if imperfect) to accelerate learning."
+            ]
+          }
+        ],
+        "questionsHeading": "Narrative Questions to Watch",
+        "questions": [
+          "Which player (rookie or bench piece) converts this high-visibility moment into actual regular-season minutes?",
+          "How well does the Pelicans’ new blend of youth and veterans hold up under live scrutiny?",
+          "Does a distinct tactical approach (e.g. small ball, zone vs man, pace changes) emerge and stick as a talking point?"
+        ]
+      }
+    }
+  }
+}

--- a/data/2025-26/manual/preseason_preview_overrides.yaml
+++ b/data/2025-26/manual/preseason_preview_overrides.yaml
@@ -1,0 +1,42 @@
+season: "2025-26"
+overrides:
+  PRE2025-02:
+    header:
+      subLabel: "NBA Melbourne Game (NBA × NBL Showcase)"
+      venueLine: "Rod Laver Arena — Melbourne, VIC (Neutral Site)"
+    summary:
+      tagline: "This isn’t just a glorified scrimmage. It’s the NBA’s first-ever exhibition game on Australian soil."
+      description:
+        - "Melbourne United and the Pelicans clash in a spotlighted environment, where both sides use the platform to test rotations, evaluate young contributors, and assert identity before the real season begins."
+      cards:
+        - title: "Matchup Snapshot"
+          bullets:
+            - "Melbourne United (NBL power) vs. New Orleans Pelicans (NBA franchise)"
+            - "Preseason / Exhibition"
+            - "Significance: symbolic, developmental, and revealing — especially given the global stage and novelty of NBA games in Australia."
+    story:
+      sections:
+        - heading: "Historical Weight & International Ambition"
+          paragraphs:
+            - "This game is more than two squads warming up. It’s a milestone: the first time an NBA team will play (even if in exhibition form) in Australia."
+            - "For Melbourne, it’s a chance to be taken seriously on a global stage. For New Orleans, it’s a branding, fan-engagement, and scouting venture. Off-court events (fan nights, practice sessions) accompany the game."
+        - heading: "Melbourne United: Local Pride Meets Global Pressure"
+          paragraphs:
+            - "Melbourne comes off a strong 2024–25 NBL season (19–10, reached the grand final) under coach Dean Vickerman."
+            - "They’ll want to show they can hang with NBA talent—especially in front of home fans. Expect heavy usage of established NBL contributors, import players, and veteran leadership to stabilize play when it matters."
+        - heading: "Pelicans Overhaul & Young Talent Watch"
+          paragraphs:
+            - "The Pelicans enter with a retooled roster. Their offseason changes included new faces, more emphasis on youth, and role adjustments."
+          bullets:
+            - "Jeremiah Fears, recent draft pick, is reportedly being mentored by veteran point guards in camp."
+            - "Zion Williamson comes in leaner and more focused on consistency and health."
+            - "The absence of key players or injury flags could tilt experimental opportunities in Melbourne."
+        - heading: "Chemistry vs. Minutes: How Aggressive Should They Go?"
+          paragraphs:
+            - "Will coaches treat this as an extension of practice—slow, controlled, with substitutions galore—or approach it as a miniature dress rehearsal?"
+            - "Melbourne may adhere more to its systems, but the Pelicans might push to simulate game pressure, defensive communication, and lineups (even if imperfect) to accelerate learning."
+      questionsHeading: "Narrative Questions to Watch"
+      questions:
+        - "Which player (rookie or bench piece) converts this high-visibility moment into actual regular-season minutes?"
+        - "How well does the Pelicans’ new blend of youth and veterans hold up under live scrutiny?"
+        - "Does a distinct tactical approach (e.g. small ball, zone vs man, pace changes) emerge and stick as a talking point?"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "packageManager": "pnpm@9.1.0",
   "scripts": {
-    "build:data": "tsx scripts/data/build_canonical.ts && tsx scripts/data/build_preseason_schedule.ts",
+    "build:data": "tsx scripts/data/build_canonical.ts && tsx scripts/data/build_preseason_schedule.ts && tsx scripts/data/build_preseason_preview_overrides.ts",
     "gen:previews": "tsx scripts/generate/preseason_previews.ts && tsx scripts/generate/previews.ts",
     "validate:previews": "tsx scripts/validate/previews_staleness.ts && tsx scripts/validate/links.ts",
     "previews": "pnpm build:data && pnpm gen:previews && pnpm validate:previews",

--- a/public/previews/preseason-pre2025-01.html
+++ b/public/previews/preseason-pre2025-01.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Philadelphia 76ers vs. New York Knicks</p>
             <p>Preseason · NBA Abu Dhabi Game</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-02.html
+++ b/public/previews/preseason-pre2025-02.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -301,21 +350,28 @@
         <time datetime="2025-10-03T09:30:00.000Z">Friday, October 3, 2025 at 5:30 AM EDT</time>
         <p>Friday, October 3, 2025 at 9:30 AM UTC (UTC)</p>
         <h1>Melbourne United at New Orleans Pelicans</h1>
-        <p><strong>Rod Laver Arena · Melbourne, VIC</strong> · Neutral Site</p>
-        <p class="lead">NBA Melbourne Game</p>
+        <p><strong>Rod Laver Arena — Melbourne, VIC (Neutral Site)</strong></p>
+        <p class="lead">NBA Melbourne Game (NBA × NBL Showcase)</p>
       </header>
 
       <section class="preview-summary">
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
-          <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          <p class="preview-summary__tagline">This isn’t just a glorified scrimmage. It’s the NBA’s first-ever exhibition game on Australian soil.</p>
+          <p class="preview-summary__description">Melbourne United and the Pelicans clash in a spotlighted environment, where both sides use the platform to test rotations, evaluate young contributors, and assert identity before the real season begins.</p>
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
-            <h2>Matchup snapshot</h2>
-            <p>Melbourne United vs. New Orleans Pelicans</p>
-            <p>Preseason · NBA Melbourne Game</p>
+            <h2>Matchup Snapshot</h2>
+            
+            <ul class="preview-summary__list">
+              <li>Melbourne United (NBL power) vs. New Orleans Pelicans (NBA franchise)</li>
+              <li>Preseason / Exhibition</li>
+              <li>Significance: symbolic, developmental, and revealing — especially given the global stage and novelty of NBA games in Australia.</li>
+            </ul>
           </section>
+        
           
           
         </div>
@@ -324,12 +380,48 @@
       <div class="preview-body">
         <article class="preview-story preview-card preview-card--story">
           <h2>Camp storylines to monitor</h2>
-          <p class="preview-story__lead">Melbourne United face the Pelicans at Rod Laver Arena · Melbourne, VIC, opening the 2025-26 preseason with the NBA Melbourne Game showcase designed to stress-test training camp priorities.</p>
-        <p class="preview-story__paragraph">Melbourne United’s staff expects to spotlight rotation hopefuls and sharpen conditioning, while New Orleans focuses on lineup chemistry in front of a neutral crowd. Both clubs are using this window to evaluate how younger pieces complement their established cores.</p>
+          <ol class="preview-story__entries">
+          <li class="preview-story__entry">
+            <h3 class="preview-story__entry-title">Historical Weight & International Ambition</h3>
+            <div class="preview-story__entry-body">
+              <p>This game is more than two squads warming up. It’s a milestone: the first time an NBA team will play (even if in exhibition form) in Australia.</p>
+            <p>For Melbourne, it’s a chance to be taken seriously on a global stage. For New Orleans, it’s a branding, fan-engagement, and scouting venture. Off-court events (fan nights, practice sessions) accompany the game.</p>
+              
+            </div>
+          </li>
+          <li class="preview-story__entry">
+            <h3 class="preview-story__entry-title">Melbourne United: Local Pride Meets Global Pressure</h3>
+            <div class="preview-story__entry-body">
+              <p>Melbourne comes off a strong 2024–25 NBL season (19–10, reached the grand final) under coach Dean Vickerman.</p>
+            <p>They’ll want to show they can hang with NBA talent—especially in front of home fans. Expect heavy usage of established NBL contributors, import players, and veteran leadership to stabilize play when it matters.</p>
+              
+            </div>
+          </li>
+          <li class="preview-story__entry">
+            <h3 class="preview-story__entry-title">Pelicans Overhaul & Young Talent Watch</h3>
+            <div class="preview-story__entry-body">
+              <p>The Pelicans enter with a retooled roster. Their offseason changes included new faces, more emphasis on youth, and role adjustments.</p>
+              <ul>
+              <li>Jeremiah Fears, recent draft pick, is reportedly being mentored by veteran point guards in camp.</li>
+              <li>Zion Williamson comes in leaner and more focused on consistency and health.</li>
+              <li>The absence of key players or injury flags could tilt experimental opportunities in Melbourne.</li>
+            </ul>
+            </div>
+          </li>
+          <li class="preview-story__entry">
+            <h3 class="preview-story__entry-title">Chemistry vs. Minutes: How Aggressive Should They Go?</h3>
+            <div class="preview-story__entry-body">
+              <p>Will coaches treat this as an extension of practice—slow, controlled, with substitutions galore—or approach it as a miniature dress rehearsal?</p>
+            <p>Melbourne may adhere more to its systems, but the Pelicans might push to simulate game pressure, defensive communication, and lineups (even if imperfect) to accelerate learning.</p>
+              
+            </div>
+          </li>
+        </ol>
+          <h3 class="preview-story__subheading">Narrative Questions to Watch</h3>
           <ul class="preview-story__list">
-            <li>Which emerging contributor helps Melbourne United turn preseason reps into regular-season trust?</li>
-            <li>How do New Orleans Pelicans balance veteran rhythm with developmental minutes during the NBA Melbourne Game showcase?</li>
-            <li>Which camp emphasis becomes a lasting talking point for both benches?</li>
+            <li>Which player (rookie or bench piece) converts this high-visibility moment into actual regular-season minutes?</li>
+            <li>How well does the Pelicans’ new blend of youth and veterans hold up under live scrutiny?</li>
+            <li>Does a distinct tactical approach (e.g. small ball, zone vs man, pace changes) emerge and stick as a talking point?</li>
           </ul>
         </article>
 

--- a/public/previews/preseason-pre2025-03.html
+++ b/public/previews/preseason-pre2025-03.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Phoenix Suns vs. Los Angeles Lakers</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-04.html
+++ b/public/previews/preseason-pre2025-04.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>New York Knicks vs. Philadelphia 76ers</p>
             <p>Preseason · NBA Abu Dhabi Game</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-05.html
+++ b/public/previews/preseason-pre2025-05.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Hapoel Jerusalem B.C. vs. Brooklyn Nets</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-06.html
+++ b/public/previews/preseason-pre2025-06.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Orlando Magic vs. Miami Heat</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-07.html
+++ b/public/previews/preseason-pre2025-07.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Minnesota Timberwolves vs. Denver Nuggets</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-08.html
+++ b/public/previews/preseason-pre2025-08.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>South East Melbourne Phoenix vs. New Orleans Pelicans</p>
             <p>Preseason · NBA Melbourne Game</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-09.html
+++ b/public/previews/preseason-pre2025-09.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Oklahoma City Thunder vs. Charlotte Hornets</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-10.html
+++ b/public/previews/preseason-pre2025-10.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Los Angeles Lakers vs. Golden State Warriors</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-11.html
+++ b/public/previews/preseason-pre2025-11.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Milwaukee Bucks vs. Miami Heat</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-12.html
+++ b/public/previews/preseason-pre2025-12.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Atlanta Hawks vs. Houston Rockets</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-13.html
+++ b/public/previews/preseason-pre2025-13.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Detroit Pistons vs. Memphis Grizzlies</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-14.html
+++ b/public/previews/preseason-pre2025-14.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Guangzhou Loong-Lions vs. San Antonio Spurs</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-15.html
+++ b/public/previews/preseason-pre2025-15.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Oklahoma City Thunder vs. Dallas Mavericks</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-16.html
+++ b/public/previews/preseason-pre2025-16.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Denver Nuggets vs. Toronto Raptors</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-17.html
+++ b/public/previews/preseason-pre2025-17.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Chicago Bulls vs. Cleveland Cavaliers</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           
         </div>

--- a/public/previews/preseason-pre2025-18.html
+++ b/public/previews/preseason-pre2025-18.html
@@ -93,6 +93,13 @@
         max-width: 56ch;
       }
 
+      .preview-summary__description {
+        margin: 0;
+        font-size: 0.95rem;
+        color: var(--text-subtle);
+        max-width: 66ch;
+      }
+
       .preview-summary__grid {
         display: grid;
         gap: clamp(1rem, 3vw, 1.6rem);
@@ -183,6 +190,48 @@
       .preview-story__paragraph {
         margin: 0;
         color: var(--text-subtle);
+      }
+
+      .preview-story__entries {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .preview-story__entry {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-title {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--text-strong);
+      }
+
+      .preview-story__entry-body {
+        display: grid;
+        gap: 0.55rem;
+        margin-top: 0.35rem;
+      }
+
+      .preview-story__entry-body p {
+        margin: 0;
+        color: var(--text-subtle);
+      }
+
+      .preview-story__entry-body ul {
+        margin: 0;
+        padding-left: 1.1rem;
+        display: grid;
+        gap: 0.4rem;
+      }
+
+      .preview-story__subheading {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--text-strong);
       }
 
       .preview-story__list {
@@ -309,13 +358,17 @@
         <header class="preview-summary__header">
           <h2 class="preview-summary__title">Game essentials</h2>
           <p class="preview-summary__tagline">Key context before rotations start moving.</p>
+          
         </header>
         <div class="preview-summary__grid">
+          
           <section class="preview-summary__card">
             <h2>Matchup snapshot</h2>
             <p>Indiana Pacers vs. Minnesota Timberwolves</p>
             <p>Preseason</p>
+            
           </section>
+        
           
           <section class="preview-summary__card">
             <h2>Coverage</h2>

--- a/scripts/data/build_preseason_preview_overrides.ts
+++ b/scripts/data/build_preseason_preview_overrides.ts
@@ -1,0 +1,292 @@
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import { parse as parseYaml } from "yaml";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../");
+const MANUAL_PATH = path.join(ROOT, "data/2025-26/manual/preseason_preview_overrides.yaml");
+const CANONICAL_PATH = path.join(ROOT, "data/2025-26/canonical/preseason_preview_overrides.json");
+
+interface RawSummaryCard {
+  title?: unknown;
+  body?: unknown;
+  bullets?: unknown;
+}
+
+interface RawSummaryOverride {
+  tagline?: unknown;
+  description?: unknown;
+  cards?: unknown;
+}
+
+interface RawHeaderOverride {
+  subLabel?: unknown;
+  venueLine?: unknown;
+}
+
+interface RawStorySection {
+  heading?: unknown;
+  paragraphs?: unknown;
+  bullets?: unknown;
+}
+
+interface RawStoryOverride {
+  introParagraphs?: unknown;
+  sections?: unknown;
+  questionsHeading?: unknown;
+  questions?: unknown;
+}
+
+interface RawPreviewOverride {
+  header?: unknown;
+  summary?: unknown;
+  story?: unknown;
+}
+
+interface RawOverridesPayload {
+  season?: unknown;
+  overrides?: unknown;
+}
+
+interface SummaryCard {
+  title: string;
+  body?: string[];
+  bullets?: string[];
+}
+
+interface SummaryOverride {
+  tagline?: string;
+  description?: string[];
+  cards?: SummaryCard[];
+}
+
+interface HeaderOverride {
+  subLabel?: string;
+  venueLine?: string;
+}
+
+interface StorySection {
+  heading: string;
+  paragraphs?: string[];
+  bullets?: string[];
+}
+
+interface StoryOverride {
+  introParagraphs?: string[];
+  sections?: StorySection[];
+  questionsHeading?: string;
+  questions?: string[];
+}
+
+interface PreviewOverride {
+  header?: HeaderOverride;
+  summary?: SummaryOverride;
+  story?: StoryOverride;
+}
+
+interface OverridesPayload {
+  season?: string;
+  overrides: Record<string, PreviewOverride>;
+}
+
+function ensureString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+function ensureStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const cleaned = value
+    .map((entry) => ensureString(entry))
+    .filter((entry): entry is string => typeof entry === "string");
+  return cleaned.length ? cleaned : undefined;
+}
+
+function normalizeSummaryCard(raw: unknown): SummaryCard | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as RawSummaryCard;
+  const title = ensureString(source.title);
+  if (!title) {
+    return undefined;
+  }
+  const body = ensureStringArray(source.body);
+  const bullets = ensureStringArray(source.bullets);
+  const card: SummaryCard = { title };
+  if (body) {
+    card.body = body;
+  }
+  if (bullets) {
+    card.bullets = bullets;
+  }
+  return card;
+}
+
+function normalizeSummaryOverride(raw: unknown): SummaryOverride | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as RawSummaryOverride;
+  const override: SummaryOverride = {};
+  const tagline = ensureString(source.tagline);
+  if (tagline) {
+    override.tagline = tagline;
+  }
+  const description = ensureStringArray(source.description);
+  if (description) {
+    override.description = description;
+  }
+  if (Array.isArray(source.cards)) {
+    const cards = source.cards
+      .map((entry) => normalizeSummaryCard(entry))
+      .filter((entry): entry is SummaryCard => Boolean(entry));
+    if (cards.length) {
+      override.cards = cards;
+    }
+  }
+  return Object.keys(override).length ? override : undefined;
+}
+
+function normalizeHeaderOverride(raw: unknown): HeaderOverride | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as RawHeaderOverride;
+  const header: HeaderOverride = {};
+  const subLabel = ensureString(source.subLabel);
+  if (subLabel) {
+    header.subLabel = subLabel;
+  }
+  const venueLine = ensureString(source.venueLine);
+  if (venueLine) {
+    header.venueLine = venueLine;
+  }
+  return Object.keys(header).length ? header : undefined;
+}
+
+function normalizeStorySection(raw: unknown): StorySection | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as RawStorySection;
+  const heading = ensureString(source.heading);
+  if (!heading) {
+    return undefined;
+  }
+  const paragraphs = ensureStringArray(source.paragraphs);
+  const bullets = ensureStringArray(source.bullets);
+  const section: StorySection = { heading };
+  if (paragraphs) {
+    section.paragraphs = paragraphs;
+  }
+  if (bullets) {
+    section.bullets = bullets;
+  }
+  return section;
+}
+
+function normalizeStoryOverride(raw: unknown): StoryOverride | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as RawStoryOverride;
+  const override: StoryOverride = {};
+  const intro = ensureStringArray(source.introParagraphs);
+  if (intro) {
+    override.introParagraphs = intro;
+  }
+  if (Array.isArray(source.sections)) {
+    const sections = source.sections
+      .map((entry) => normalizeStorySection(entry))
+      .filter((entry): entry is StorySection => Boolean(entry));
+    if (sections.length) {
+      override.sections = sections;
+    }
+  }
+  const questionsHeading = ensureString(source.questionsHeading);
+  if (questionsHeading) {
+    override.questionsHeading = questionsHeading;
+  }
+  const questions = ensureStringArray(source.questions);
+  if (questions) {
+    override.questions = questions;
+  }
+  return Object.keys(override).length ? override : undefined;
+}
+
+function normalizePreviewOverride(raw: unknown): PreviewOverride | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const source = raw as RawPreviewOverride;
+  const header = normalizeHeaderOverride(source.header);
+  const summary = normalizeSummaryOverride(source.summary);
+  const story = normalizeStoryOverride(source.story);
+  const override: PreviewOverride = {};
+  if (header) {
+    override.header = header;
+  }
+  if (summary) {
+    override.summary = summary;
+  }
+  if (story) {
+    override.story = story;
+  }
+  return Object.keys(override).length ? override : undefined;
+}
+
+function normalizeOverridesPayload(raw: unknown): OverridesPayload {
+  if (!raw || typeof raw !== "object") {
+    return { overrides: {} };
+  }
+  const source = raw as RawOverridesPayload;
+  const season = ensureString(source.season);
+  const overrides: Record<string, PreviewOverride> = {};
+  if (source.overrides && typeof source.overrides === "object") {
+    for (const [key, value] of Object.entries(source.overrides as Record<string, unknown>)) {
+      const override = normalizePreviewOverride(value);
+      if (override) {
+        overrides[key] = override;
+      }
+    }
+  }
+  return { season: season ?? undefined, overrides };
+}
+
+async function buildPreseasonPreviewOverrides(): Promise<OverridesPayload> {
+  try {
+    const raw = await readFile(MANUAL_PATH, "utf8");
+    const parsed = parseYaml(raw);
+    return normalizeOverridesPayload(parsed);
+  } catch (error) {
+    console.warn(`Failed to read preseason preview overrides: ${(error as Error).message}`);
+    return { overrides: {} };
+  }
+}
+
+async function run(): Promise<void> {
+  const payload = await buildPreseasonPreviewOverrides();
+  const output = {
+    generatedAt: new Date().toISOString(),
+    season: payload.season,
+    overrides: payload.overrides,
+  };
+  await writeFile(CANONICAL_PATH, `${JSON.stringify(output, null, 2)}\n`, "utf8");
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMain) {
+  run().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}
+
+export { buildPreseasonPreviewOverrides };


### PR DESCRIPTION
## Summary
- add a manual override configuration and build step for preseason preview copy
- extend the preseason preview generator to load overrides and support richer story structures
- regenerate preseason preview HTML with the Melbourne vs. New Orleans narrative update and new styling hooks

## Testing
- pnpm previews

------
https://chatgpt.com/codex/tasks/task_e_68d9bad9c8c08327be56748cb5c64cb6