### PR TITLE
Handle cached mode in verify_bdl script

### DIFF
--- a/scripts/dev/verify_bdl.ts
+++ b/scripts/dev/verify_bdl.ts
@@ -13,8 +13,26 @@ async function verify(): Promise<void> {
   console.log(`BDL OK — ${count} player(s) returned`);
 }
 
+function useCache(): boolean {
+  const value = process.env.USE_BDL_CACHE;
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 async function run(): Promise<void> {
-  await verify();
+  try {
+    await verify();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("Missing BDL_API_KEY") && useCache()) {
+      console.log("BDL check skipped — using cached data (USE_BDL_CACHE)");
+      return;
+    }
+    throw error;
+  }
 }
 
 const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;


### PR DESCRIPTION
## Summary
- skip the Ball Don't Lie verification request when USE_BDL_CACHE is enabled
- add helper to detect cache flag so CI can run without an API key

## Testing
- USE_BDL_CACHE=1 pnpm verify:bdl

------
https://chatgpt.com/codex/tasks/task_e_68d9e4ca15a8832798a35d654eaa0fb5