### PR TITLE
Remove live roster tracker section from players hub

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -33,21 +33,6 @@
       </header>
 
       <main class="players-lab">
-        <section class="players-lab__section players-lab__section--rosters">
-          <header class="players-lab__section-header">
-            <h2>Live roster tracker</h2>
-            <p class="players-lab__lede">
-              Scan every active roster in the league with data piped directly from the BallDontLie API. Filters update instantly
-              so you can zero in on a specific franchise or jersey.
-            </p>
-          </header>
-          <div id="players-app" class="roster-app">
-            <div class="roster-status">
-              <p>Loading active rosters…</p>
-            </div>
-          </div>
-        </section>
-
         <section class="players-lab__section player-atlas" data-player-profiles>
           <header class="players-lab__section-header">
             <h2>Player scouting atlas</h2>
@@ -339,8 +324,5 @@
     </div>
     <script src="vendor/chart.umd.js" defer></script>
     <script type="module" src="scripts/players.js"></script>
-    <!-- BUILD:PLAYERS -->
-    <script id="players-bundle" type="module" src="assets/js/players.2179c0b6b0a5ee1b.js"></script>
-    <!-- /BUILD:PLAYERS -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the live roster tracker section from the players hub page so only the scouting atlas remains
- drop the roster bundle script include that was only used by the removed tracker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da902e40b8832797035931a6fb64ed