### PR TITLE
Fix players bundle path for relative hosting

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -339,6 +339,6 @@
     </div>
     <script src="vendor/chart.umd.js" defer></script>
     <script type="module" src="scripts/players.js"></script>
-    <script type="module" src="/assets/js/players.2fd87b63.js"></script>
+    <script type="module" src="assets/js/players.2fd87b63.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update the hashed players bundle reference to use a relative path so it resolves when the site is hosted from a subdirectory

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d9d4581a188327b274c766cb7ef153