### PR TITLE
Fix pnpm activation in pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,12 +24,12 @@ jobs:
         with:
           node-version: 20
           cache: "pnpm"
-      - name: Enable corepack
-        run: corepack enable
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 9
-          run_install: true
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9 --activate
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Fetch rosters
         env:
           BALLDONTLIE_API_KEY: ${{ secrets.BALLDONTLIE_API_KEY }}


### PR DESCRIPTION
## Summary
- activate pnpm via Corepack and prepare pnpm@9 before running pnpm commands
- install dependencies directly with pnpm install instead of relying on pnpm/action-setup

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9cbde45748327b791d6441ce5e5a1