### PR TITLE
Remove manual roster fallback

### DIFF
--- a/scripts/tests/test_roster_merge.spec.ts
+++ b/scripts/tests/test_roster_merge.spec.ts
@@ -62,7 +62,7 @@ describe("mergeSources", () => {
       nbaStats,
       bbr: emptySource,
       overrides,
-      fallbackPlayers: [],
+      primary: emptySource,
     });
 
     const lakers = canonical.teams.find((team) => team.tricode === "LAL");


### PR DESCRIPTION
## Summary
- remove the manual roster reference fallback so canonical data always requires Ball Don't Lie rosters
- simplify mergeSources to rely exclusively on API-driven inputs and update its unit test accordingly

## Testing
- pnpm test
- pnpm previews # fails: Missing BDL_API_KEY

------
https://chatgpt.com/codex/tasks/task_e_68da75383ca083279a9a1e4dacf9d9db