### PR TITLE
Fix previews workflow BDL key provisioning

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build-previews:
     runs-on: ubuntu-latest
+    environment: previews
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,20 +51,33 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Provision Ball Don't Lie key
+        shell: bash
+        env:
+          RAW_BDL_API_KEY: ${{ secrets.BDL_API_KEY || vars.BDL_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RAW_BDL_API_KEY:-}" ]; then
+            echo "BDL_API_KEY secret not configured for previews workflow" >&2
+            echo "Provide a repository or environment secret named BDL_API_KEY." >&2
+            exit 1
+          fi
+          mkdir -p secrets
+          printf '%s' "$RAW_BDL_API_KEY" > secrets/bdl_api_key
+          chmod 600 secrets/bdl_api_key
+          echo "BDL_API_KEY=$RAW_BDL_API_KEY" >> "$GITHUB_ENV"
+
       - name: Stamp date
         id: metadata
         run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Verify Ball Don't Lie API access
-        env:
-          BDL_API_KEY: ${{ secrets.BDL_API_KEY }}
         run: pnpm verify:bdl
 
       - name: Build and validate previews
         env:
           USE_NBA_STATS: "0"
           USE_BREF: "0"
-          BDL_API_KEY: ${{ secrets.BDL_API_KEY }}
         run: pnpm previews
 
       - name: Validate previews

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node dependencies
 node_modules/
 
+# Secrets injected during CI or local runs
+secrets/
+
 # Python artifacts
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- request the previews environment for the nightly build so environment secrets are available
- provision the Ball Don't Lie API key into the job environment and secrets file before running data builds
- ignore the generated secrets directory in git to prevent accidental commits

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9e7053c0c8327969d026e4cc46fcb