### PR TITLE
Make BRef enrichment non-fatal and optional

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -55,6 +55,8 @@ jobs:
         run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Generate previews
+        env:
+          USE_BREF: "0"
         run: pnpm previews
 
       - name: Validate previews

--- a/scripts/fetch/bref.ts
+++ b/scripts/fetch/bref.ts
@@ -2,9 +2,9 @@ export const BREF_MAP: Record<string, string> = {
   ATL: "ATL",
   BOS: "BOS",
   BKN: "BRK",
-  BRK: "BRK", // Nets
+  BRK: "BRK",
   CHA: "CHO",
-  CHO: "CHO", // Hornets
+  CHO: "CHO",
   CHI: "CHI",
   CLE: "CLE",
   DAL: "DAL",
@@ -25,32 +25,33 @@ export const BREF_MAP: Record<string, string> = {
   ORL: "ORL",
   PHI: "PHI",
   PHX: "PHO",
-  PHO: "PHO", // Suns
+  PHO: "PHO",
   POR: "POR",
   SAC: "SAC",
   SAS: "SAS",
   TOR: "TOR",
   UTA: "UTA",
   WAS: "WAS",
-} as const;
+};
 
-export function brefTeam(abbr: string): string {
-  const k = abbr.toUpperCase();
-  const m = BREF_MAP[k];
-  if (!m) throw new Error(`Unknown team abbr for Basketball-Reference: ${abbr}`);
-  return m;
-}
+export const brefTeam = (abbr: string): string =>
+  BREF_MAP[abbr.toUpperCase()] ?? (() => {
+    throw new Error(`Unknown ${abbr}`);
+  })();
 
-export async function fetchBref(url: string, attempt = 1): Promise<Response> {
+export async function fetchBref(url: string, attempt = 1): Promise<string> {
   const res = await fetch(url, {
     headers: {
-      "User-Agent": "nba-previews-bot/1.0 (+https://github.com/rhicksrad/NBA)",
+      "User-Agent": "nba-previews/1.0 (+https://github.com/rhicksrad/NBA)",
       Accept: "text/html,application/xhtml+xml",
     },
   });
-  if (res.status >= 500 && attempt < 3) {
-    await new Promise((r) => setTimeout(r, 400 * attempt));
+  if (res.status >= 500 && attempt < 4) {
+    await new Promise((r) => setTimeout(r, 300 * attempt));
     return fetchBref(url, attempt + 1);
   }
-  return res;
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${url}`);
+  }
+  return res.text();
 }


### PR DESCRIPTION
## Summary
- handle Basketball-Reference scraping failures by warning, tracking missing teams, and falling back to canonical data
- add a dedicated Basketball-Reference helper with correct slugs, user-agent, and retries
- allow canonical builds and CI to skip BRef enrichment while persisting missing-team metadata when available

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d9d8292ce48327bb24a4b31674df96