### PR TITLE
Fix pnpm setup in workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,3 @@
-# .github/workflows/pages.yml
 name: Deploy
 
 on:
@@ -24,23 +23,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node (with pnpm cache)
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
 
-      # Install pnpm onto PATH (no Corepack in this workflow)
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.12.1
-          run_install: false
-
-      - name: Verify pnpm
+      - name: Install pnpm (and fix PATH)
+        shell: bash
         run: |
+          npm i -g pnpm@9.12.1
+          prefix="$(npm config get prefix)"
+          echo "$prefix/bin" >> "$GITHUB_PATH"
           pnpm -v
           which pnpm
+
+      - name: Use dedicated pnpm store
+        run: pnpm config set store-dir ~/.pnpm-store
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: pnpm-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -71,6 +76,3 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-
-
-

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -1,4 +1,3 @@
-# .github/workflows/previews.yml
 name: Previews pipeline
 
 on:
@@ -22,23 +21,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        with: { fetch-depth: 0 }
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      # Install pnpm onto PATH (no Corepack here)
-      - name: Install pnpm
+      - name: Install pnpm (and fix PATH)
+        shell: bash
         run: |
           npm i -g pnpm@9.12.1
+          prefix="$(npm config get prefix)"
+          echo "$prefix/bin" >> "$GITHUB_PATH"
           pnpm -v
           which pnpm
 
-      # Use a stable pnpm store and cache it
-      - name: Set pnpm store path
+      - name: Use dedicated pnpm store
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
@@ -46,8 +45,7 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-${{ runner.os }}-
+          restore-keys: pnpm-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -81,5 +79,3 @@ jobs:
           branch: "chore/auto-previews-${{ github.run_id }}"
           base: "main"
           delete-branch: true
-
-


### PR DESCRIPTION
## Summary
- replace the previews pipeline with the known-good configuration that installs pnpm explicitly and caches the pnpm store without using setup-node caching
- update the pages deployment workflow to install pnpm manually and reuse the shared caching pattern
- verify that no workflow still references `cache: pnpm` or `corepack`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9d30c8ef083279a91979dbaaeb7f5