### PR TITLE
Throttle Ball Don't Lie requests

### DIFF
--- a/scripts/fetch/bdl_rosters.ts
+++ b/scripts/fetch/bdl_rosters.ts
@@ -1,5 +1,6 @@
 import { getTeams } from "./bdl.js";
 import type { BdlTeam } from "./bdl.js";
+import { request } from "./http.js";
 import { SEASON } from "../lib/season.js";
 import { TEAM_METADATA } from "../lib/teams.js";
 import type { LeagueDataSource, SourcePlayerRecord, SourceTeamRecord } from "../lib/types.js";
@@ -70,18 +71,7 @@ async function http<T>(path: string, qs: Record<string, string | number | undefi
     }
   });
 
-  const response = await fetch(url.toString(), {
-    headers: KEY ? { Authorization: KEY } : undefined,
-  });
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    throw new Error(
-      `${response.status} ${response.statusText} for ${url.toString()}${body ? ` — ${body}` : ""}`,
-    );
-  }
-
-  return (await response.json()) as T;
+  return request<T>(url.toString());
 }
 
 async function fetchTeamPlayers(teamId: number, season: number): Promise<BdlApiPlayer[]> {

--- a/scripts/fetch/http.ts
+++ b/scripts/fetch/http.ts
@@ -1,7 +1,9 @@
 import { loadSecret } from "../lib/secrets.js";
 
 const MAX_ATTEMPTS = 5;
-const MIN_DELAY_MS = 120;
+// Ball Don't Lie free tier allows at most 60 requests per minute.
+// Enforce a ~1.1s delay between calls so we stay comfortably under the limit.
+const MIN_DELAY_MS = 1100;
 
 interface QueueTask<T> {
   execute: () => Promise<T>;


### PR DESCRIPTION
## Summary
- route Ball Don't Lie roster fetches through the shared HTTP queue so they respect throttling
- increase the queue delay to stay below the 60-requests-per-minute Ball Don't Lie limit

## Testing
- USE_BDL_CACHE=1 pnpm verify:bdl

------
https://chatgpt.com/codex/tasks/task_e_68d9ec2e736c8327b4233a802e7bc3a4