### PR TITLE
Fix Ball Don't Lie roster fetch URL

### DIFF
--- a/scripts/fetch/bdl_rosters.ts
+++ b/scripts/fetch/bdl_rosters.ts
@@ -10,7 +10,7 @@ export interface BallDontLieRosters extends LeagueDataSource {
 
 export const MAX_TEAM_ACTIVE = 30;
 
-const API = "https://api.balldontlie.io/v1";
+const API = "https://api.balldontlie.io/v1/";
 
 function resolveBdlKey(): string | undefined {
   const candidates = [
@@ -62,7 +62,8 @@ function toSourcePlayer(player: BdlApiPlayer, teamId: string, tricode: string): 
 }
 
 async function http<T>(path: string, qs: Record<string, string | number | undefined>): Promise<T> {
-  const url = new URL(path, API);
+  const normalizedPath = path.replace(/^\/+/, "");
+  const url = new URL(normalizedPath, API);
   Object.entries(qs).forEach(([key, value]) => {
     if (value !== undefined) {
       url.searchParams.append(key, String(value));
@@ -89,7 +90,7 @@ async function fetchTeamPlayers(teamId: number, season: number): Promise<BdlApiP
 
   while (true) {
     const result: { data: BdlApiPlayer[]; meta?: { next_cursor?: number | null } } = await http(
-      "/players",
+      "players",
       {
         "team_ids[]": teamId,
         per_page: PER_PAGE,


### PR DESCRIPTION
## Summary
- ensure Ball Don't Lie roster requests target the v1 API prefix
- normalize request path handling so leading slashes do not strip the versioned base path

## Testing
- pnpm verify:bdl *(fails: Missing BDL_API_KEY — set your Ball Don't Lie All-Star key or enable USE_BDL_CACHE=1)*

------
https://chatgpt.com/codex/tasks/task_e_68d9eb5e637c8327b3eb5e476475dd3b