### PR TITLE
Fix Basketball-Reference enrichment error handling

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Generate previews
         env:
           USE_NBA_STATS: "0"
+          USE_BREF: "0"
         run: pnpm previews
 
       - name: Validate previews

--- a/scripts/fetch/bbr_rosters.ts
+++ b/scripts/fetch/bbr_rosters.ts
@@ -50,7 +50,7 @@ export async function fetchBbrRosterForTeam(teamAbbr: string, seasonEndYear: num
 }
 
 export interface BbrRosterResult {
-  source: LeagueDataSource;
+  rosters: LeagueDataSource;
   missing: string[];
 }
 
@@ -87,6 +87,7 @@ export async function fetchBbrRosters(
       }
       totalPlayers += roster.length;
       if (roster.length === 0) {
+        console.warn(`BRef: 0 parsed players for ${abbr}; marking missing and continuing.`);
         missing.push(abbr);
       }
     } catch (error) {
@@ -104,12 +105,14 @@ export async function fetchBbrRosters(
     }
   }
 
-  if (totalPlayers > 0 && (totalPlayers < 360 || totalPlayers > 600)) {
-    throw new Error(`League player total ${totalPlayers} outside expected range`);
+  if (totalPlayers === 0) {
+    console.warn(
+      "BRef: parsed 0 players across all teams; treating as enrichment-only and continuing."
+    );
   }
 
   return {
-    source: {
+    rosters: {
       teams,
       players,
       transactions: [],


### PR DESCRIPTION
## Summary
- allow Basketball-Reference roster fetches to mark teams as missing instead of throwing when no players are parsed
- make canonical build treat Basketball-Reference enrichment as optional, writing missing-team metadata and validating totals after merging
- disable Basketball-Reference enrichment in CI by default via USE_BREF

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d9da1aefe48327904594daf7ad6736