### PR TITLE
Fix GitHub Pages artifact directory

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./
+          path: public
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- update the Pages workflow to upload the `public` directory so the artifact includes `index.html`

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9d5fc5248832784704e9fd04fb950