### PR TITLE
Skip BDL verification in CI when the API key is unavailable

### DIFF
--- a/scripts/dev/verify_bdl.ts
+++ b/scripts/dev/verify_bdl.ts
@@ -22,6 +22,15 @@ function useCache(): boolean {
   return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
+function inCi(): boolean {
+  const value = process.env.CI;
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 async function run(): Promise<void> {
   try {
     await verify();
@@ -29,6 +38,10 @@ async function run(): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("Missing BDL_API_KEY") && useCache()) {
       console.log("BDL check skipped — using cached data (USE_BDL_CACHE)");
+      return;
+    }
+    if (message.includes("Missing BDL_API_KEY") && inCi()) {
+      console.log("BDL check skipped — missing BDL_API_KEY in CI environment");
       return;
     }
     throw error;


### PR DESCRIPTION
## Summary
- add a CI environment guard so verify:bdl skips when no Ball Don't Lie API key is present
- keep the existing USE_BDL_CACHE override for cached runs

## Testing
- CI=true pnpm verify:bdl

------
https://chatgpt.com/codex/tasks/task_e_68d9e56e72f083279b079830e3acf3fd