### PR TITLE
Refactor roster build to rely on BallDontLie

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -55,6 +55,8 @@ jobs:
         run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Generate previews
+        env:
+          USE_NBA_STATS: "0"
         run: pnpm previews
 
       - name: Validate previews

--- a/scripts/fetch/bbr_rosters.ts
+++ b/scripts/fetch/bbr_rosters.ts
@@ -1,166 +1,121 @@
 import { load } from "cheerio";
-import { mkdir, rm, writeFile } from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
-import { brefTeam, fetchBref } from "../data/helpers/bref.js";
-import { TEAM_METADATA } from "../lib/teams.js";
-import {
+import { brefTeam, fetchBref } from "./bref.js";
+import { ensureTeamMetadata } from "../lib/teams.js";
+import type {
   CoachRecord,
-  InjuryRecord,
   LeagueDataSource,
   SourcePlayerRecord,
   SourceTeamRecord,
-  TransactionRecord,
 } from "../lib/types.js";
-import { loadCanonicalLeagueSource } from "./canonical_cache.js";
 
 const BBR_BASE = "https://www.basketball-reference.com";
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const BREF_MISSING_PATH = path.join(ROOT, "data/2025-26/manual/bref_missing.json");
 
-function resolveEndYear(season: string): number {
-  const [start, endFragment] = season.split("-");
-  const base = Number.parseInt(start, 10);
-  if (Number.isNaN(base)) {
-    throw new Error(`Invalid season string: ${season}`);
-  }
-  if (!endFragment) {
-    return base + 1;
-  }
-  const prefix = start.slice(0, start.length - endFragment.length);
-  const year = Number.parseInt(`${prefix}${endFragment}`, 10);
-  return Number.isNaN(year) ? base + 1 : year;
+function parseRosterFromHtml(html: string, teamId: string, tricode: string) {
+  const $ = load(html);
+  const roster: SourcePlayerRecord[] = [];
+
+  $("table#roster tbody tr").each((_, element) => {
+    const name = $(element).find("th[data-stat='player'] a").text().trim();
+    if (!name) {
+      return;
+    }
+    const pos = $(element).find("td[data-stat='pos']").text().trim();
+    const player: SourcePlayerRecord = {
+      name,
+      position: pos || undefined,
+      teamId,
+      teamTricode: tricode,
+    };
+    roster.push(player);
+  });
+
+  const coachText = $(
+    "table#coach-staff tbody tr:first-child td[data-stat='coach_name']"
+  )
+    .text()
+    .trim();
+
+  const coach: CoachRecord | undefined = coachText ? { name: coachText } : undefined;
+
+  return { roster, coach };
 }
 
-export async function fetchBbrRosters(season: string): Promise<LeagueDataSource> {
-  const endYear = resolveEndYear(season);
-  const canonicalFallback = await loadCanonicalLeagueSource();
+export async function fetchBbrRosterForTeam(teamAbbr: string, seasonEndYear: number) {
+  const meta = ensureTeamMetadata(teamAbbr);
+  const code = brefTeam(teamAbbr);
+  const url = `${BBR_BASE}/teams/${code}/${seasonEndYear}.html`;
+  const html = await fetchBref(url);
+  const { roster, coach } = parseRosterFromHtml(html, meta.teamId, meta.tricode);
+  return { team: teamAbbr, players: roster, coach };
+}
+
+export interface BbrRosterResult {
+  source: LeagueDataSource;
+  missing: string[];
+}
+
+export async function fetchBbrRosters(
+  teamAbbrs: string[],
+  seasonEndYear: number
+): Promise<BbrRosterResult> {
   const teams: Record<string, Partial<SourceTeamRecord>> = {};
   const players: Record<string, SourcePlayerRecord> = {};
-  const missingTeams: string[] = [];
-  const transactions: TransactionRecord[] = canonicalFallback
-    ? canonicalFallback.transactions.map((transaction) => ({ ...transaction }))
-    : [];
-  const coaches: Record<string, CoachRecord> = canonicalFallback
-    ? Object.fromEntries(
-        Object.entries(canonicalFallback.coaches).map(([team, record]) => [
-          team,
-          { ...record },
-        ])
-      )
-    : {};
-  const injuries: InjuryRecord[] = canonicalFallback
-    ? canonicalFallback.injuries.map((injury) => ({ ...injury }))
-    : [];
-
+  const coaches: Record<string, CoachRecord> = {};
+  const missing: string[] = [];
   let totalPlayers = 0;
 
-  for (const meta of TEAM_METADATA) {
-    const tricode = meta.tricode;
-    const code = brefTeam(tricode);
-    const url = `${BBR_BASE}/teams/${code}/${endYear}.html`;
+  for (const abbr of teamAbbrs) {
+    const meta = ensureTeamMetadata(abbr);
     try {
-      const response = await fetchBref(url);
-      if (response.status === 404) {
-        console.warn(`BRef 404 for ${tricode} at ${url}`);
-        missingTeams.push(tricode);
-        throw new Error("Basketball-Reference 404");
-      }
-      if (!response.ok) {
-        throw new Error(`Unexpected status ${response.status}`);
-      }
-      const html = await response.text();
-      const $ = load(html);
-      const roster: SourcePlayerRecord[] = [];
-      $("table#roster tbody tr").each((_, element) => {
-        const name = $(element).find("th[data-stat='player'] a").text().trim();
-        if (!name) {
-          return;
-        }
-        const pos = $(element).find("td[data-stat='pos']").text().trim();
-        const player: SourcePlayerRecord = {
-          name,
-          position: pos || undefined,
-          teamId: meta.teamId,
-          teamTricode: tricode,
-        };
-        roster.push(player);
-        const key = player.playerId ?? player.name;
-        players[key] = player;
-      });
-
-      totalPlayers += roster.length;
-
-      const coachText = $("table#coach-staff tbody tr:first-child td[data-stat='coach_name']").text().trim();
-      if (coachText) {
-        const coach: CoachRecord = { name: coachText };
-        coaches[tricode] = coach;
-      }
-
-      teams[tricode] = {
+      const { players: roster, coach } = await fetchBbrRosterForTeam(abbr, seasonEndYear);
+      teams[abbr] = {
         teamId: meta.teamId,
-        tricode,
+        tricode: meta.tricode,
         market: meta.market,
         name: meta.name,
         roster,
-        coach: coaches[tricode],
+        coach,
         lastSeasonWins: meta.lastSeasonWins,
         lastSeasonSRS: meta.lastSeasonSRS,
       };
-    } catch (error) {
-      console.warn(`Failed to fetch Basketball-Reference roster for ${tricode}: ${(error as Error).message}`);
-      const fallbackTeam = canonicalFallback?.teams[tricode];
-      if (fallbackTeam) {
-        const roster = (fallbackTeam.roster ?? []).map((player) => ({ ...player }));
-        const fallbackCoach = coaches[tricode] ?? (fallbackTeam.coach ? { ...fallbackTeam.coach } : undefined);
-        if (fallbackCoach) {
-          coaches[tricode] = { ...fallbackCoach };
-        }
-        teams[tricode] = {
-          teamId: fallbackTeam.teamId ?? meta.teamId,
-          tricode: fallbackTeam.tricode ?? tricode,
-          market: fallbackTeam.market ?? meta.market,
-          name: fallbackTeam.name ?? meta.name,
-          roster,
-          coach: fallbackCoach ? { ...fallbackCoach } : undefined,
-          lastSeasonWins: fallbackTeam.lastSeasonWins ?? meta.lastSeasonWins,
-          lastSeasonSRS: fallbackTeam.lastSeasonSRS ?? meta.lastSeasonSRS,
-        };
-        for (const player of roster) {
-          const key = player.playerId ?? player.name;
-          players[key] = { ...player };
-        }
-        totalPlayers += roster.length;
-      } else {
-        teams[tricode] = {
-          teamId: meta.teamId,
-          tricode,
-          market: meta.market,
-          name: meta.name,
-          roster: [],
-          lastSeasonWins: meta.lastSeasonWins,
-          lastSeasonSRS: meta.lastSeasonSRS,
-        };
-        totalPlayers += 0;
+      if (coach) {
+        coaches[abbr] = coach;
       }
+      for (const player of roster) {
+        const key = player.playerId ?? player.name;
+        players[key] = player;
+      }
+      totalPlayers += roster.length;
+      if (roster.length === 0) {
+        missing.push(abbr);
+      }
+    } catch (error) {
+      missing.push(abbr);
+      teams[abbr] = {
+        teamId: meta.teamId,
+        tricode: meta.tricode,
+        market: meta.market,
+        name: meta.name,
+        roster: [],
+        lastSeasonWins: meta.lastSeasonWins,
+        lastSeasonSRS: meta.lastSeasonSRS,
+      };
+      console.warn(`BRef fetch failed for ${abbr}: ${String(error)}`);
     }
   }
 
-  if (totalPlayers < 360 || totalPlayers > 600) {
-    throw new Error(`Basketball-Reference roster size ${totalPlayers} outside expected range`);
+  if (totalPlayers > 0 && (totalPlayers < 360 || totalPlayers > 600)) {
+    throw new Error(`League player total ${totalPlayers} outside expected range`);
   }
 
-  if (missingTeams.length) {
-    await mkdir(path.dirname(BREF_MISSING_PATH), { recursive: true });
-    await writeFile(
-      BREF_MISSING_PATH,
-      JSON.stringify({ season, missingTeams, at: new Date().toISOString() }, null, 2),
-      "utf8",
-    );
-    console.warn("Basketball-Reference missing teams:", missingTeams.join(", "));
-  } else {
-    await rm(BREF_MISSING_PATH, { force: true });
-  }
-
-  return { teams, players, transactions, coaches, injuries };
+  return {
+    source: {
+      teams,
+      players,
+      transactions: [],
+      coaches,
+      injuries: [],
+    },
+    missing,
+  };
 }

--- a/scripts/fetch/bdl_rosters.ts
+++ b/scripts/fetch/bdl_rosters.ts
@@ -1,0 +1,143 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import type { BLPlayer, BLTeam } from "../../types/ball.js";
+import { ensureTeamMetadata, TEAM_METADATA } from "../lib/teams.js";
+import type { LeagueDataSource, SourcePlayerRecord, SourceTeamRecord } from "../lib/types.js";
+
+const API = "https://api.balldontlie.io/v1";
+const KEY = process.env.BALLDONTLIE_API_KEY ?? "";
+const MAX_ATTEMPTS = 4;
+
+interface PaginatedPlayers {
+  data: BLPlayer[];
+  meta?: { next_cursor?: number | null };
+}
+
+function authHeaders(): Record<string, string> {
+  return KEY ? { Authorization: KEY } : {};
+}
+
+async function http<T>(url: string, attempt = 1): Promise<T> {
+  try {
+    const res = await fetch(url, { headers: authHeaders() });
+    if (res.status === 429 && attempt < MAX_ATTEMPTS) {
+      await sleep(500 * Math.pow(2, attempt - 1));
+      return http<T>(url, attempt + 1);
+    }
+    if (!res.ok) {
+      if (attempt < MAX_ATTEMPTS) {
+        await sleep(500 * Math.pow(2, attempt - 1));
+        return http<T>(url, attempt + 1);
+      }
+      throw new Error(`${res.status} ${res.statusText} for ${url}`);
+    }
+    return (await res.json()) as T;
+  } catch (error) {
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(500 * Math.pow(2, attempt - 1));
+      return http<T>(url, attempt + 1);
+    }
+    throw error;
+  }
+}
+
+async function getTeams(): Promise<BLTeam[]> {
+  const json = await http<{ data: BLTeam[] }>(`${API}/teams`);
+  return json.data ?? [];
+}
+
+async function getActivePlayersByTeam(teamId: number): Promise<BLPlayer[]> {
+  const players: BLPlayer[] = [];
+  let cursor: number | undefined;
+  const baseUrl = `${API}/players/active?team_ids[]=${teamId}&per_page=100`;
+
+  while (true) {
+    const url = cursor != null ? `${baseUrl}&cursor=${cursor}` : baseUrl;
+    const json = await http<PaginatedPlayers>(url);
+    if (Array.isArray(json.data)) {
+      players.push(...json.data);
+    }
+    const nextCursor = json.meta?.next_cursor ?? null;
+    if (!nextCursor) {
+      break;
+    }
+    cursor = nextCursor;
+    await sleep(125);
+  }
+
+  return players;
+}
+
+function toSourcePlayer(
+  player: BLPlayer,
+  teamId: string,
+  tricode: string
+): SourcePlayerRecord {
+  const fullName = `${player.first_name} ${player.last_name}`.trim();
+  return {
+    playerId: String(player.id),
+    name: fullName,
+    position: player.position ?? undefined,
+    teamId,
+    teamTricode: tricode,
+  };
+}
+
+export interface BallDontLieRosters extends LeagueDataSource {
+  teamAbbrs: string[];
+}
+
+export async function fetchBallDontLieRosters(): Promise<BallDontLieRosters> {
+  const teamsResponse = await getTeams();
+  if (!teamsResponse.length) {
+    throw new Error("BallDontLie returned no teams");
+  }
+
+  const validAbbrs = new Set(TEAM_METADATA.map((team) => team.tricode));
+  const teams: Record<string, Partial<SourceTeamRecord>> = {};
+  const players: Record<string, SourcePlayerRecord> = {};
+  const teamAbbrs: string[] = [];
+  let totalPlayers = 0;
+
+  for (const team of teamsResponse) {
+    const abbr = team.abbreviation.toUpperCase();
+    if (!validAbbrs.has(abbr)) {
+      continue;
+    }
+    const meta = ensureTeamMetadata(abbr);
+    const rawPlayers = await getActivePlayersByTeam(team.id);
+    const roster = rawPlayers.map((player) => toSourcePlayer(player, meta.teamId, meta.tricode));
+    totalPlayers += roster.length;
+
+    teams[abbr] = {
+      teamId: meta.teamId,
+      tricode: meta.tricode,
+      market: meta.market,
+      name: meta.name,
+      roster,
+      lastSeasonWins: meta.lastSeasonWins,
+      lastSeasonSRS: meta.lastSeasonSRS,
+    };
+
+    for (const player of roster) {
+      players[player.playerId ?? player.name] = player;
+    }
+
+    teamAbbrs.push(abbr);
+    await sleep(100);
+  }
+
+  if (totalPlayers < 360 || totalPlayers > 600) {
+    throw new Error(`BallDontLie returned suspicious league size ${totalPlayers}`);
+  }
+
+  teamAbbrs.sort();
+
+  return {
+    teamAbbrs,
+    teams,
+    players,
+    transactions: [],
+    coaches: {},
+    injuries: [],
+  };
+}

--- a/scripts/fetch/bref.ts
+++ b/scripts/fetch/bref.ts
@@ -2,9 +2,9 @@ export const BREF_MAP: Record<string, string> = {
   ATL: "ATL",
   BOS: "BOS",
   BKN: "BRK",
-  BRK: "BRK", // Nets
+  BRK: "BRK",
   CHA: "CHO",
-  CHO: "CHO", // Hornets
+  CHO: "CHO",
   CHI: "CHI",
   CLE: "CLE",
   DAL: "DAL",
@@ -25,32 +25,34 @@ export const BREF_MAP: Record<string, string> = {
   ORL: "ORL",
   PHI: "PHI",
   PHX: "PHO",
-  PHO: "PHO", // Suns
+  PHO: "PHO",
   POR: "POR",
   SAC: "SAC",
   SAS: "SAS",
   TOR: "TOR",
   UTA: "UTA",
   WAS: "WAS",
-} as const;
+};
 
 export function brefTeam(abbr: string): string {
-  const k = abbr.toUpperCase();
-  const m = BREF_MAP[k];
-  if (!m) throw new Error(`Unknown team abbr for Basketball-Reference: ${abbr}`);
-  return m;
+  const out = BREF_MAP[abbr.toUpperCase()];
+  if (!out) throw new Error(`Unknown team abbr for BRef: ${abbr}`);
+  return out;
 }
 
-export async function fetchBref(url: string, attempt = 1): Promise<Response> {
+export async function fetchBref(url: string, attempt = 1): Promise<string> {
   const res = await fetch(url, {
     headers: {
-      "User-Agent": "nba-previews-bot/1.0 (+https://github.com/rhicksrad/NBA)",
+      "User-Agent": "nba-previews/1.0 (+https://github.com/rhicksrad/NBA)",
       Accept: "text/html,application/xhtml+xml",
     },
   });
-  if (res.status >= 500 && attempt < 3) {
-    await new Promise((r) => setTimeout(r, 400 * attempt));
+  if (res.status >= 500 && attempt < 4) {
+    await new Promise((r) => setTimeout(r, 300 * attempt));
     return fetchBref(url, attempt + 1);
   }
-  return res;
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} for ${url}`);
+  }
+  return res.text();
 }

--- a/scripts/validate_rosters.ts
+++ b/scripts/validate_rosters.ts
@@ -36,6 +36,11 @@ async function main() {
     throw new Error("Duplicate player IDs in players_index.json");
   }
 
+  const totalPlayers = index.players.length;
+  if (totalPlayers < 360 || totalPlayers > 600) {
+    throw new Error(`Suspicious league size ${totalPlayers}`);
+  }
+
   const missing = index.players.filter(
     (player) => !player.team_abbr || typeof player.team_abbr !== "string",
   );


### PR DESCRIPTION
## Summary
- add a BallDontLie roster fetcher and promote it to the primary source in the canonical data builder while treating Basketball-Reference and NBA Stats as optional enrichments
- harden the Basketball-Reference scraper with slug fixes, retries, and missing-team reporting so empty responses no longer fail the build
- gate NBA Stats requests behind an environment flag in CI and extend roster validation to fail only on impossible league-wide totals

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d69ece4883279a91e2ccc98d5cd9