### PR TITLE
Add resilient players bundle build anchoring

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -339,6 +339,8 @@
     </div>
     <script src="vendor/chart.umd.js" defer></script>
     <script type="module" src="scripts/players.js"></script>
-    <script type="module" src="assets/js/players.2fd87b63.js"></script>
+    <!-- BUILD:PLAYERS -->
+    <script id="players-bundle" type="module" src="/assets/js/players.js"></script>
+    <!-- /BUILD:PLAYERS -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a BUILD:PLAYERS marker and deterministic players bundle tag to public/players.html
- rewrite scripts/build-players.js to hash the bundle and inject or replace the players-bundle tag safely

## Testing
- pnpm build *(fails: esbuild not found in PATH in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d7f77b4c83279c01ed6ab638d25d