### PR TITLE
Refine player card visualization layout

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -138,10 +138,26 @@
                   </div>
                 </dl>
               </div>
-              <div class="player-card__visuals" data-player-metrics aria-label="Percentile visualizations"></div>
-              <p class="player-card__visuals-empty" data-player-metrics-empty hidden>
-                Percentile visuals are coming soon for this player.
-              </p>
+              <section
+                class="player-card__visuals-section"
+                aria-labelledby="player-card-visuals-title"
+              >
+                <header class="player-card__visuals-header">
+                  <h4 id="player-card-visuals-title">Percentile visual reads</h4>
+                  <p>
+                    Twelve scouting gauges anchor the 2025-26 outlook on each player's 2024-25
+                    production — a quick scan of creation, feel, and defensive range.
+                  </p>
+                </header>
+                <div
+                  class="player-card__visuals"
+                  data-player-metrics
+                  aria-label="Percentile visualizations"
+                ></div>
+                <p class="player-card__visuals-empty" data-player-metrics-empty hidden>
+                  Percentile visuals are coming soon for this player.
+                </p>
+              </section>
             </article>
           </div>
         </section>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -4216,6 +4216,25 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   text-align: right;
 }
 .player-card__body { display: grid; gap: 1.1rem; }
+.player-card__visuals-section {
+  display: grid;
+  gap: clamp(0.9rem, 2.2vw, 1.25rem);
+}
+.player-card__visuals-header {
+  display: grid;
+  gap: 0.4rem;
+}
+.player-card__visuals-header h4 {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+  color: color-mix(in srgb, var(--navy) 85%, var(--royal) 15%);
+}
+.player-card__visuals-header p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--text-subtle) 82%, var(--navy) 18%);
+}
 .player-card__bio {
   margin: 0;
   font-size: 1rem;
@@ -4245,7 +4264,15 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-card__visuals {
   display: grid;
   gap: clamp(0.85rem, 2.2vw, 1.2rem);
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-auto-rows: 1fr;
+  align-items: stretch;
+}
+
+@media (max-width: 540px) {
+  .player-card__visuals {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 .player-card__visuals-empty {
   margin: 0;
@@ -4264,6 +4291,9 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   padding: 1rem 1.1rem 1.15rem;
   box-shadow: 0 16px 30px rgba(11, 37, 69, 0.12);
   overflow: hidden;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  align-content: start;
+  height: 100%;
 }
 .player-metric::before {
   content: '';
@@ -4277,10 +4307,11 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-metric__header {
   position: relative;
   z-index: 1;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
+  column-gap: 0.75rem;
+  row-gap: 0.35rem;
 }
 .player-metric__label {
   font-weight: 600;
@@ -4288,12 +4319,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   color: color-mix(in srgb, var(--navy) 88%, var(--royal) 12%);
 }
 .player-metric__value {
-  display: flex;
+  display: inline-flex;
   align-items: baseline;
   gap: 0.35rem;
   font-weight: 700;
   font-size: 1.05rem;
   color: color-mix(in srgb, var(--royal) 68%, var(--navy) 32%);
+  justify-self: end;
 }
 .player-metric__value-number {
   font-size: clamp(1.1rem, 2.6vw, 1.35rem);
@@ -4337,6 +4369,11 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   font-size: 0.9rem;
   line-height: 1.55;
   color: color-mix(in srgb, var(--text-subtle) 82%, var(--navy) 18%);
+  align-self: start;
+}
+
+.player-metric__description:last-child {
+  margin-top: auto;
 }
 .player-metric--tier-elite::before {
   background: linear-gradient(90deg, var(--royal), var(--sky));


### PR DESCRIPTION
## Summary
- wrap the player card percentile visuals in a dedicated section with contextual copy that ties the 2025-26 lens to the 2024-25 baseline
- rebalance the metric grid to stretch cards evenly, improve header alignment, and keep descriptions visible across breakpoints

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d9c0e67274832798db2df9850fd15b