### PR TITLE
Automate GOAT recency leaderboard generation

### DIFF
--- a/public/data/goat_recent.json
+++ b/public/data/goat_recent.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-30T00:00:00Z",
+  "generatedAt": "2025-09-29T14:45:30+00:00",
   "window": "2022-23 to 2024-25",
   "metric": "Rolling three-year GOAT index",
   "players": [
@@ -7,101 +7,101 @@
       "rank": 1,
       "personId": "203999",
       "name": "Nikola Jokic",
-      "displayName": "Nikola Joki\u0107",
+      "displayName": "Nikola Jokic",
       "team": "Nuggets",
       "franchise": "DEN",
-      "score": 97.4,
-      "blurb": "Two MVPs and a title run fueled by an all-time efficiency blend of scoring and playmaking."
+      "score": 100.0,
+      "blurb": "275 games · 185-90 record · 2022-23–2024-25"
     },
     {
       "rank": 2,
-      "personId": "203507",
-      "name": "Giannis Antetokounmpo",
-      "displayName": "Giannis Antetokounmpo",
-      "team": "Bucks",
-      "franchise": "MIL",
-      "score": 94.3,
-      "blurb": "Still the league's most relentless downhill force, anchoring elite two-way metrics."
-    },
-    {
-      "rank": 3,
-      "personId": "1629029",
-      "name": "Luka Doncic",
-      "displayName": "Luka Don\u010di\u0107",
-      "team": "Mavericks",
-      "franchise": "DAL",
-      "score": 92.8,
-      "blurb": "Carrying Dallas with historic usage, triple-double pace, and deep playoff shotmaking."
-    },
-    {
-      "rank": 4,
-      "personId": "203954",
-      "name": "Joel Embiid",
-      "displayName": "Joel Embiid",
-      "team": "76ers",
-      "franchise": "PHI",
-      "score": 91.5,
-      "blurb": "The reigning scoring champ whose interior gravity warps defenses every trip."
-    },
-    {
-      "rank": 5,
       "personId": "1628983",
       "name": "Shai Gilgeous-Alexander",
       "displayName": "Shai Gilgeous-Alexander",
       "team": "Thunder",
       "franchise": "OKC",
-      "score": 90.2,
-      "blurb": "Efficiency monster with elite drives, rim pressure, and clutch steal rates."
+      "score": 91.6,
+      "blurb": "260 games · 177-83 record · 2022-23–2024-25"
     },
     {
-      "rank": 6,
+      "rank": 3,
+      "personId": "203507",
+      "name": "Giannis Antetokounmpo",
+      "displayName": "Giannis Antetokounmpo",
+      "team": "Bucks",
+      "franchise": "MIL",
+      "score": 88.9,
+      "blurb": "219 games · 137-82 record · 2022-23–2024-25"
+    },
+    {
+      "rank": 4,
       "personId": "1628369",
       "name": "Jayson Tatum",
       "displayName": "Jayson Tatum",
       "team": "Celtics",
       "franchise": "BOS",
-      "score": 88.9,
-      "blurb": "Versatile wing engine spearheading Boston's top-tier net ratings on both ends."
+      "score": 83.9,
+      "blurb": "277 games · 200-77 record · 2022-23–2024-25"
+    },
+    {
+      "rank": 5,
+      "personId": "1629029",
+      "name": "Luka Doncic",
+      "displayName": "Luka Doncic",
+      "team": "Lakers",
+      "franchise": "LAL",
+      "score": 81.4,
+      "blurb": "215 games · 124-91 record · 2022-23–2024-25"
+    },
+    {
+      "rank": 6,
+      "personId": "203076",
+      "name": "Anthony Davis",
+      "displayName": "Anthony Davis",
+      "team": "Mavericks",
+      "franchise": "DAL",
+      "score": 78.1,
+      "blurb": "220 games · 123-97 record · 2022-23–2024-25"
     },
     {
       "rank": 7,
+      "personId": "1627734",
+      "name": "Domantas Sabonis",
+      "displayName": "Domantas Sabonis",
+      "team": "Kings",
+      "franchise": "SAC",
+      "score": 78.0,
+      "blurb": "254 games · 137-117 record · 2022-23–2024-25"
+    },
+    {
+      "rank": 8,
       "personId": "2544",
       "name": "LeBron James",
       "displayName": "LeBron James",
       "team": "Lakers",
       "franchise": "LAL",
-      "score": 88.7,
-      "blurb": "Year 21 and still posting All-NBA numbers: 27-8-8 pace with elite true shooting and matchup versatility."
-    },
-    {
-      "rank": 8,
-      "personId": "201939",
-      "name": "Stephen Curry",
-      "displayName": "Stephen Curry",
-      "team": "Warriors",
-      "franchise": "GSW",
-      "score": 87.4,
-      "blurb": "The original gravity well, still bending defenses with pull-up threes and movement."
+      "score": 77.8,
+      "blurb": "234 games · 130-104 record · 2022-23–2024-25"
     },
     {
       "rank": 9,
-      "personId": "203076",
-      "name": "Anthony Davis",
-      "displayName": "Anthony Davis",
-      "team": "Lakers",
-      "franchise": "LAL",
-      "score": 86.5,
-      "blurb": "Premier rim protector posting 25/12 lines while switching across schemes."
+      "personId": "1630169",
+      "name": "Tyrese Haliburton",
+      "displayName": "Tyrese Haliburton",
+      "team": "Pacers",
+      "franchise": "IND",
+      "score": 77.4,
+      "blurb": "244 games · 142-102 record · 2022-23–2024-25"
     },
     {
       "rank": 10,
-      "personId": "201142",
-      "name": "Kevin Durant",
-      "displayName": "Kevin Durant",
-      "team": "Suns",
-      "franchise": "PHX",
-      "score": 85.9,
-      "blurb": "Still an elite shotmaker with 50/40/90 efficiency powering Phoenix's half-court sets."
+      "personId": "201935",
+      "name": "James Harden",
+      "displayName": "James Harden",
+      "team": "Clippers",
+      "franchise": "LAC",
+      "score": 74.9,
+      "blurb": "239 games · 152-87 record · 2022-23–2024-25"
     }
   ]
 }

--- a/public/data/player_profiles.json
+++ b/public/data/player_profiles.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-28T21:37:59+00:00",
+  "generatedAt": "2025-09-29T14:45:30+00:00",
   "metrics": [
     {
       "id": "offensive-creation",
@@ -66,6 +66,7 @@
     {
       "id": "aaron-gordon-203932",
       "name": "Aaron Gordon",
+      "personId": "203932",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -98,7 +99,8 @@
     {
       "id": "aaron-holiday-1628988",
       "name": "Aaron Holiday",
-      "team": "Indiana Pacers",
+      "personId": "1628988",
+      "team": "Houston Rockets",
       "position": "G",
       "height": null,
       "weight": null,
@@ -111,7 +113,7 @@
       "goatRank": 1583,
       "goatTier": "Rotation",
       "goatResume": "3,178 pts · 978 ast · 787 reb in 611 games",
-      "bio": "Aaron Holiday is a guard for the Indiana Pacers. They hail from Ruston, Louisiana. Draft details for Aaron are currently unavailable.",
+      "bio": "Aaron Holiday is a guard for the Houston Rockets. They hail from Ruston, Louisiana. Draft details for Aaron are currently unavailable.",
       "keywords": [
         "1628988",
         "aaron",
@@ -119,9 +121,9 @@
         "goat",
         "guard",
         "holiday",
-        "indiana",
+        "houston",
         "louisiana",
-        "pacers",
+        "rockets",
         "rotation",
         "ruston"
       ],
@@ -132,6 +134,7 @@
     {
       "id": "aaron-nesmith-1630174",
       "name": "Aaron Nesmith",
+      "personId": "1630174",
       "team": "Boston Celtics",
       "position": "F",
       "height": null,
@@ -164,6 +167,7 @@
     {
       "id": "abdel-nader-1627846",
       "name": "Abdel Nader",
+      "personId": "1627846",
       "team": "Phoenix Suns",
       "position": "F",
       "height": "6'5\"",
@@ -193,11 +197,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 458
+      "goatRecentRank": 476
     },
     {
       "id": "adam-mokoka-1629690",
       "name": "Adam Mokoka",
+      "personId": "1629690",
       "team": "Chicago Bulls",
       "position": "G",
       "height": "6'4\"",
@@ -226,12 +231,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 492
+      "goatRecentRank": 496
     },
     {
       "id": "al-horford-201143",
       "name": "Al Horford",
-      "team": "Oklahoma City Thunder",
+      "personId": "201143",
+      "team": "Boston Celtics",
       "position": "F",
       "height": null,
       "weight": null,
@@ -244,11 +250,12 @@
       "goatRank": 44,
       "goatTier": "Hall of Fame",
       "goatResume": "17,860 pts · 4,420 ast · 11,009 reb in 1,481 games",
-      "bio": "Al Horford is a forward for the Oklahoma City Thunder. They hail from Puerto Plata, Dominican Republic. Draft details for Al are currently unavailable.",
+      "bio": "Al Horford is a forward for the Boston Celtics. They hail from Puerto Plata, Dominican Republic. Draft details for Al are currently unavailable.",
       "keywords": [
         "201143",
         "al",
-        "city",
+        "boston",
+        "celtics",
         "dominican republic",
         "f",
         "fame",
@@ -257,9 +264,7 @@
         "hall",
         "horford",
         "of",
-        "oklahoma",
-        "puerto plata",
-        "thunder"
+        "puerto plata"
       ],
       "metrics": {},
       "goatRecentScore": 58.9,
@@ -268,7 +273,8 @@
     {
       "id": "al-farouq-aminu-202329",
       "name": "Al-Farouq Aminu",
-      "team": "Chicago Bulls",
+      "personId": "202329",
+      "team": "Portland Trail Blazers",
       "position": "F",
       "height": "6'8\"",
       "weight": "202329 lbs",
@@ -281,28 +287,30 @@
       "goatRank": 628,
       "goatTier": "Starter",
       "goatResume": "6,246 pts · 998 ast · 4,857 reb in 872 games",
-      "bio": "Al-Farouq Aminu is a forward for the Chicago Bulls. They hail from Atlanta, Georgia. Al-Farouq entered the league in the 2010 NBA Draft.",
+      "bio": "Al-Farouq Aminu is a forward for the Portland Trail Blazers. They hail from Atlanta, Georgia. Al-Farouq entered the league in the 2010 NBA Draft.",
       "keywords": [
         "202329",
         "al-farouq",
         "aminu",
         "atlanta",
-        "bulls",
-        "chicago",
+        "blazers",
         "f",
         "forward",
         "georgia",
         "goat",
-        "starter"
+        "portland",
+        "starter",
+        "trail"
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 526
+      "goatRecentRank": 462
     },
     {
       "id": "alec-burks-202692",
       "name": "Alec Burks",
-      "team": "New York Knicks",
+      "personId": "202692",
+      "team": "Miami Heat",
       "position": "G",
       "height": null,
       "weight": null,
@@ -315,7 +323,7 @@
       "goatRank": 831,
       "goatTier": "Starter",
       "goatResume": "9,184 pts · 1,676 ast · 2,901 reb in 1,012 games",
-      "bio": "Alec Burks is a guard for the New York Knicks. They hail from Grandview, Missouri. Draft details for Alec are currently unavailable.",
+      "bio": "Alec Burks is a guard for the Miami Heat. They hail from Grandview, Missouri. Draft details for Alec are currently unavailable.",
       "keywords": [
         "202692",
         "alec",
@@ -324,19 +332,19 @@
         "goat",
         "grandview",
         "guard",
-        "knicks",
+        "heat",
+        "miami",
         "missouri",
-        "new",
-        "starter",
-        "york"
+        "starter"
       ],
       "metrics": {},
       "goatRecentScore": 39.6,
-      "goatRecentRank": 198
+      "goatRecentRank": 197
     },
     {
       "id": "aleksej-pokusevski-1630197",
       "name": "Aleksej Pokusevski",
+      "personId": "1630197",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": "7'0\"",
@@ -366,11 +374,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 24.2,
-      "goatRecentRank": 286
+      "goatRecentRank": 284
     },
     {
       "id": "alen-smailagic-1629346",
       "name": "Alen Smailagic",
+      "personId": "1629346",
       "team": "Golden State Warriors",
       "position": "F",
       "height": "6'10\"",
@@ -401,11 +410,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 478
+      "goatRecentRank": 413
     },
     {
       "id": "alex-caruso-1627936",
       "name": "Alex Caruso",
+      "personId": "1627936",
       "team": "Los Angeles Lakers",
       "position": "F",
       "height": null,
@@ -441,7 +451,8 @@
     {
       "id": "alex-len-203458",
       "name": "Alex Len",
-      "team": "Washington Wizards",
+      "personId": "203458",
+      "team": "New York Knicks",
       "position": "C",
       "height": null,
       "weight": null,
@@ -454,7 +465,7 @@
       "goatRank": 1364,
       "goatTier": "Rotation",
       "goatResume": "4,956 pts · 646 ast · 3,909 reb in 977 games",
-      "bio": "Alex Len is a center for the Washington Wizards. They hail from Antratsyt, Ukraine. Draft details for Alex are currently unavailable.",
+      "bio": "Alex Len is a center for the New York Knicks. They hail from Antratsyt, Ukraine. Draft details for Alex are currently unavailable.",
       "keywords": [
         "203458",
         "alex",
@@ -462,20 +473,22 @@
         "c",
         "center",
         "goat",
+        "knicks",
         "len",
+        "new",
         "rotation",
         "ukraine",
-        "washington",
-        "wizards"
+        "york"
       ],
       "metrics": {},
       "goatRecentScore": 38.7,
-      "goatRecentRank": 203
+      "goatRecentRank": 202
     },
     {
       "id": "alfonzo-mckinnie-1628035",
       "name": "Alfonzo McKinnie",
-      "team": "Los Angeles Lakers",
+      "personId": "1628035",
+      "team": "Chicago Bulls",
       "position": "F",
       "height": "6'7\"",
       "weight": "215 lbs",
@@ -488,29 +501,28 @@
       "goatRank": 2023,
       "goatTier": "Rotation",
       "goatResume": "860 pts · 66 ast · 560 reb in 315 games",
-      "bio": "Alfonzo McKinnie is a forward for the Los Angeles Lakers. They hail from Chicago, Illinois. Alfonzo entered the league in the -1 NBA Draft.",
+      "bio": "Alfonzo McKinnie is a forward for the Chicago Bulls. They hail from Chicago, Illinois. Alfonzo entered the league in the -1 NBA Draft.",
       "keywords": [
         "1628035",
         "alfonzo",
-        "angeles",
+        "bulls",
         "chicago",
         "f",
         "forward",
         "goat",
         "illinois",
-        "lakers",
-        "los",
         "mckinnie",
         "rotation"
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 483
+      "goatRecentRank": 481
     },
     {
       "id": "alize-johnson-1628993",
       "name": "Alize Johnson",
-      "team": "Brooklyn Nets",
+      "personId": "1628993",
+      "team": "Minnesota Timberwolves",
       "position": null,
       "height": "6'8\"",
       "weight": "1628993 lbs",
@@ -523,25 +535,26 @@
       "goatRank": 2648,
       "goatTier": "Rotation",
       "goatResume": "270 pts · 52 ast · 326 reb in 181 games",
-      "bio": "Alize Johnson is a multi-skilled player for the Brooklyn Nets. They hail from Williamsport, Pennsylvania. Alize entered the league in the 2018 NBA Draft.",
+      "bio": "Alize Johnson is a multi-skilled player for the Minnesota Timberwolves. They hail from Williamsport, Pennsylvania. Alize entered the league in the 2018 NBA Draft.",
       "keywords": [
         "1628993",
         "alize",
-        "brooklyn",
         "goat",
         "johnson",
-        "nets",
+        "minnesota",
         "pennsylvania",
         "rotation",
+        "timberwolves",
         "williamsport"
       ],
       "metrics": {},
       "goatRecentScore": 7.2,
-      "goatRecentRank": 402
+      "goatRecentRank": 391
     },
     {
       "id": "amida-brimah-1628578",
       "name": "Amida Brimah",
+      "personId": "1628578",
       "team": "Indiana Pacers",
       "position": "C",
       "height": "6'10\"",
@@ -570,11 +583,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 13.6,
-      "goatRecentRank": 374
+      "goatRecentRank": 365
     },
     {
       "id": "amir-coffey-1629599",
       "name": "Amir Coffey",
+      "personId": "1629599",
       "team": "Los Angeles Clippers",
       "position": "F",
       "height": null,
@@ -605,11 +619,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.2,
-      "goatRecentRank": 214
+      "goatRecentRank": 213
     },
     {
       "id": "anderson-varejao-2760",
       "name": "Anderson Varejao",
+      "personId": "2760",
       "team": "Cleveland Cavaliers",
       "position": "F",
       "height": "6'11\"",
@@ -639,12 +654,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 521
+      "goatRecentRank": 416
     },
     {
       "id": "andre-drummond-203083",
       "name": "Andre Drummond",
-      "team": "Los Angeles Lakers",
+      "personId": "203083",
+      "team": "Philadelphia 76ers",
       "position": "C",
       "height": null,
       "weight": null,
@@ -657,19 +673,18 @@
       "goatRank": 351,
       "goatTier": "Starter",
       "goatResume": "12,324 pts · 1,207 ast · 11,877 reb in 1,047 games",
-      "bio": "Andre Drummond is a center for the Los Angeles Lakers. They hail from Mount Vernon, New York. Draft details for Andre are currently unavailable.",
+      "bio": "Andre Drummond is a center for the Philadelphia 76ers. They hail from Mount Vernon, New York. Draft details for Andre are currently unavailable.",
       "keywords": [
         "203083",
+        "76ers",
         "andre",
-        "angeles",
         "c",
         "center",
         "drummond",
         "goat",
-        "lakers",
-        "los",
         "mount vernon",
         "new york",
+        "philadelphia",
         "starter"
       ],
       "metrics": {},
@@ -679,7 +694,8 @@
     {
       "id": "andre-iguodala-2738",
       "name": "Andre Iguodala",
-      "team": "Miami Heat",
+      "personId": "2738",
+      "team": "Golden State Warriors",
       "position": "G / F",
       "height": "6'6\"",
       "weight": "2738 lbs",
@@ -692,7 +708,7 @@
       "goatRank": 42,
       "goatTier": "Hall of Fame",
       "goatResume": "16,427 pts · 6,057 ast · 7,187 reb in 1,569 games",
-      "bio": "Andre Iguodala is a guard-forward for the Miami Heat. They hail from Springfield, Illinois. Andre entered the league in the 2004 NBA Draft.",
+      "bio": "Andre Iguodala is a guard-forward for the Golden State Warriors. They hail from Springfield, Illinois. Andre entered the league in the 2004 NBA Draft.",
       "keywords": [
         "2738",
         "andre",
@@ -701,59 +717,24 @@
         "forward",
         "g",
         "goat",
+        "golden",
         "guard",
         "hall",
-        "heat",
         "iguodala",
         "illinois",
-        "miami",
         "of",
-        "springfield"
+        "springfield",
+        "state",
+        "warriors"
       ],
       "metrics": {},
       "goatRecentScore": 12.0,
-      "goatRecentRank": 380
-    },
-    {
-      "id": "andre-roberson-203460",
-      "name": "Andre Roberson",
-      "team": "Free Agent",
-      "position": "G / F",
-      "height": "6'7\"",
-      "weight": "210 lbs",
-      "born": "December 4, 1991 · Las Cruces, New Mexico",
-      "origin": "Las Cruces, New Mexico",
-      "draft": "2013 · Pick 26 (1st round)",
-      "era": "2010s",
-      "archetype": "Hybrid guard-forward",
-      "goatScore": 14.6,
-      "goatRank": 1362,
-      "goatTier": "Rotation",
-      "goatResume": "1,624 pts · 322 ast · 1,479 reb in 419 games",
-      "bio": "Andre Roberson is a guard-forward currently available in free agency. They hail from Las Cruces, New Mexico. Andre entered the league in the 2013 NBA Draft.",
-      "keywords": [
-        "203460",
-        "agent",
-        "andre",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "las cruces",
-        "new mexico",
-        "roberson",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 509
+      "goatRecentRank": 371
     },
     {
       "id": "andrew-wiggins-203952",
       "name": "Andrew Wiggins",
+      "personId": "203952",
       "team": "Golden State Warriors",
       "position": "F",
       "height": null,
@@ -789,7 +770,8 @@
     {
       "id": "anfernee-simons-1629014",
       "name": "Anfernee Simons",
-      "team": "Portland Trail Blazers",
+      "personId": "1629014",
+      "team": "Boston Celtics",
       "position": null,
       "height": null,
       "weight": null,
@@ -802,18 +784,17 @@
       "goatRank": 1348,
       "goatTier": "Rotation",
       "goatResume": "6,137 pts · 1,320 ast · 1,038 reb in 492 games",
-      "bio": "Anfernee Simons is a multi-skilled player for the Portland Trail Blazers. They hail from Altamonte Springs, Florida. Draft details for Anfernee are currently unavailable.",
+      "bio": "Anfernee Simons is a multi-skilled player for the Boston Celtics. They hail from Altamonte Springs, Florida. Draft details for Anfernee are currently unavailable.",
       "keywords": [
         "1629014",
         "altamonte springs",
         "anfernee",
-        "blazers",
+        "boston",
+        "celtics",
         "florida",
         "goat",
-        "portland",
         "rotation",
-        "simons",
-        "trail"
+        "simons"
       ],
       "metrics": {},
       "goatRecentScore": 43.1,
@@ -822,7 +803,8 @@
     {
       "id": "anthony-davis-203076",
       "name": "Anthony Davis",
-      "team": "Los Angeles Lakers",
+      "personId": "203076",
+      "team": "Dallas Mavericks",
       "position": "C",
       "height": null,
       "weight": null,
@@ -835,20 +817,19 @@
       "goatRank": 103,
       "goatTier": "All-Star",
       "goatResume": "21,838 pts · 2,301 ast · 9,665 reb in 1,029 games",
-      "bio": "Anthony Davis is a center for the Los Angeles Lakers. They hail from Chicago, Illinois. Draft details for Anthony are currently unavailable.",
+      "bio": "Anthony Davis is a center for the Dallas Mavericks. They hail from Chicago, Illinois. Draft details for Anthony are currently unavailable.",
       "keywords": [
         "203076",
         "all-star",
-        "angeles",
         "anthony",
         "c",
         "center",
         "chicago",
+        "dallas",
         "davis",
         "goat",
         "illinois",
-        "lakers",
-        "los"
+        "mavericks"
       ],
       "metrics": {},
       "goatRecentScore": 78.1,
@@ -857,6 +838,7 @@
     {
       "id": "anthony-edwards-1630162",
       "name": "Anthony Edwards",
+      "personId": "1630162",
       "team": "Minnesota Timberwolves",
       "position": "G",
       "height": null,
@@ -889,6 +871,7 @@
     {
       "id": "anthony-gill-1630264",
       "name": "Anthony Gill",
+      "personId": "1630264",
       "team": "Washington Wizards",
       "position": null,
       "height": null,
@@ -914,11 +897,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.7,
-      "goatRecentRank": 260
+      "goatRecentRank": 259
     },
     {
       "id": "anthony-lamb-1630237",
       "name": "Anthony Lamb",
+      "personId": "1630237",
       "team": "Houston Rockets",
       "position": "F",
       "height": "6'6\"",
@@ -947,12 +931,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.8,
-      "goatRecentRank": 289
+      "goatRecentRank": 287
     },
     {
       "id": "anthony-tolliver-201229",
       "name": "Anthony Tolliver",
-      "team": "Philadelphia 76ers",
+      "personId": "201229",
+      "team": "Detroit Pistons",
       "position": "F",
       "height": "6'8\"",
       "weight": "240 lbs",
@@ -965,63 +950,27 @@
       "goatRank": 952,
       "goatTier": "Starter",
       "goatResume": "4,896 pts · 713 ast · 2,666 reb in 968 games",
-      "bio": "Anthony Tolliver is a forward for the Philadelphia 76ers. They hail from USA. Anthony entered the league in the -1 NBA Draft.",
+      "bio": "Anthony Tolliver is a forward for the Detroit Pistons. They hail from USA. Anthony entered the league in the -1 NBA Draft.",
       "keywords": [
         "201229",
-        "76ers",
         "anthony",
+        "detroit",
         "f",
         "forward",
         "goat",
-        "philadelphia",
+        "pistons",
         "starter",
         "tolliver",
         "usa"
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 518
-    },
-    {
-      "id": "anzejs-pasecniks-1628394",
-      "name": "Anzejs Pasecniks",
-      "team": "Free Agent",
-      "position": "F / C",
-      "height": "7'1\"",
-      "weight": "229 lbs",
-      "born": "December 20, 1995 · Riga, Latvia",
-      "origin": "Riga, Latvia",
-      "draft": "2017 · Pick 25 (1st round)",
-      "era": "2010s",
-      "archetype": "Hybrid forward-center",
-      "goatScore": 6.4,
-      "goatRank": 2620,
-      "goatTier": "Rotation",
-      "goatResume": "192 pts · 27 ast · 135 reb in 62 games",
-      "bio": "Anzejs Pasecniks is a forward-center currently available in free agency. They hail from Riga, Latvia. Anzejs entered the league in the 2017 NBA Draft.",
-      "keywords": [
-        "1628394",
-        "agent",
-        "anzejs",
-        "c",
-        "center",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "latvia",
-        "pasecniks",
-        "riga",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 6.6,
-      "goatRecentRank": 406
+      "goatRecentRank": 433
     },
     {
       "id": "armoni-brooks-1629717",
       "name": "Armoni Brooks",
+      "personId": "1629717",
       "team": "Houston Rockets",
       "position": "G",
       "height": "6'3\"",
@@ -1050,12 +999,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 10.6,
-      "goatRecentRank": 389
+      "goatRecentRank": 379
     },
     {
       "id": "aron-baynes-203382",
       "name": "Aron Baynes",
-      "team": "Toronto Raptors",
+      "personId": "203382",
+      "team": "Detroit Pistons",
       "position": "F / C",
       "height": "6'10\"",
       "weight": "260 lbs",
@@ -1068,66 +1018,31 @@
       "goatRank": 976,
       "goatTier": "Starter",
       "goatResume": "3,501 pts · 465 ast · 2,718 reb in 719 games",
-      "bio": "Aron Baynes is a forward-center for the Toronto Raptors. They hail from Gisborne, New Zealand. Aron entered the league in the -1 NBA Draft.",
+      "bio": "Aron Baynes is a forward-center for the Detroit Pistons. They hail from Gisborne, New Zealand. Aron entered the league in the -1 NBA Draft.",
       "keywords": [
         "203382",
         "aron",
         "baynes",
         "c",
         "center",
+        "detroit",
         "f",
         "forward",
         "gisborne",
         "goat",
         "new zealand",
-        "raptors",
-        "starter",
-        "toronto"
+        "pistons",
+        "starter"
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 544
-    },
-    {
-      "id": "ashton-hagans-1630204",
-      "name": "Ashton Hagans",
-      "team": "Free Agent",
-      "position": "G / F",
-      "height": "6'3\"",
-      "weight": "190 lbs",
-      "born": "July 8, 1999 · USA",
-      "origin": "USA",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Hybrid guard-forward",
-      "goatScore": 7.5,
-      "goatRank": 2356,
-      "goatTier": "Rotation",
-      "goatResume": "80 pts · 55 ast · 46 reb in 27 games",
-      "bio": "Ashton Hagans is a guard-forward currently available in free agency. They hail from USA. Ashton entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1630204",
-        "agent",
-        "ashton",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "hagans",
-        "rotation",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 6.8,
-      "goatRecentRank": 405
+      "goatRecentRank": 418
     },
     {
       "id": "austin-rivers-203085",
       "name": "Austin Rivers",
-      "team": "Denver Nuggets",
+      "personId": "203085",
+      "team": "Minnesota Timberwolves",
       "position": "G",
       "height": "6'4\"",
       "weight": "200 lbs",
@@ -1140,28 +1055,29 @@
       "goatRank": 750,
       "goatTier": "Starter",
       "goatResume": "6,807 pts · 1,711 ast · 1,674 reb in 903 games",
-      "bio": "Austin Rivers is a guard for the Denver Nuggets. They hail from Santa Monica, California. Austin entered the league in the 2012 NBA Draft.",
+      "bio": "Austin Rivers is a guard for the Minnesota Timberwolves. They hail from Santa Monica, California. Austin entered the league in the 2012 NBA Draft.",
       "keywords": [
         "203085",
         "austin",
         "california",
-        "denver",
         "g",
         "goat",
         "guard",
-        "nuggets",
+        "minnesota",
         "rivers",
         "santa monica",
-        "starter"
+        "starter",
+        "timberwolves"
       ],
       "metrics": {},
       "goatRecentScore": 17.1,
-      "goatRecentRank": 346
+      "goatRecentRank": 340
     },
     {
       "id": "avery-bradley-202340",
       "name": "Avery Bradley",
-      "team": "Houston Rockets",
+      "personId": "202340",
+      "team": "Los Angeles Lakers",
       "position": "G",
       "height": "6'3\"",
       "weight": "180 lbs",
@@ -1174,27 +1090,29 @@
       "goatRank": 746,
       "goatTier": "Starter",
       "goatResume": "8,160 pts · 1,224 ast · 2,073 reb in 861 games",
-      "bio": "Avery Bradley is a guard for the Houston Rockets. They hail from Tacoma, Washington. Avery entered the league in the 2010 NBA Draft.",
+      "bio": "Avery Bradley is a guard for the Los Angeles Lakers. They hail from Tacoma, Washington. Avery entered the league in the 2010 NBA Draft.",
       "keywords": [
         "202340",
+        "angeles",
         "avery",
         "bradley",
         "g",
         "goat",
         "guard",
-        "houston",
-        "rockets",
+        "lakers",
+        "los",
         "starter",
         "tacoma",
         "washington"
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 466
+      "goatRecentRank": 403
     },
     {
       "id": "axel-toupane-1626253",
       "name": "Axel Toupane",
+      "personId": "1626253",
       "team": "Milwaukee Bucks",
       "position": "G / F",
       "height": "6'7\"",
@@ -1225,11 +1143,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 508
+      "goatRecentRank": 422
     },
     {
       "id": "bam-adebayo-1628389",
       "name": "Bam Adebayo",
+      "personId": "1628389",
       "team": "Miami Heat",
       "position": null,
       "height": null,
@@ -1262,6 +1181,7 @@
     {
       "id": "ben-mclemore-203463",
       "name": "Ben McLemore",
+      "personId": "203463",
       "team": "Los Angeles Lakers",
       "position": "G",
       "height": "6'3\"",
@@ -1292,12 +1212,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 539
+      "goatRecentRank": 419
     },
     {
       "id": "ben-simmons-1627732",
       "name": "Ben Simmons",
-      "team": "Philadelphia 76ers",
+      "personId": "1627732",
+      "team": "Los Angeles Clippers",
       "position": null,
       "height": null,
       "weight": null,
@@ -1310,25 +1231,27 @@
       "goatRank": 366,
       "goatTier": "Starter",
       "goatResume": "5,685 pts · 3,140 ast · 3,260 reb in 464 games",
-      "bio": "Ben Simmons is a multi-skilled player for the Philadelphia 76ers. They hail from Melbourne, Australia. Draft details for Ben are currently unavailable.",
+      "bio": "Ben Simmons is a multi-skilled player for the Los Angeles Clippers. They hail from Melbourne, Australia. Draft details for Ben are currently unavailable.",
       "keywords": [
         "1627732",
-        "76ers",
+        "angeles",
         "australia",
         "ben",
+        "clippers",
         "goat",
+        "los",
         "melbourne",
-        "philadelphia",
         "simmons",
         "starter"
       ],
       "metrics": {},
       "goatRecentScore": 36.7,
-      "goatRecentRank": 215
+      "goatRecentRank": 214
     },
     {
       "id": "bismack-biyombo-202687",
       "name": "Bismack Biyombo",
+      "personId": "202687",
       "team": "Charlotte Hornets",
       "position": "C",
       "height": "6'8\"",
@@ -1358,11 +1281,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 35.9,
-      "goatRecentRank": 218
+      "goatRecentRank": 217
     },
     {
       "id": "blake-griffin-201933",
       "name": "Blake Griffin",
+      "personId": "201933",
       "team": "Brooklyn Nets",
       "position": "F",
       "height": "6'9\"",
@@ -1392,11 +1316,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.4,
-      "goatRecentRank": 301
+      "goatRecentRank": 298
     },
     {
       "id": "boban-marjanovic-1626246",
       "name": "Boban Marjanovic",
+      "personId": "1626246",
       "team": "Dallas Mavericks",
       "position": "C",
       "height": "7'4\"",
@@ -1426,11 +1351,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 22.7,
-      "goatRecentRank": 309
+      "goatRecentRank": 305
     },
     {
       "id": "bobby-portis-1626171",
       "name": "Bobby Portis",
+      "personId": "1626171",
       "team": "Milwaukee Bucks",
       "position": "F",
       "height": null,
@@ -1465,6 +1391,7 @@
     {
       "id": "bogdan-bogdanovic-203992",
       "name": "Bogdan Bogdanovic",
+      "personId": "203992",
       "team": "Atlanta Hawks",
       "position": "F",
       "height": null,
@@ -1500,6 +1427,7 @@
     {
       "id": "bojan-bogdanovic-202711",
       "name": "Bojan Bogdanovic",
+      "personId": "202711",
       "team": "Utah Jazz",
       "position": "F",
       "height": "6'7\"",
@@ -1529,11 +1457,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 28.8,
-      "goatRecentRank": 255
+      "goatRecentRank": 254
     },
     {
       "id": "bol-bol-1629626",
       "name": "Bol Bol",
+      "personId": "1629626",
       "team": "Denver Nuggets",
       "position": "F",
       "height": null,
@@ -1567,6 +1496,7 @@
     {
       "id": "brad-wanamaker-202954",
       "name": "Brad Wanamaker",
+      "personId": "202954",
       "team": "Charlotte Hornets",
       "position": "G",
       "height": "6'3\"",
@@ -1596,11 +1526,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 528
+      "goatRecentRank": 441
     },
     {
       "id": "bradley-beal-203078",
       "name": "Bradley Beal",
+      "personId": "203078",
       "team": "Washington Wizards",
       "position": "G",
       "height": null,
@@ -1635,6 +1566,7 @@
     {
       "id": "brandon-clarke-1629634",
       "name": "Brandon Clarke",
+      "personId": "1629634",
       "team": "Memphis Grizzlies",
       "position": "C",
       "height": null,
@@ -1664,11 +1596,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.6,
-      "goatRecentRank": 184
+      "goatRecentRank": 183
     },
     {
       "id": "brandon-goodwin-1629164",
       "name": "Brandon Goodwin",
+      "personId": "1629164",
       "team": "Atlanta Hawks",
       "position": "G",
       "height": "6'0\"",
@@ -1698,11 +1631,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 470
+      "goatRecentRank": 478
     },
     {
       "id": "brandon-ingram-1627742",
       "name": "Brandon Ingram",
+      "personId": "1627742",
       "team": "New Orleans Pelicans",
       "position": "F",
       "height": "6'8\"",
@@ -1736,45 +1670,9 @@
       "goatRecentRank": 167
     },
     {
-      "id": "brian-bowen-ii-1628968",
-      "name": "Brian Bowen II",
-      "team": "Free Agent",
-      "position": "G / F",
-      "height": "6'6\"",
-      "weight": "190 lbs",
-      "born": "October 2, 1998 · USA",
-      "origin": "USA",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Hybrid guard-forward",
-      "goatScore": 4.2,
-      "goatRank": 3547,
-      "goatTier": "Reserve",
-      "goatResume": "16 pts · 1 ast · 14 reb in 53 games",
-      "bio": "Brian Bowen II is a guard-forward currently available in free agency. They hail from USA. Brian entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1628968",
-        "agent",
-        "bowen",
-        "brian",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "ii",
-        "reserve",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 516
-    },
-    {
       "id": "brodric-thomas-1630271",
       "name": "Brodric Thomas",
+      "personId": "1630271",
       "team": "Cleveland Cavaliers",
       "position": "G",
       "height": "6'5\"",
@@ -1803,11 +1701,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 9.0,
-      "goatRecentRank": 394
+      "goatRecentRank": 383
     },
     {
       "id": "brook-lopez-201572",
       "name": "Brook Lopez",
+      "personId": "201572",
       "team": "Milwaukee Bucks",
       "position": null,
       "height": null,
@@ -1840,7 +1739,8 @@
     {
       "id": "bruce-brown-1628971",
       "name": "Bruce Brown",
-      "team": "Brooklyn Nets",
+      "personId": "1628971",
+      "team": "Denver Nuggets",
       "position": "G",
       "height": null,
       "weight": null,
@@ -1853,18 +1753,18 @@
       "goatRank": 823,
       "goatTier": "Starter",
       "goatResume": "4,584 pts · 1,228 ast · 2,167 reb in 556 games",
-      "bio": "Bruce Brown is a guard for the Brooklyn Nets. They hail from Boston, Massachusetts. Draft details for Bruce are currently unavailable.",
+      "bio": "Bruce Brown is a guard for the Denver Nuggets. They hail from Boston, Massachusetts. Draft details for Bruce are currently unavailable.",
       "keywords": [
         "1628971",
         "boston",
-        "brooklyn",
         "brown",
         "bruce",
+        "denver",
         "g",
         "goat",
         "guard",
         "massachusetts",
-        "nets",
+        "nuggets",
         "starter"
       ],
       "metrics": {},
@@ -1872,43 +1772,9 @@
       "goatRecentRank": 134
     },
     {
-      "id": "bruno-caboclo-203998",
-      "name": "Bruno Caboclo",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'9\"",
-      "weight": "218 lbs",
-      "born": "September 21, 1995 · Osasco, Brazil",
-      "origin": "Osasco, Brazil",
-      "draft": "2014 · Pick 20 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 6.5,
-      "goatRank": 2602,
-      "goatTier": "Rotation",
-      "goatResume": "558 pts · 84 ast · 341 reb in 275 games",
-      "bio": "Bruno Caboclo is a forward currently available in free agency. They hail from Osasco, Brazil. Bruno entered the league in the 2014 NBA Draft.",
-      "keywords": [
-        "203998",
-        "agent",
-        "brazil",
-        "bruno",
-        "caboclo",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "osasco",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 432
-    },
-    {
       "id": "bruno-fernando-1628981",
       "name": "Bruno Fernando",
+      "personId": "1628981",
       "team": "Atlanta Hawks",
       "position": "F / C",
       "height": "6'10\"",
@@ -1940,11 +1806,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 33.1,
-      "goatRecentRank": 228
+      "goatRecentRank": 227
     },
     {
       "id": "bryn-forbes-1627854",
       "name": "Bryn Forbes",
+      "personId": "1627854",
       "team": "Milwaukee Bucks",
       "position": "G",
       "height": "6'2\"",
@@ -1974,11 +1841,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 13.7,
-      "goatRecentRank": 372
+      "goatRecentRank": 363
     },
     {
       "id": "buddy-hield-1627741",
       "name": "Buddy Hield",
+      "personId": "1627741",
       "team": "Sacramento Kings",
       "position": "G",
       "height": null,
@@ -2013,6 +1881,7 @@
     {
       "id": "caleb-martin-1628997",
       "name": "Caleb Martin",
+      "personId": "1628997",
       "team": "Charlotte Hornets",
       "position": "F",
       "height": "6'5\"",
@@ -2047,6 +1916,7 @@
     {
       "id": "cam-reddish-1629629",
       "name": "Cam Reddish",
+      "personId": "1629629",
       "team": "Atlanta Hawks",
       "position": null,
       "height": null,
@@ -2074,11 +1944,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.4,
-      "goatRecentRank": 262
+      "goatRecentRank": 261
     },
     {
       "id": "cam-reynolds-1629244",
       "name": "Cam Reynolds",
+      "personId": "1629244",
       "team": "Houston Rockets",
       "position": "F",
       "height": "6'7\"",
@@ -2107,11 +1978,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 512
+      "goatRecentRank": 502
     },
     {
       "id": "cameron-johnson-1629661",
       "name": "Cameron Johnson",
+      "personId": "1629661",
       "team": "Phoenix Suns",
       "position": "F",
       "height": null,
@@ -2141,11 +2013,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.1,
-      "goatRecentRank": 195
+      "goatRecentRank": 194
     },
     {
       "id": "cameron-oliver-1628419",
       "name": "Cameron Oliver",
+      "personId": "1628419",
       "team": "Houston Rockets",
       "position": "F",
       "height": "6'8\"",
@@ -2174,11 +2047,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 461
+      "goatRecentRank": 414
     },
     {
       "id": "cameron-payne-1626166",
       "name": "Cameron Payne",
+      "personId": "1626166",
       "team": "Phoenix Suns",
       "position": "G",
       "height": null,
@@ -2213,7 +2087,8 @@
     {
       "id": "caris-levert-1627747",
       "name": "Caris LeVert",
-      "team": "Indiana Pacers",
+      "personId": "1627747",
+      "team": "Detroit Pistons",
       "position": "G",
       "height": "6'6\"",
       "weight": "205 lbs",
@@ -2226,18 +2101,18 @@
       "goatRank": 711,
       "goatTier": "Starter",
       "goatResume": "7,958 pts · 2,285 ast · 2,176 reb in 608 games",
-      "bio": "Caris LeVert is a guard for the Indiana Pacers. They hail from Columbus, Ohio. Caris entered the league in the 2016 NBA Draft.",
+      "bio": "Caris LeVert is a guard for the Detroit Pistons. They hail from Columbus, Ohio. Caris entered the league in the 2016 NBA Draft.",
       "keywords": [
         "1627747",
         "caris",
         "columbus",
+        "detroit",
         "g",
         "goat",
         "guard",
-        "indiana",
         "levert",
         "ohio",
-        "pacers",
+        "pistons",
         "starter"
       ],
       "metrics": {},
@@ -2247,6 +2122,7 @@
     {
       "id": "carmelo-anthony-2546",
       "name": "Carmelo Anthony",
+      "personId": "2546",
       "team": "Portland Trail Blazers",
       "position": "F",
       "height": "6'7\"",
@@ -2277,11 +2153,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 496
+      "goatRecentRank": 459
     },
     {
       "id": "carsen-edwards-1629035",
       "name": "Carsen Edwards",
+      "personId": "1629035",
       "team": "Boston Celtics",
       "position": "G",
       "height": "5'11\"",
@@ -2311,11 +2188,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 445
+      "goatRecentRank": 409
     },
     {
       "id": "cassius-stanley-1630199",
       "name": "Cassius Stanley",
+      "personId": "1630199",
       "team": "Indiana Pacers",
       "position": "G",
       "height": "6'5\"",
@@ -2344,11 +2222,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 535
+      "goatRecentRank": 426
     },
     {
       "id": "cassius-winston-1630216",
       "name": "Cassius Winston",
+      "personId": "1630216",
       "team": "Washington Wizards",
       "position": "G",
       "height": "6'1\"",
@@ -2377,11 +2256,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 435
+      "goatRecentRank": 491
     },
     {
       "id": "cedi-osman-1626224",
       "name": "Cedi Osman",
+      "personId": "1626224",
       "team": "Cleveland Cavaliers",
       "position": "F",
       "height": "6'7\"",
@@ -2411,11 +2291,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 34.3,
-      "goatRecentRank": 223
+      "goatRecentRank": 222
     },
     {
       "id": "chandler-hutchison-1628990",
       "name": "Chandler Hutchison",
+      "personId": "1628990",
       "team": "Washington Wizards",
       "position": "G / F",
       "height": "6'6\"",
@@ -2446,11 +2327,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 510
+      "goatRecentRank": 484
     },
     {
       "id": "charlie-brown-jr-1629718",
       "name": "Charlie Brown Jr.",
+      "personId": "1629718",
       "team": "Oklahoma City Thunder",
       "position": "G",
       "height": "6'6\"",
@@ -2481,11 +2363,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 13.6,
-      "goatRecentRank": 375
+      "goatRecentRank": 366
     },
     {
       "id": "chasson-randle-1626184",
       "name": "Chasson Randle",
+      "personId": "1626184",
       "team": "Orlando Magic",
       "position": "G",
       "height": "6'2\"",
@@ -2515,11 +2398,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.0,
-      "goatRecentRank": 306
+      "goatRecentRank": 303
     },
     {
       "id": "chimezie-metu-1629002",
       "name": "Chimezie Metu",
+      "personId": "1629002",
       "team": "Sacramento Kings",
       "position": "F / C",
       "height": "6'9\"",
@@ -2551,11 +2435,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.3,
-      "goatRecentRank": 213
+      "goatRecentRank": 212
     },
     {
       "id": "chris-boucher-1628449",
       "name": "Chris Boucher",
+      "personId": "1628449",
       "team": "Toronto Raptors",
       "position": null,
       "height": null,
@@ -2588,6 +2473,7 @@
     {
       "id": "chris-chiozza-1629185",
       "name": "Chris Chiozza",
+      "personId": "1629185",
       "team": "Brooklyn Nets",
       "position": "G",
       "height": "5'11\"",
@@ -2617,11 +2503,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.3,
-      "goatRecentRank": 414
+      "goatRecentRank": 400
     },
     {
       "id": "chris-paul-101108",
       "name": "Chris Paul",
+      "personId": "101108",
       "team": "Phoenix Suns",
       "position": null,
       "height": null,
@@ -2654,41 +2541,9 @@
       "goatRecentRank": 80
     },
     {
-      "id": "chris-silva-1629735",
-      "name": "Chris Silva",
-      "team": "Free Agent",
-      "position": null,
-      "height": "6'8\"",
-      "weight": "1629735 lbs",
-      "born": "September 19, 1996 · Libreville, Gabon",
-      "origin": "Libreville, Gabon",
-      "draft": "-22 · Pick -22 (-22th round)",
-      "era": "-30s",
-      "archetype": "Versatile playmaker",
-      "goatScore": 4.8,
-      "goatRank": 3233,
-      "goatTier": "Reserve",
-      "goatResume": "236 pts · 42 ast · 221 reb in 157 games",
-      "bio": "Chris Silva is a multi-skilled player currently available in free agency. They hail from Libreville, Gabon. Chris entered the league in the -22 NBA Draft.",
-      "keywords": [
-        "1629735",
-        "agent",
-        "chris",
-        "free",
-        "free agent",
-        "gabon",
-        "goat",
-        "libreville",
-        "reserve",
-        "silva"
-      ],
-      "metrics": {},
-      "goatRecentScore": 23.4,
-      "goatRecentRank": 300
-    },
-    {
       "id": "christian-wood-1626174",
       "name": "Christian Wood",
+      "personId": "1626174",
       "team": "Houston Rockets",
       "position": null,
       "height": null,
@@ -2716,11 +2571,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 39.2,
-      "goatRecentRank": 202
+      "goatRecentRank": 201
     },
     {
       "id": "chuma-okeke-1629643",
       "name": "Chuma Okeke",
+      "personId": "1629643",
       "team": "Orlando Magic",
       "position": "F",
       "height": "6'7\"",
@@ -2749,11 +2605,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.9,
-      "goatRecentRank": 288
+      "goatRecentRank": 286
     },
     {
       "id": "cj-elleby-1629604",
       "name": "CJ Elleby",
+      "personId": "1629604",
       "team": "Portland Trail Blazers",
       "position": "G / F",
       "height": "6'6\"",
@@ -2785,11 +2642,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.1,
-      "goatRecentRank": 303
+      "goatRecentRank": 300
     },
     {
       "id": "cj-mccollum-203468",
       "name": "CJ McCollum",
+      "personId": "203468",
       "team": "Portland Trail Blazers",
       "position": null,
       "height": null,
@@ -2823,6 +2681,7 @@
     {
       "id": "clint-capela-203991",
       "name": "Clint Capela",
+      "personId": "203991",
       "team": "Atlanta Hawks",
       "position": "C",
       "height": null,
@@ -2857,6 +2716,7 @@
     {
       "id": "coby-white-1629632",
       "name": "Coby White",
+      "personId": "1629632",
       "team": "Chicago Bulls",
       "position": "G",
       "height": "6'5\"",
@@ -2891,6 +2751,7 @@
     {
       "id": "cody-martin-1628998",
       "name": "Cody Martin",
+      "personId": "1628998",
       "team": "Charlotte Hornets",
       "position": "F",
       "height": null,
@@ -2920,11 +2781,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.7,
-      "goatRecentRank": 321
+      "goatRecentRank": 317
     },
     {
       "id": "cody-zeller-203469",
       "name": "Cody Zeller",
+      "personId": "203469",
       "team": "Charlotte Hornets",
       "position": "F / C",
       "height": "6'11\"",
@@ -2956,11 +2818,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.0,
-      "goatRecentRank": 268
+      "goatRecentRank": 267
     },
     {
       "id": "cole-anthony-1630175",
       "name": "Cole Anthony",
+      "personId": "1630175",
       "team": "Orlando Magic",
       "position": "G",
       "height": null,
@@ -2993,7 +2856,8 @@
     {
       "id": "collin-sexton-1629012",
       "name": "Collin Sexton",
-      "team": "Cleveland Cavaliers",
+      "personId": "1629012",
+      "team": "Charlotte Hornets",
       "position": null,
       "height": null,
       "weight": null,
@@ -3006,14 +2870,14 @@
       "goatRank": 1013,
       "goatTier": "Starter",
       "goatResume": "7,911 pts · 1,572 ast · 1,198 reb in 453 games",
-      "bio": "Collin Sexton is a multi-skilled player for the Cleveland Cavaliers. They hail from Marietta, Georgia. Draft details for Collin are currently unavailable.",
+      "bio": "Collin Sexton is a multi-skilled player for the Charlotte Hornets. They hail from Marietta, Georgia. Draft details for Collin are currently unavailable.",
       "keywords": [
         "1629012",
-        "cavaliers",
-        "cleveland",
+        "charlotte",
         "collin",
         "georgia",
         "goat",
+        "hornets",
         "marietta",
         "sexton",
         "starter"
@@ -3025,7 +2889,8 @@
     {
       "id": "cory-joseph-202709",
       "name": "Cory Joseph",
-      "team": "Detroit Pistons",
+      "personId": "202709",
+      "team": "Orlando Magic",
       "position": "G",
       "height": null,
       "weight": null,
@@ -3038,27 +2903,28 @@
       "goatRank": 553,
       "goatTier": "Starter",
       "goatResume": "6,651 pts · 2,809 ast · 2,321 reb in 1,154 games",
-      "bio": "Cory Joseph is a guard for the Detroit Pistons. They hail from Pickering, Canada. Draft details for Cory are currently unavailable.",
+      "bio": "Cory Joseph is a guard for the Orlando Magic. They hail from Pickering, Canada. Draft details for Cory are currently unavailable.",
       "keywords": [
         "202709",
         "canada",
         "cory",
-        "detroit",
         "g",
         "goat",
         "guard",
         "joseph",
+        "magic",
+        "orlando",
         "pickering",
-        "pistons",
         "starter"
       ],
       "metrics": {},
       "goatRecentScore": 30.2,
-      "goatRecentRank": 241
+      "goatRecentRank": 240
     },
     {
       "id": "cristiano-felicio-1626245",
       "name": "Cristiano Felicio",
+      "personId": "1626245",
       "team": "Chicago Bulls",
       "position": "F / C",
       "height": "6'11\"",
@@ -3090,11 +2956,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 457
+      "goatRecentRank": 463
     },
     {
       "id": "d-angelo-russell-1626156",
       "name": "D'Angelo Russell",
+      "personId": "1626156",
       "team": "Minnesota Timberwolves",
       "position": null,
       "height": null,
@@ -3127,6 +2994,7 @@
     {
       "id": "d-j-augustin-201571",
       "name": "D.J. Augustin",
+      "personId": "201571",
       "team": "Houston Rockets",
       "position": "G",
       "height": "5'11\"",
@@ -3156,11 +3024,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 418
+      "goatRecentRank": 501
     },
     {
       "id": "d-j-wilson-1628391",
       "name": "D.J. Wilson",
+      "personId": "1628391",
       "team": "Houston Rockets",
       "position": "F",
       "height": "6'10\"",
@@ -3190,45 +3059,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.6,
-      "goatRecentRank": 353
-    },
-    {
-      "id": "dakota-mathias-1629751",
-      "name": "Dakota Mathias",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'4\"",
-      "weight": "200 lbs",
-      "born": "July 11, 1995 · USA",
-      "origin": "USA",
-      "draft": "2018 NBA Draft",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 4.1,
-      "goatRank": 3608,
-      "goatTier": "Reserve",
-      "goatResume": "63 pts · 16 ast · 13 reb in 30 games",
-      "bio": "Dakota Mathias is a guard currently available in free agency. They hail from USA. Dakota entered the league in the 2018 NBA Draft NBA Draft.",
-      "keywords": [
-        "1629751",
-        "agent",
-        "dakota",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "mathias",
-        "reserve",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 497
+      "goatRecentRank": 347
     },
     {
       "id": "damian-jones-1627745",
       "name": "Damian Jones",
+      "personId": "1627745",
       "team": "Sacramento Kings",
       "position": "C",
       "height": "6'11\"",
@@ -3258,11 +3094,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.4,
-      "goatRecentRank": 297
+      "goatRecentRank": 295
     },
     {
       "id": "damian-lillard-203081",
       "name": "Damian Lillard",
+      "personId": "203081",
       "team": "Portland Trail Blazers",
       "position": null,
       "height": null,
@@ -3296,7 +3133,8 @@
     {
       "id": "damion-lee-1627814",
       "name": "Damion Lee",
-      "team": "Golden State Warriors",
+      "personId": "1627814",
+      "team": "Phoenix Suns",
       "position": null,
       "height": null,
       "weight": null,
@@ -3309,26 +3147,26 @@
       "goatRank": 1662,
       "goatTier": "Rotation",
       "goatResume": "2,672 pts · 451 ast · 1,101 reb in 471 games",
-      "bio": "Damion Lee is a multi-skilled player for the Golden State Warriors. They hail from Baltimore, Maryland. Draft details for Damion are currently unavailable.",
+      "bio": "Damion Lee is a multi-skilled player for the Phoenix Suns. They hail from Baltimore, Maryland. Draft details for Damion are currently unavailable.",
       "keywords": [
         "1627814",
         "baltimore",
         "damion",
         "goat",
-        "golden",
         "lee",
         "maryland",
+        "phoenix",
         "rotation",
-        "state",
-        "warriors"
+        "suns"
       ],
       "metrics": {},
       "goatRecentScore": 27.5,
-      "goatRecentRank": 261
+      "goatRecentRank": 260
     },
     {
       "id": "damyean-dotson-1628422",
       "name": "Damyean Dotson",
+      "personId": "1628422",
       "team": "Cleveland Cavaliers",
       "position": "G",
       "height": "6'5\"",
@@ -3358,11 +3196,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 481
+      "goatRecentRank": 497
     },
     {
       "id": "daniel-gafford-1629655",
       "name": "Daniel Gafford",
+      "personId": "1629655",
       "team": "Washington Wizards",
       "position": null,
       "height": null,
@@ -3395,6 +3234,7 @@
     {
       "id": "daniel-oturu-1630187",
       "name": "Daniel Oturu",
+      "personId": "1630187",
       "team": "Los Angeles Clippers",
       "position": "C",
       "height": "6'8\"",
@@ -3424,11 +3264,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 542
+      "goatRecentRank": 500
     },
     {
       "id": "daniel-theis-1628464",
       "name": "Daniel Theis",
+      "personId": "1628464",
       "team": "Chicago Bulls",
       "position": null,
       "height": null,
@@ -3456,11 +3297,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.7,
-      "goatRecentRank": 247
+      "goatRecentRank": 246
     },
     {
       "id": "danilo-gallinari-201568",
       "name": "Danilo Gallinari",
+      "personId": "201568",
       "team": "Atlanta Hawks",
       "position": "F",
       "height": "6'10\"",
@@ -3490,11 +3332,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.7,
-      "goatRecentRank": 350
+      "goatRecentRank": 344
     },
     {
       "id": "danny-green-201980",
       "name": "Danny Green",
+      "personId": "201980",
       "team": "Philadelphia 76ers",
       "position": "G",
       "height": "6'6\"",
@@ -3524,11 +3367,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 14.0,
-      "goatRecentRank": 370
+      "goatRecentRank": 362
     },
     {
       "id": "dante-exum-203957",
       "name": "Dante Exum",
+      "personId": "203957",
       "team": "Houston Rockets",
       "position": "G",
       "height": "6'5\"",
@@ -3558,11 +3402,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.9,
-      "goatRecentRank": 244
+      "goatRecentRank": 243
     },
     {
       "id": "danuel-house-jr-1627863",
       "name": "Danuel House Jr.",
+      "personId": "1627863",
       "team": "Houston Rockets",
       "position": "G / F",
       "height": "6'6\"",
@@ -3594,46 +3439,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 26.9,
-      "goatRecentRank": 269
-    },
-    {
-      "id": "daquan-jeffries-1629610",
-      "name": "DaQuan Jeffries",
-      "team": "Free Agent",
-      "position": "F",
-      "height": null,
-      "weight": null,
-      "born": null,
-      "origin": "Edmond, Oklahoma",
-      "draft": null,
-      "era": "2020s",
-      "archetype": "Modern forward",
-      "goatScore": 8.9,
-      "goatRank": 2092,
-      "goatTier": "Rotation",
-      "goatResume": "552 pts · 98 ast · 250 reb in 238 games",
-      "bio": "DaQuan Jeffries is a forward currently available in free agency. They hail from Edmond, Oklahoma. Draft details for DaQuan are currently unavailable.",
-      "keywords": [
-        "1629610",
-        "agent",
-        "daquan",
-        "edmond",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "jeffries",
-        "oklahoma",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 15.7,
-      "goatRecentRank": 361
+      "goatRecentRank": 268
     },
     {
       "id": "dario-saric-203967",
       "name": "Dario Saric",
+      "personId": "203967",
       "team": "Phoenix Suns",
       "position": null,
       "height": null,
@@ -3661,11 +3472,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.3,
-      "goatRecentRank": 191
+      "goatRecentRank": 190
     },
     {
       "id": "darius-bazley-1629647",
       "name": "Darius Bazley",
+      "personId": "1629647",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": "6'9\"",
@@ -3696,11 +3508,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.2,
-      "goatRecentRank": 327
+      "goatRecentRank": 322
     },
     {
       "id": "darius-garland-1629636",
       "name": "Darius Garland",
+      "personId": "1629636",
       "team": "Cleveland Cavaliers",
       "position": null,
       "height": null,
@@ -3731,43 +3544,9 @@
       "goatRecentRank": 34
     },
     {
-      "id": "darius-miller-203121",
-      "name": "Darius Miller",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'6\"",
-      "weight": "225 lbs",
-      "born": "March 21, 1990 · Maysville, Kentucky",
-      "origin": "Maysville, Kentucky",
-      "draft": "2012 · Pick 46 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 9.0,
-      "goatRank": 2080,
-      "goatTier": "Rotation",
-      "goatResume": "1,764 pts · 394 ast · 491 reb in 394 games",
-      "bio": "Darius Miller is a forward currently available in free agency. They hail from Maysville, Kentucky. Darius entered the league in the 2012 NBA Draft.",
-      "keywords": [
-        "203121",
-        "agent",
-        "darius",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "kentucky",
-        "maysville",
-        "miller",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 529
-    },
-    {
       "id": "david-nwaba-1628021",
       "name": "David Nwaba",
+      "personId": "1628021",
       "team": "Houston Rockets",
       "position": "G / F",
       "height": "6'5\"",
@@ -3798,11 +3577,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 15.9,
-      "goatRecentRank": 360
+      "goatRecentRank": 353
     },
     {
       "id": "davis-bertans-202722",
       "name": "Davis Bertans",
+      "personId": "202722",
       "team": "Washington Wizards",
       "position": "F",
       "height": "6'10\"",
@@ -3832,12 +3612,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.6,
-      "goatRecentRank": 293
+      "goatRecentRank": 291
     },
     {
       "id": "de-aaron-fox-1628368",
       "name": "De'Aaron Fox",
-      "team": "Sacramento Kings",
+      "personId": "1628368",
+      "team": "San Antonio Spurs",
       "position": null,
       "height": null,
       "weight": null,
@@ -3850,16 +3631,17 @@
       "goatRank": 414,
       "goatTier": "Starter",
       "goatResume": "12,072 pts · 3,464 ast · 2,226 reb in 587 games",
-      "bio": "De'Aaron Fox is a multi-skilled player for the Sacramento Kings. They hail from New Orleans, Louisiana. Draft details for De'Aaron are currently unavailable.",
+      "bio": "De'Aaron Fox is a multi-skilled player for the San Antonio Spurs. They hail from New Orleans, Louisiana. Draft details for De'Aaron are currently unavailable.",
       "keywords": [
         "1628368",
+        "antonio",
         "de'aaron",
         "fox",
         "goat",
-        "kings",
         "louisiana",
         "new orleans",
-        "sacramento",
+        "san",
+        "spurs",
         "starter"
       ],
       "metrics": {},
@@ -3869,6 +3651,7 @@
     {
       "id": "de-andre-hunter-1629631",
       "name": "De'Andre Hunter",
+      "personId": "1629631",
       "team": "Atlanta Hawks",
       "position": "F",
       "height": null,
@@ -3903,7 +3686,8 @@
     {
       "id": "de-anthony-melton-1629001",
       "name": "De'Anthony Melton",
-      "team": "Memphis Grizzlies",
+      "personId": "1629001",
+      "team": "Brooklyn Nets",
       "position": null,
       "height": null,
       "weight": null,
@@ -3916,25 +3700,26 @@
       "goatRank": 1238,
       "goatTier": "Starter",
       "goatResume": "3,674 pts · 1,098 ast · 1,500 reb in 456 games",
-      "bio": "De'Anthony Melton is a multi-skilled player for the Memphis Grizzlies. They hail from North Hollywood, California. Draft details for De'Anthony are currently unavailable.",
+      "bio": "De'Anthony Melton is a multi-skilled player for the Brooklyn Nets. They hail from North Hollywood, California. Draft details for De'Anthony are currently unavailable.",
       "keywords": [
         "1629001",
+        "brooklyn",
         "california",
         "de'anthony",
         "goat",
-        "grizzlies",
         "melton",
-        "memphis",
+        "nets",
         "north hollywood",
         "starter"
       ],
       "metrics": {},
       "goatRecentScore": 42.4,
-      "goatRecentRank": 177
+      "goatRecentRank": 176
     },
     {
       "id": "dean-wade-1629731",
       "name": "Dean Wade",
+      "personId": "1629731",
       "team": "Cleveland Cavaliers",
       "position": null,
       "height": null,
@@ -3962,11 +3747,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.3,
-      "goatRecentRank": 189
+      "goatRecentRank": 188
     },
     {
       "id": "deandre-ayton-1629028",
       "name": "Deandre Ayton",
+      "personId": "1629028",
       "team": "Phoenix Suns",
       "position": "C",
       "height": "7'0\"",
@@ -4001,6 +3787,7 @@
     {
       "id": "deandre-jordan-201599",
       "name": "DeAndre Jordan",
+      "personId": "201599",
       "team": "Brooklyn Nets",
       "position": "C",
       "height": null,
@@ -4035,6 +3822,7 @@
     {
       "id": "deandre-bembry-1627761",
       "name": "DeAndre' Bembry",
+      "personId": "1627761",
       "team": "Toronto Raptors",
       "position": "G / F",
       "height": "6'5\"",
@@ -4066,11 +3854,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 527
+      "goatRecentRank": 450
     },
     {
       "id": "deividas-sirvydis-1629686",
       "name": "Deividas Sirvydis",
+      "personId": "1629686",
       "team": "Detroit Pistons",
       "position": "G / F",
       "height": "6'8\"",
@@ -4101,12 +3890,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 11.2,
-      "goatRecentRank": 385
+      "goatRecentRank": 375
     },
     {
       "id": "dejounte-murray-1627749",
       "name": "Dejounte Murray",
-      "team": "San Antonio Spurs",
+      "personId": "1627749",
+      "team": "New Orleans Pelicans",
       "position": null,
       "height": null,
       "weight": null,
@@ -4119,16 +3909,16 @@
       "goatRank": 594,
       "goatTier": "Starter",
       "goatResume": "8,460 pts · 2,946 ast · 3,192 reb in 599 games",
-      "bio": "Dejounte Murray is a multi-skilled player for the San Antonio Spurs. They hail from Seattle, Washington. Draft details for Dejounte are currently unavailable.",
+      "bio": "Dejounte Murray is a multi-skilled player for the New Orleans Pelicans. They hail from Seattle, Washington. Draft details for Dejounte are currently unavailable.",
       "keywords": [
         "1627749",
-        "antonio",
         "dejounte",
         "goat",
         "murray",
-        "san",
+        "new",
+        "orleans",
+        "pelicans",
         "seattle",
-        "spurs",
         "starter",
         "washington"
       ],
@@ -4139,7 +3929,8 @@
     {
       "id": "delon-wright-1626153",
       "name": "Delon Wright",
-      "team": "Sacramento Kings",
+      "personId": "1626153",
+      "team": "Indiana Pacers",
       "position": "G",
       "height": null,
       "weight": null,
@@ -4152,7 +3943,7 @@
       "goatRank": 783,
       "goatTier": "Starter",
       "goatResume": "4,106 pts · 1,807 ast · 1,842 reb in 789 games",
-      "bio": "Delon Wright is a guard for the Sacramento Kings. They hail from Los Angeles, California. Draft details for Delon are currently unavailable.",
+      "bio": "Delon Wright is a guard for the Indiana Pacers. They hail from Los Angeles, California. Draft details for Delon are currently unavailable.",
       "keywords": [
         "1626153",
         "california",
@@ -4160,20 +3951,21 @@
         "g",
         "goat",
         "guard",
-        "kings",
+        "indiana",
         "los angeles",
-        "sacramento",
+        "pacers",
         "starter",
         "wright"
       ],
       "metrics": {},
       "goatRecentScore": 37.7,
-      "goatRecentRank": 208
+      "goatRecentRank": 207
     },
     {
       "id": "demar-derozan-201942",
       "name": "DeMar DeRozan",
-      "team": "San Antonio Spurs",
+      "personId": "201942",
+      "team": "Sacramento Kings",
       "position": null,
       "height": null,
       "weight": null,
@@ -4186,18 +3978,17 @@
       "goatRank": 122,
       "goatTier": "All-Star",
       "goatResume": "27,912 pts · 5,309 ast · 5,763 reb in 1,367 games",
-      "bio": "DeMar DeRozan is a multi-skilled player for the San Antonio Spurs. They hail from Compton, California. Draft details for DeMar are currently unavailable.",
+      "bio": "DeMar DeRozan is a multi-skilled player for the Sacramento Kings. They hail from Compton, California. Draft details for DeMar are currently unavailable.",
       "keywords": [
         "201942",
         "all-star",
-        "antonio",
         "california",
         "compton",
         "demar",
         "derozan",
         "goat",
-        "san",
-        "spurs"
+        "kings",
+        "sacramento"
       ],
       "metrics": {},
       "goatRecentScore": 62.4,
@@ -4206,6 +3997,7 @@
     {
       "id": "demarcus-cousins-202326",
       "name": "DeMarcus Cousins",
+      "personId": "202326",
       "team": "Los Angeles Clippers",
       "position": "C",
       "height": "6'10\"",
@@ -4236,11 +4028,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 462
+      "goatRecentRank": 412
     },
     {
       "id": "deni-avdija-1630166",
       "name": "Deni Avdija",
+      "personId": "1630166",
       "team": "Washington Wizards",
       "position": null,
       "height": null,
@@ -4271,6 +4064,7 @@
     {
       "id": "dennis-schroder-203471",
       "name": "Dennis Schroder",
+      "personId": "203471",
       "team": "Los Angeles Lakers",
       "position": "G",
       "height": null,
@@ -4306,6 +4100,7 @@
     {
       "id": "dennis-smith-jr-1628372",
       "name": "Dennis Smith Jr.",
+      "personId": "1628372",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'2\"",
@@ -4336,12 +4131,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.7,
-      "goatRecentRank": 246
+      "goatRecentRank": 245
     },
     {
       "id": "denzel-valentine-1627756",
       "name": "Denzel Valentine",
-      "team": "Chicago Bulls",
+      "personId": "1627756",
+      "team": "Utah Jazz",
       "position": "G",
       "height": "6'4\"",
       "weight": "220 lbs",
@@ -4354,27 +4150,28 @@
       "goatRank": 1985,
       "goatTier": "Rotation",
       "goatResume": "1,902 pts · 493 ast · 913 reb in 357 games",
-      "bio": "Denzel Valentine is a guard for the Chicago Bulls. They hail from Lansing, Michigan. Denzel entered the league in the 2016 NBA Draft.",
+      "bio": "Denzel Valentine is a guard for the Utah Jazz. They hail from Lansing, Michigan. Denzel entered the league in the 2016 NBA Draft.",
       "keywords": [
         "1627756",
-        "bulls",
-        "chicago",
         "denzel",
         "g",
         "goat",
         "guard",
+        "jazz",
         "lansing",
         "michigan",
         "rotation",
+        "utah",
         "valentine"
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 475
+      "goatRecentRank": 494
     },
     {
       "id": "derrick-favors-202324",
       "name": "Derrick Favors",
+      "personId": "202324",
       "team": "Utah Jazz",
       "position": "F",
       "height": "6'9\"",
@@ -4404,11 +4201,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.5,
-      "goatRecentRank": 294
+      "goatRecentRank": 292
     },
     {
       "id": "derrick-jones-jr-1627884",
       "name": "Derrick Jones Jr.",
+      "personId": "1627884",
       "team": "Portland Trail Blazers",
       "position": null,
       "height": null,
@@ -4443,6 +4241,7 @@
     {
       "id": "derrick-rose-201565",
       "name": "Derrick Rose",
+      "personId": "201565",
       "team": "New York Knicks",
       "position": "G",
       "height": "6'3\"",
@@ -4473,11 +4272,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.0,
-      "goatRecentRank": 330
+      "goatRecentRank": 324
     },
     {
       "id": "derrick-white-1628401",
       "name": "Derrick White",
+      "personId": "1628401",
       "team": "San Antonio Spurs",
       "position": null,
       "height": null,
@@ -4511,6 +4311,7 @@
     {
       "id": "desmond-bane-1630217",
       "name": "Desmond Bane",
+      "personId": "1630217",
       "team": "Memphis Grizzlies",
       "position": null,
       "height": null,
@@ -4541,6 +4342,7 @@
     {
       "id": "devin-booker-1626164",
       "name": "Devin Booker",
+      "personId": "1626164",
       "team": "Phoenix Suns",
       "position": null,
       "height": null,
@@ -4571,42 +4373,9 @@
       "goatRecentRank": 32
     },
     {
-      "id": "devin-cannady-1629962",
-      "name": "Devin Cannady",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'2\"",
-      "weight": "183 lbs",
-      "born": "May 21, 1996 · USA",
-      "origin": "USA",
-      "draft": "2019 NBA Draft",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 4.6,
-      "goatRank": 3344,
-      "goatTier": "Reserve",
-      "goatResume": "106 pts · 15 ast · 21 reb in 25 games",
-      "bio": "Devin Cannady is a guard currently available in free agency. They hail from USA. Devin entered the league in the 2019 NBA Draft NBA Draft.",
-      "keywords": [
-        "1629962",
-        "agent",
-        "cannady",
-        "devin",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "reserve",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 20.0,
-      "goatRecentRank": 329
-    },
-    {
       "id": "devin-vassell-1630170",
       "name": "Devin Vassell",
+      "personId": "1630170",
       "team": "San Antonio Spurs",
       "position": null,
       "height": null,
@@ -4633,11 +4402,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.7,
-      "goatRecentRank": 182
+      "goatRecentRank": 181
     },
     {
       "id": "devon-dotson-1629653",
       "name": "Devon Dotson",
+      "personId": "1629653",
       "team": "Chicago Bulls",
       "position": "G",
       "height": "6'1\"",
@@ -4666,11 +4436,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 7.6,
-      "goatRecentRank": 400
+      "goatRecentRank": 389
     },
     {
       "id": "devontae-cacok-1629719",
       "name": "Devontae Cacok",
+      "personId": "1629719",
       "team": "Los Angeles Lakers",
       "position": "F",
       "height": "6'7\"",
@@ -4700,11 +4471,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.1,
-      "goatRecentRank": 416
+      "goatRecentRank": 402
     },
     {
       "id": "devonte-graham-1628984",
       "name": "Devonte' Graham",
+      "personId": "1628984",
       "team": "Charlotte Hornets",
       "position": "G",
       "height": "6'1\"",
@@ -4734,11 +4506,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.3,
-      "goatRecentRank": 264
+      "goatRecentRank": 263
     },
     {
       "id": "dewayne-dedmon-203473",
       "name": "Dewayne Dedmon",
+      "personId": "203473",
       "team": "Miami Heat",
       "position": "C",
       "height": "6'10\"",
@@ -4768,11 +4541,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 22.5,
-      "goatRecentRank": 311
+      "goatRecentRank": 307
     },
     {
       "id": "didi-louzada-1629712",
       "name": "Didi Louzada",
+      "personId": "1629712",
       "team": "New Orleans Pelicans",
       "position": "G",
       "height": "6'5\"",
@@ -4802,11 +4576,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 543
+      "goatRecentRank": 417
     },
     {
       "id": "dillon-brooks-1628415",
       "name": "Dillon Brooks",
+      "personId": "1628415",
       "team": "Memphis Grizzlies",
       "position": null,
       "height": null,
@@ -4839,6 +4614,7 @@
     {
       "id": "domantas-sabonis-1627734",
       "name": "Domantas Sabonis",
+      "personId": "1627734",
       "team": "Indiana Pacers",
       "position": null,
       "height": null,
@@ -4871,6 +4647,7 @@
     {
       "id": "donovan-mitchell-1628378",
       "name": "Donovan Mitchell",
+      "personId": "1628378",
       "team": "Utah Jazz",
       "position": null,
       "height": null,
@@ -4903,6 +4680,7 @@
     {
       "id": "donta-hall-1629743",
       "name": "Donta Hall",
+      "personId": "1629743",
       "team": "Orlando Magic",
       "position": "C",
       "height": "6'10\"",
@@ -4931,11 +4709,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 511
+      "goatRecentRank": 436
     },
     {
       "id": "donte-divincenzo-1628978",
       "name": "Donte DiVincenzo",
+      "personId": "1628978",
       "team": "Milwaukee Bucks",
       "position": null,
       "height": null,
@@ -4968,6 +4747,7 @@
     {
       "id": "dorian-finney-smith-1627827",
       "name": "Dorian Finney-Smith",
+      "personId": "1627827",
       "team": "Dallas Mavericks",
       "position": null,
       "height": null,
@@ -4995,11 +4775,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 38.0,
-      "goatRecentRank": 205
+      "goatRecentRank": 204
     },
     {
       "id": "doug-mcdermott-203926",
       "name": "Doug McDermott",
+      "personId": "203926",
       "team": "Indiana Pacers",
       "position": null,
       "height": null,
@@ -5027,11 +4808,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 33.7,
-      "goatRecentRank": 225
+      "goatRecentRank": 224
     },
     {
       "id": "draymond-green-203110",
       "name": "Draymond Green",
+      "personId": "203110",
       "team": "Golden State Warriors",
       "position": null,
       "height": null,
@@ -5065,6 +4847,7 @@
     {
       "id": "drew-eubanks-1629234",
       "name": "Drew Eubanks",
+      "personId": "1629234",
       "team": "San Antonio Spurs",
       "position": "C",
       "height": null,
@@ -5100,6 +4883,7 @@
     {
       "id": "duncan-robinson-1629130",
       "name": "Duncan Robinson",
+      "personId": "1629130",
       "team": "Miami Heat",
       "position": null,
       "height": null,
@@ -5132,6 +4916,7 @@
     {
       "id": "dwayne-bacon-1628407",
       "name": "Dwayne Bacon",
+      "personId": "1628407",
       "team": "Orlando Magic",
       "position": "G / F",
       "height": "6'6\"",
@@ -5163,11 +4948,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.3,
-      "goatRecentRank": 413
+      "goatRecentRank": 399
     },
     {
       "id": "dwight-howard-2730",
       "name": "Dwight Howard",
+      "personId": "2730",
       "team": "Philadelphia 76ers",
       "position": "F / C",
       "height": "6'10\"",
@@ -5201,11 +4987,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 531
+      "goatRecentRank": 448
     },
     {
       "id": "dwight-powell-203939",
       "name": "Dwight Powell",
+      "personId": "203939",
       "team": "Dallas Mavericks",
       "position": "F / C",
       "height": "6'10\"",
@@ -5242,6 +5029,7 @@
     {
       "id": "dylan-windler-1629685",
       "name": "Dylan Windler",
+      "personId": "1629685",
       "team": "Cleveland Cavaliers",
       "position": "G / F",
       "height": "6'7\"",
@@ -5272,11 +5060,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 15.3,
-      "goatRecentRank": 365
+      "goatRecentRank": 357
     },
     {
       "id": "e-twaun-moore-202734",
       "name": "E'Twaun Moore",
+      "personId": "202734",
       "team": "Phoenix Suns",
       "position": "G",
       "height": "6'3\"",
@@ -5306,11 +5095,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 460
+      "goatRecentRank": 421
     },
     {
       "id": "ed-davis-202334",
       "name": "Ed Davis",
+      "personId": "202334",
       "team": "Minnesota Timberwolves",
       "position": "F / C",
       "height": "6'9\"",
@@ -5342,11 +5132,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 536
+      "goatRecentRank": 434
     },
     {
       "id": "edmond-sumner-1628410",
       "name": "Edmond Sumner",
+      "personId": "1628410",
       "team": "Indiana Pacers",
       "position": "G",
       "height": "6'4\"",
@@ -5376,11 +5167,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.7,
-      "goatRecentRank": 290
+      "goatRecentRank": 288
     },
     {
       "id": "elfrid-payton-203901",
       "name": "Elfrid Payton",
+      "personId": "203901",
       "team": "New York Knicks",
       "position": "G",
       "height": "6'3\"",
@@ -5411,11 +5203,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 7.0,
-      "goatRecentRank": 404
+      "goatRecentRank": 393
     },
     {
       "id": "elijah-bryant-1629091",
       "name": "Elijah Bryant",
+      "personId": "1629091",
       "team": "Milwaukee Bucks",
       "position": "G",
       "height": "6'5\"",
@@ -5444,11 +5237,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 438
+      "goatRecentRank": 475
     },
     {
       "id": "elijah-hughes-1630190",
       "name": "Elijah Hughes",
+      "personId": "1630190",
       "team": "Utah Jazz",
       "position": "G",
       "height": "6'5\"",
@@ -5477,11 +5271,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 473
+      "goatRecentRank": 477
     },
     {
       "id": "enes-freedom-202683",
       "name": "Enes Freedom",
+      "personId": "202683",
       "team": "Portland Trail Blazers",
       "position": "C",
       "height": "6'10\"",
@@ -5512,11 +5307,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 540
+      "goatRecentRank": 454
     },
     {
       "id": "eric-bledsoe-202339",
       "name": "Eric Bledsoe",
+      "personId": "202339",
       "team": "New Orleans Pelicans",
       "position": "G",
       "height": "6'1\"",
@@ -5547,11 +5343,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 517
+      "goatRecentRank": 499
     },
     {
       "id": "eric-gordon-201569",
       "name": "Eric Gordon",
+      "personId": "201569",
       "team": "Houston Rockets",
       "position": null,
       "height": null,
@@ -5579,11 +5376,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.3,
-      "goatRecentRank": 212
+      "goatRecentRank": 211
     },
     {
       "id": "eric-paschall-1629672",
       "name": "Eric Paschall",
+      "personId": "1629672",
       "team": "Golden State Warriors",
       "position": "F",
       "height": "6'6\"",
@@ -5614,11 +5412,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 22.9,
-      "goatRecentRank": 307
+      "goatRecentRank": 304
     },
     {
       "id": "ersan-ilyasova-101141",
       "name": "Ersan Ilyasova",
+      "personId": "101141",
       "team": "Utah Jazz",
       "position": "F",
       "height": "6'9\"",
@@ -5648,11 +5447,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 477
+      "goatRecentRank": 486
     },
     {
       "id": "evan-fournier-203095",
       "name": "Evan Fournier",
+      "personId": "203095",
       "team": "Boston Celtics",
       "position": "G / F",
       "height": "6'6\"",
@@ -5684,11 +5484,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.9,
-      "goatRecentRank": 335
+      "goatRecentRank": 329
     },
     {
       "id": "facundo-campazzo-1630267",
       "name": "Facundo Campazzo",
+      "personId": "1630267",
       "team": "Denver Nuggets",
       "position": "G",
       "height": "5'10\"",
@@ -5717,11 +5518,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 8.5,
-      "goatRecentRank": 395
+      "goatRecentRank": 384
     },
     {
       "id": "frank-jackson-1628402",
       "name": "Frank Jackson",
+      "personId": "1628402",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'3\"",
@@ -5751,11 +5553,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 8.0,
-      "goatRecentRank": 397
+      "goatRecentRank": 386
     },
     {
       "id": "frank-kaminsky-1626163",
       "name": "Frank Kaminsky",
+      "personId": "1626163",
       "team": "Phoenix Suns",
       "position": "F / C",
       "height": "7'0\"",
@@ -5787,46 +5590,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 17.0,
-      "goatRecentRank": 349
-    },
-    {
-      "id": "frank-mason-iii-1628412",
-      "name": "Frank Mason III",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "5'11\"",
-      "weight": "190 lbs",
-      "born": "April 3, 1994 · Petersburg, Virginia",
-      "origin": "Petersburg, Virginia",
-      "draft": "2017 · Pick 34 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 7.1,
-      "goatRank": 2439,
-      "goatTier": "Rotation",
-      "goatResume": "825 pts · 322 ast · 239 reb in 178 games",
-      "bio": "Frank Mason III is a guard currently available in free agency. They hail from Petersburg, Virginia. Frank entered the league in the 2017 NBA Draft.",
-      "keywords": [
-        "1628412",
-        "agent",
-        "frank",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "mason",
-        "petersburg",
-        "rotation",
-        "virginia"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 490
+      "goatRecentRank": 343
     },
     {
       "id": "frank-ntilikina-1628373",
       "name": "Frank Ntilikina",
+      "personId": "1628373",
       "team": "New York Knicks",
       "position": "G",
       "height": "6'4\"",
@@ -5857,11 +5626,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 15.6,
-      "goatRecentRank": 362
+      "goatRecentRank": 354
     },
     {
       "id": "fred-vanvleet-1627832",
       "name": "Fred VanVleet",
+      "personId": "1627832",
       "team": "Toronto Raptors",
       "position": null,
       "height": null,
@@ -5894,6 +5664,7 @@
     {
       "id": "freddie-gillespie-1630273",
       "name": "Freddie Gillespie",
+      "personId": "1630273",
       "team": "Toronto Raptors",
       "position": "C",
       "height": "6'9\"",
@@ -5922,11 +5693,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 441
+      "goatRecentRank": 466
     },
     {
       "id": "furkan-korkmaz-1627788",
       "name": "Furkan Korkmaz",
+      "personId": "1627788",
       "team": "Philadelphia 76ers",
       "position": "G / F",
       "height": "6'7\"",
@@ -5958,11 +5730,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 26.8,
-      "goatRecentRank": 270
+      "goatRecentRank": 269
     },
     {
       "id": "ga-bitadze-1629048",
       "name": "ga Bitadze",
+      "personId": "1629048",
       "team": "Indiana Pacers",
       "position": "F / C",
       "height": "6'11\"",
@@ -5999,6 +5772,7 @@
     {
       "id": "gabe-vincent-1629216",
       "name": "Gabe Vincent",
+      "personId": "1629216",
       "team": "Miami Heat",
       "position": "G",
       "height": null,
@@ -6028,11 +5802,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.5,
-      "goatRecentRank": 209
+      "goatRecentRank": 208
     },
     {
       "id": "gabriel-deck-1630466",
       "name": "Gabriel Deck",
+      "personId": "1630466",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": "6'6\"",
@@ -6062,12 +5837,13 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 498
+      "goatRecentRank": 438
     },
     {
       "id": "garrett-temple-202066",
       "name": "Garrett Temple",
-      "team": "Chicago Bulls",
+      "personId": "202066",
+      "team": "Toronto Raptors",
       "position": null,
       "height": null,
       "weight": null,
@@ -6080,25 +5856,26 @@
       "goatRank": 991,
       "goatTier": "Starter",
       "goatResume": "4,901 pts · 1,361 ast · 1,848 reb in 1,128 games",
-      "bio": "Garrett Temple is a multi-skilled player for the Chicago Bulls. They hail from Baton Rouge, Louisiana. Draft details for Garrett are currently unavailable.",
+      "bio": "Garrett Temple is a multi-skilled player for the Toronto Raptors. They hail from Baton Rouge, Louisiana. Draft details for Garrett are currently unavailable.",
       "keywords": [
         "202066",
         "baton rouge",
-        "bulls",
-        "chicago",
         "garrett",
         "goat",
         "louisiana",
+        "raptors",
         "starter",
-        "temple"
+        "temple",
+        "toronto"
       ],
       "metrics": {},
       "goatRecentScore": 22.4,
-      "goatRecentRank": 312
+      "goatRecentRank": 308
     },
     {
       "id": "garrison-mathews-1629726",
       "name": "Garrison Mathews",
+      "personId": "1629726",
       "team": "Washington Wizards",
       "position": null,
       "height": null,
@@ -6126,11 +5903,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 32.5,
-      "goatRecentRank": 233
+      "goatRecentRank": 232
     },
     {
       "id": "gary-clark-1629109",
       "name": "Gary Clark",
+      "personId": "1629109",
       "team": "Philadelphia 76ers",
       "position": "F",
       "height": "6'6\"",
@@ -6160,11 +5938,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 421
+      "goatRecentRank": 423
     },
     {
       "id": "gary-harris-203914",
       "name": "Gary Harris",
+      "personId": "203914",
       "team": "Orlando Magic",
       "position": "G",
       "height": "6'4\"",
@@ -6194,47 +5973,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 31.5,
-      "goatRecentRank": 239
-    },
-    {
-      "id": "gary-payton-ii-1627780",
-      "name": "Gary Payton II",
-      "team": "Free Agent",
-      "position": "F",
-      "height": null,
-      "weight": null,
-      "born": null,
-      "origin": "Seattle, Washington",
-      "draft": null,
-      "era": "2020s",
-      "archetype": "Modern forward",
-      "goatScore": 13.0,
-      "goatRank": 1503,
-      "goatTier": "Rotation",
-      "goatResume": "1,808 pts · 382 ast · 923 reb in 388 games",
-      "bio": "Gary Payton II is a forward currently available in free agency. They hail from Seattle, Washington. Draft details for Gary are currently unavailable.",
-      "keywords": [
-        "1627780",
-        "agent",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "gary",
-        "goat",
-        "ii",
-        "payton",
-        "rotation",
-        "seattle",
-        "washington"
-      ],
-      "metrics": {},
-      "goatRecentScore": 42.5,
-      "goatRecentRank": 176
+      "goatRecentRank": 238
     },
     {
       "id": "gary-trent-jr-1629018",
       "name": "Gary Trent Jr.",
+      "personId": "1629018",
       "team": "Toronto Raptors",
       "position": "G",
       "height": null,
@@ -6270,6 +6014,7 @@
     {
       "id": "george-hill-201588",
       "name": "George Hill",
+      "personId": "201588",
       "team": "Philadelphia 76ers",
       "position": "G",
       "height": "6'4\"",
@@ -6299,11 +6044,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 19.4,
-      "goatRecentRank": 333
+      "goatRecentRank": 327
     },
     {
       "id": "georges-niang-1627777",
       "name": "Georges Niang",
+      "personId": "1627777",
       "team": "Utah Jazz",
       "position": "F",
       "height": null,
@@ -6338,6 +6084,7 @@
     {
       "id": "giannis-antetokounmpo-203507",
       "name": "Giannis Antetokounmpo",
+      "personId": "203507",
       "team": "Milwaukee Bucks",
       "position": null,
       "height": null,
@@ -6368,44 +6115,9 @@
       "goatRecentRank": 3
     },
     {
-      "id": "glenn-robinson-iii-203922",
-      "name": "Glenn Robinson III",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'6\"",
-      "weight": "222 lbs",
-      "born": "January 8, 1994 · Gary, Indiana",
-      "origin": "Gary, Indiana",
-      "draft": "2014 · Pick 40 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 10.0,
-      "goatRank": 1915,
-      "goatTier": "Rotation",
-      "goatResume": "2,103 pts · 275 ast · 886 reb in 473 games",
-      "bio": "Glenn Robinson III is a forward currently available in free agency. They hail from Gary, Indiana. Glenn entered the league in the 2014 NBA Draft.",
-      "keywords": [
-        "203922",
-        "agent",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "gary",
-        "glenn",
-        "goat",
-        "iii",
-        "indiana",
-        "robinson",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 446
-    },
-    {
       "id": "goran-dragic-201609",
       "name": "Goran Dragic",
+      "personId": "201609",
       "team": "Miami Heat",
       "position": "G",
       "height": "6'4\"",
@@ -6435,11 +6147,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 21.4,
-      "goatRecentRank": 316
+      "goatRecentRank": 312
     },
     {
       "id": "gordon-hayward-202330",
       "name": "Gordon Hayward",
+      "personId": "202330",
       "team": "Charlotte Hornets",
       "position": "F",
       "height": "6'7\"",
@@ -6469,11 +6182,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.6,
-      "goatRecentRank": 249
+      "goatRecentRank": 248
     },
     {
       "id": "gorgui-dieng-203476",
       "name": "Gorgui Dieng",
+      "personId": "203476",
       "team": "San Antonio Spurs",
       "position": "C",
       "height": "6'10\"",
@@ -6504,11 +6218,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 9.9,
-      "goatRecentRank": 392
+      "goatRecentRank": 382
     },
     {
       "id": "grant-riller-1630203",
       "name": "Grant Riller",
+      "personId": "1630203",
       "team": "Charlotte Hornets",
       "position": "G",
       "height": "6'2\"",
@@ -6537,11 +6252,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 444
+      "goatRecentRank": 452
     },
     {
       "id": "grant-williams-1629684",
       "name": "Grant Williams",
+      "personId": "1629684",
       "team": "Boston Celtics",
       "position": null,
       "height": null,
@@ -6569,11 +6285,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.3,
-      "goatRecentRank": 190
+      "goatRecentRank": 189
     },
     {
       "id": "grayson-allen-1628960",
       "name": "Grayson Allen",
+      "personId": "1628960",
       "team": "Memphis Grizzlies",
       "position": "F",
       "height": null,
@@ -6606,42 +6323,9 @@
       "goatRecentRank": 128
     },
     {
-      "id": "greg-whittington-204222",
-      "name": "Greg Whittington",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'8\"",
-      "weight": "210 lbs",
-      "born": "February 7, 1993 · USA",
-      "origin": "USA",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern forward",
-      "goatScore": 3.4,
-      "goatRank": 3981,
-      "goatTier": "Reserve",
-      "goatResume": "11 pts · 2 ast · 19 reb in 22 games",
-      "bio": "Greg Whittington is a forward currently available in free agency. They hail from USA. Greg entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "204222",
-        "agent",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "greg",
-        "reserve",
-        "usa",
-        "whittington"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 472
-    },
-    {
       "id": "hamidou-diallo-1628977",
       "name": "Hamidou Diallo",
+      "personId": "1628977",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'5\"",
@@ -6671,11 +6355,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.6,
-      "goatRecentRank": 351
+      "goatRecentRank": 345
     },
     {
       "id": "harrison-barnes-203084",
       "name": "Harrison Barnes",
+      "personId": "203084",
       "team": "Sacramento Kings",
       "position": null,
       "height": null,
@@ -6708,6 +6393,7 @@
     {
       "id": "harry-giles-iii-1628385",
       "name": "Harry Giles III",
+      "personId": "1628385",
       "team": "Portland Trail Blazers",
       "position": "F / C",
       "height": "6'11\"",
@@ -6740,11 +6426,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.6,
-      "goatRecentRank": 352
+      "goatRecentRank": 346
     },
     {
       "id": "hassan-whiteside-202355",
       "name": "Hassan Whiteside",
+      "personId": "202355",
       "team": "Sacramento Kings",
       "position": "C",
       "height": "7'0\"",
@@ -6774,48 +6461,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 501
-    },
-    {
-      "id": "henry-ellenson-1627740",
-      "name": "Henry Ellenson",
-      "team": "Free Agent",
-      "position": "F / C",
-      "height": "6'10\"",
-      "weight": "240 lbs",
-      "born": "January 13, 1997 · Rice Lake, Wisconsin",
-      "origin": "Rice Lake, Wisconsin",
-      "draft": "2016 · Pick 18 (1st round)",
-      "era": "2010s",
-      "archetype": "Hybrid forward-center",
-      "goatScore": 6.4,
-      "goatRank": 2622,
-      "goatTier": "Rotation",
-      "goatResume": "434 pts · 60 ast · 247 reb in 201 games",
-      "bio": "Henry Ellenson is a forward-center currently available in free agency. They hail from Rice Lake, Wisconsin. Henry entered the league in the 2016 NBA Draft.",
-      "keywords": [
-        "1627740",
-        "agent",
-        "c",
-        "center",
-        "ellenson",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "henry",
-        "rice lake",
-        "rotation",
-        "wisconsin"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 502
+      "goatRecentRank": 449
     },
     {
       "id": "ignas-brazdeikis-1629649",
       "name": "Ignas Brazdeikis",
+      "personId": "1629649",
       "team": "Orlando Magic",
       "position": "F",
       "height": "6'6\"",
@@ -6844,46 +6495,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 469
-    },
-    {
-      "id": "iman-shumpert-202697",
-      "name": "Iman Shumpert",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'5\"",
-      "weight": "212 lbs",
-      "born": "June 26, 1990 · Oak Park, Illinois",
-      "origin": "Oak Park, Illinois",
-      "draft": "2011 · Pick 17 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 23.3,
-      "goatRank": 657,
-      "goatTier": "Starter",
-      "goatResume": "3,954 pts · 964 ast · 1,891 reb in 624 games",
-      "bio": "Iman Shumpert is a guard currently available in free agency. They hail from Oak Park, Illinois. Iman entered the league in the 2011 NBA Draft.",
-      "keywords": [
-        "202697",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "illinois",
-        "iman",
-        "oak park",
-        "shumpert",
-        "starter"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 494
+      "goatRecentRank": 442
     },
     {
       "id": "immanuel-quickley-1630193",
       "name": "Immanuel Quickley",
+      "personId": "1630193",
       "team": "New York Knicks",
       "position": "G",
       "height": "6'2\"",
@@ -6918,6 +6535,7 @@
     {
       "id": "isaac-bonga-1629067",
       "name": "Isaac Bonga",
+      "personId": "1629067",
       "team": "Washington Wizards",
       "position": "G",
       "height": "6'8\"",
@@ -6947,11 +6565,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 455
+      "goatRecentRank": 427
     },
     {
       "id": "isaac-okoro-1630171",
       "name": "Isaac Okoro",
+      "personId": "1630171",
       "team": "Cleveland Cavaliers",
       "position": "G / F",
       "height": "6'5\"",
@@ -6987,6 +6606,7 @@
     {
       "id": "isaiah-hartenstein-1628392",
       "name": "Isaiah Hartenstein",
+      "personId": "1628392",
       "team": "Cleveland Cavaliers",
       "position": "F / C",
       "height": "7'0\"",
@@ -7023,6 +6643,7 @@
     {
       "id": "isaiah-joe-1630198",
       "name": "Isaiah Joe",
+      "personId": "1630198",
       "team": "Philadelphia 76ers",
       "position": "G",
       "height": "6'3\"",
@@ -7056,6 +6677,7 @@
     {
       "id": "isaiah-roby-1629676",
       "name": "Isaiah Roby",
+      "personId": "1629676",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": "6'8\"",
@@ -7086,11 +6708,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 13.6,
-      "goatRecentRank": 373
+      "goatRecentRank": 364
     },
     {
       "id": "isaiah-stewart-1630191",
       "name": "Isaiah Stewart",
+      "personId": "1630191",
       "team": "Detroit Pistons",
       "position": "C",
       "height": null,
@@ -7118,46 +6741,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 39.2,
-      "goatRecentRank": 200
-    },
-    {
-      "id": "isaiah-thomas-202738",
-      "name": "Isaiah Thomas",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "5'9\"",
-      "weight": "185 lbs",
-      "born": "February 7, 1989 · Tacoma, Washington",
-      "origin": "Tacoma, Washington",
-      "draft": "2011 · Pick 60 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 26.1,
-      "goatRank": 515,
-      "goatTier": "Starter",
-      "goatResume": "10,665 pts · 2,924 ast · 1,462 reb in 694 games",
-      "bio": "Isaiah Thomas is a guard currently available in free agency. They hail from Tacoma, Washington. Isaiah entered the league in the 2011 NBA Draft.",
-      "keywords": [
-        "202738",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "isaiah",
-        "starter",
-        "tacoma",
-        "thomas",
-        "washington"
-      ],
-      "metrics": {},
-      "goatRecentScore": 13.9,
-      "goatRecentRank": 371
+      "goatRecentRank": 199
     },
     {
       "id": "ish-smith-202397",
       "name": "Ish Smith",
+      "personId": "202397",
       "team": "Washington Wizards",
       "position": null,
       "height": "6'0\"",
@@ -7185,11 +6774,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.6,
-      "goatRecentRank": 291
+      "goatRecentRank": 289
     },
     {
       "id": "ivica-zubac-1627826",
       "name": "Ivica Zubac",
+      "personId": "1627826",
       "team": "Los Angeles Clippers",
       "position": null,
       "height": null,
@@ -7223,6 +6813,7 @@
     {
       "id": "ja-morant-1629630",
       "name": "Ja Morant",
+      "personId": "1629630",
       "team": "Memphis Grizzlies",
       "position": null,
       "height": null,
@@ -7255,6 +6846,7 @@
     {
       "id": "jabari-parker-203953",
       "name": "Jabari Parker",
+      "personId": "203953",
       "team": "Boston Celtics",
       "position": "F",
       "height": "6'7\"",
@@ -7284,11 +6876,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 495
+      "goatRecentRank": 480
     },
     {
       "id": "jaden-mcdaniels-1630183",
       "name": "Jaden McDaniels",
+      "personId": "1630183",
       "team": "Minnesota Timberwolves",
       "position": null,
       "height": null,
@@ -7319,6 +6912,7 @@
     {
       "id": "jae-crowder-203109",
       "name": "Jae Crowder",
+      "personId": "203109",
       "team": "Phoenix Suns",
       "position": null,
       "height": null,
@@ -7346,11 +6940,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.5,
-      "goatRecentRank": 295
+      "goatRecentRank": 293
     },
     {
       "id": "jae-sean-tate-1630256",
       "name": "Jae'Sean Tate",
+      "personId": "1630256",
       "team": "Houston Rockets",
       "position": "C",
       "height": null,
@@ -7378,11 +6973,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.3,
-      "goatRecentRank": 210
+      "goatRecentRank": 209
     },
     {
       "id": "jahlil-okafor-1626143",
       "name": "Jahlil Okafor",
+      "personId": "1626143",
       "team": "Detroit Pistons",
       "position": "F / C",
       "height": "6'10\"",
@@ -7414,11 +7010,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 2.7,
-      "goatRecentRank": 410
+      "goatRecentRank": 397
     },
     {
       "id": "jahmi-us-ramsey-1630186",
       "name": "Jahmi'us Ramsey",
+      "personId": "1630186",
       "team": "Sacramento Kings",
       "position": "G",
       "height": "6'3\"",
@@ -7447,11 +7044,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 7.6,
-      "goatRecentRank": 399
+      "goatRecentRank": 388
     },
     {
       "id": "jakarr-sampson-203960",
       "name": "JaKarr Sampson",
+      "personId": "203960",
       "team": "Indiana Pacers",
       "position": "F",
       "height": "6'7\"",
@@ -7481,11 +7079,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 426
+      "goatRecentRank": 492
     },
     {
       "id": "jake-layman-1627774",
       "name": "Jake Layman",
+      "personId": "1627774",
       "team": "Minnesota Timberwolves",
       "position": "F",
       "height": "6'8\"",
@@ -7515,11 +7114,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.5,
-      "goatRecentRank": 250
+      "goatRecentRank": 249
     },
     {
       "id": "jakob-poeltl-1627751",
       "name": "Jakob Poeltl",
+      "personId": "1627751",
       "team": "San Antonio Spurs",
       "position": null,
       "height": null,
@@ -7553,6 +7153,7 @@
     {
       "id": "jalen-brunson-1628973",
       "name": "Jalen Brunson",
+      "personId": "1628973",
       "team": "Dallas Mavericks",
       "position": null,
       "height": null,
@@ -7585,6 +7186,7 @@
     {
       "id": "jalen-harris-1630223",
       "name": "Jalen Harris",
+      "personId": "1630223",
       "team": "Toronto Raptors",
       "position": "G",
       "height": "6'5\"",
@@ -7613,45 +7215,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.1,
-      "goatRecentRank": 304
-    },
-    {
-      "id": "jalen-lecque-1629665",
-      "name": "Jalen Lecque",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'4\"",
-      "weight": "185 lbs",
-      "born": "June 13, 2000 · USA",
-      "origin": "USA",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern guard",
-      "goatScore": 2.9,
-      "goatRank": 4394,
-      "goatTier": "Reserve",
-      "goatResume": "35 pts · 6 ast · 11 reb in 41 games",
-      "bio": "Jalen Lecque is a guard currently available in free agency. They hail from USA. Jalen entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1629665",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "jalen",
-        "lecque",
-        "reserve",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 488
+      "goatRecentRank": 301
     },
     {
       "id": "jalen-mcdaniels-1629667",
       "name": "Jalen McDaniels",
+      "personId": "1629667",
       "team": "Charlotte Hornets",
       "position": "F / C",
       "height": "6'9\"",
@@ -7683,11 +7252,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 32.0,
-      "goatRecentRank": 235
+      "goatRecentRank": 234
     },
     {
       "id": "jalen-smith-1630188",
       "name": "Jalen Smith",
+      "personId": "1630188",
       "team": "Phoenix Suns",
       "position": "C",
       "height": null,
@@ -7720,6 +7290,7 @@
     {
       "id": "jamal-murray-1627750",
       "name": "Jamal Murray",
+      "personId": "1627750",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -7752,6 +7323,7 @@
     {
       "id": "james-ennis-iii-203516",
       "name": "James Ennis III",
+      "personId": "203516",
       "team": "Orlando Magic",
       "position": "F",
       "height": "6'6\"",
@@ -7781,11 +7353,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 422
+      "goatRecentRank": 439
     },
     {
       "id": "james-harden-201935",
       "name": "James Harden",
+      "personId": "201935",
       "team": "Brooklyn Nets",
       "position": null,
       "height": null,
@@ -7820,6 +7393,7 @@
     {
       "id": "james-johnson-201949",
       "name": "James Johnson",
+      "personId": "201949",
       "team": "New Orleans Pelicans",
       "position": null,
       "height": null,
@@ -7848,11 +7422,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.1,
-      "goatRecentRank": 342
+      "goatRecentRank": 336
     },
     {
       "id": "james-nunnally-203263",
       "name": "James Nunnally",
+      "personId": "203263",
       "team": "New Orleans Pelicans",
       "position": "F",
       "height": "6'7\"",
@@ -7882,11 +7457,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 506
+      "goatRecentRank": 411
     },
     {
       "id": "james-wiseman-1630164",
       "name": "James Wiseman",
+      "personId": "1630164",
       "team": "Golden State Warriors",
       "position": "C",
       "height": "7'0\"",
@@ -7916,11 +7492,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.1,
-      "goatRecentRank": 253
+      "goatRecentRank": 252
     },
     {
       "id": "jamychal-green-203210",
       "name": "JaMychal Green",
+      "personId": "203210",
       "team": "Denver Nuggets",
       "position": "F / C",
       "height": "6'9\"",
@@ -7952,11 +7529,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.0,
-      "goatRecentRank": 280
+      "goatRecentRank": 278
     },
     {
       "id": "jared-dudley-201162",
       "name": "Jared Dudley",
+      "personId": "201162",
       "team": "Los Angeles Lakers",
       "position": "F",
       "height": "6'6\"",
@@ -7987,11 +7565,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 491
+      "goatRecentRank": 489
     },
     {
       "id": "jared-harper-1629607",
       "name": "Jared Harper",
+      "personId": "1629607",
       "team": "New York Knicks",
       "position": "G",
       "height": "5'10\"",
@@ -8021,11 +7600,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 450
+      "goatRecentRank": 487
     },
     {
       "id": "jaren-jackson-jr-1628991",
       "name": "Jaren Jackson Jr.",
+      "personId": "1628991",
       "team": "Memphis Grizzlies",
       "position": null,
       "height": null,
@@ -8059,6 +7639,7 @@
     {
       "id": "jarred-vanderbilt-1629020",
       "name": "Jarred Vanderbilt",
+      "personId": "1629020",
       "team": "Minnesota Timberwolves",
       "position": "C",
       "height": null,
@@ -8093,6 +7674,7 @@
     {
       "id": "jarrell-brantley-1629714",
       "name": "Jarrell Brantley",
+      "personId": "1629714",
       "team": "Utah Jazz",
       "position": "F",
       "height": "6'5\"",
@@ -8121,11 +7703,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 2.7,
-      "goatRecentRank": 409
+      "goatRecentRank": 396
     },
     {
       "id": "jarrett-allen-1628386",
       "name": "Jarrett Allen",
+      "personId": "1628386",
       "team": "Cleveland Cavaliers",
       "position": null,
       "height": null,
@@ -8158,6 +7741,7 @@
     {
       "id": "jarrett-culver-1629633",
       "name": "Jarrett Culver",
+      "personId": "1629633",
       "team": "Minnesota Timberwolves",
       "position": "G / F",
       "height": "6'6\"",
@@ -8189,11 +7773,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 12.1,
-      "goatRecentRank": 379
+      "goatRecentRank": 370
     },
     {
       "id": "javale-mcgee-201580",
       "name": "JaVale McGee",
+      "personId": "201580",
       "team": "Denver Nuggets",
       "position": "F / C",
       "height": "7'0\"",
@@ -8225,11 +7810,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 35.8,
-      "goatRecentRank": 219
+      "goatRecentRank": 218
     },
     {
       "id": "javonte-green-1629750",
       "name": "Javonte Green",
+      "personId": "1629750",
       "team": "Chicago Bulls",
       "position": "F",
       "height": null,
@@ -8259,11 +7845,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.6,
-      "goatRecentRank": 248
+      "goatRecentRank": 247
     },
     {
       "id": "jaxson-hayes-1629637",
       "name": "Jaxson Hayes",
+      "personId": "1629637",
       "team": "New Orleans Pelicans",
       "position": null,
       "height": null,
@@ -8297,6 +7884,7 @@
     {
       "id": "jay-scrubb-1630206",
       "name": "Jay Scrubb",
+      "personId": "1630206",
       "team": "Los Angeles Clippers",
       "position": null,
       "height": "6'5\"",
@@ -8324,45 +7912,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 11.8,
-      "goatRecentRank": 382
-    },
-    {
-      "id": "jaylen-adams-1629121",
-      "name": "Jaylen Adams",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'0\"",
-      "weight": "225 lbs",
-      "born": "May 4, 1996 · USA",
-      "origin": "USA",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern guard",
-      "goatScore": 5.0,
-      "goatRank": 3147,
-      "goatTier": "Rotation",
-      "goatResume": "149 pts · 77 ast · 78 reb in 79 games",
-      "bio": "Jaylen Adams is a guard currently available in free agency. They hail from USA. Jaylen entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1629121",
-        "adams",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "jaylen",
-        "rotation",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 427
+      "goatRecentRank": 373
     },
     {
       "id": "jaylen-brown-1627759",
       "name": "Jaylen Brown",
+      "personId": "1627759",
       "team": "Boston Celtics",
       "position": null,
       "height": null,
@@ -8395,6 +7950,7 @@
     {
       "id": "jaylen-hoard-1629658",
       "name": "Jaylen Hoard",
+      "personId": "1629658",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": "6'8\"",
@@ -8424,11 +7980,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 487
+      "goatRecentRank": 407
     },
     {
       "id": "jaylen-nowell-1629669",
       "name": "Jaylen Nowell",
+      "personId": "1629669",
       "team": "Minnesota Timberwolves",
       "position": "G",
       "height": "6'4\"",
@@ -8458,11 +8015,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.3,
-      "goatRecentRank": 263
+      "goatRecentRank": 262
     },
     {
       "id": "jayson-tatum-1628369",
       "name": "Jayson Tatum",
+      "personId": "1628369",
       "team": "Boston Celtics",
       "position": null,
       "height": null,
@@ -8495,6 +8053,7 @@
     {
       "id": "jeff-green-201145",
       "name": "Jeff Green",
+      "personId": "201145",
       "team": "Brooklyn Nets",
       "position": "F",
       "height": null,
@@ -8524,11 +8083,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.9,
-      "goatRecentRank": 188
+      "goatRecentRank": 187
     },
     {
       "id": "jeff-teague-201952",
       "name": "Jeff Teague",
+      "personId": "201952",
       "team": "Milwaukee Bucks",
       "position": "G",
       "height": "6'3\"",
@@ -8558,11 +8118,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 520
+      "goatRecentRank": 488
     },
     {
       "id": "jerami-grant-203924",
       "name": "Jerami Grant",
+      "personId": "203924",
       "team": "Detroit Pistons",
       "position": null,
       "height": null,
@@ -8590,11 +8151,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 39.9,
-      "goatRecentRank": 196
+      "goatRecentRank": 195
     },
     {
       "id": "jeremiah-martin-1629725",
       "name": "Jeremiah Martin",
+      "personId": "1629725",
       "team": "Cleveland Cavaliers",
       "position": "G",
       "height": "6'2\"",
@@ -8624,11 +8186,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 513
+      "goatRecentRank": 455
     },
     {
       "id": "jeremy-lamb-203087",
       "name": "Jeremy Lamb",
+      "personId": "203087",
       "team": "Indiana Pacers",
       "position": "G / F",
       "height": "6'5\"",
@@ -8660,46 +8223,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 4.8,
-      "goatRecentRank": 408
-    },
-    {
-      "id": "jerome-robinson-1629010",
-      "name": "Jerome Robinson",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'5\"",
-      "weight": "1629010 lbs",
-      "born": "February 22, 1997 · Raleigh, North Carolina",
-      "origin": "Raleigh, North Carolina",
-      "draft": "2018 · Pick 13 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 6.2,
-      "goatRank": 2695,
-      "goatTier": "Rotation",
-      "goatResume": "691 pts · 171 ast · 266 reb in 237 games",
-      "bio": "Jerome Robinson is a guard currently available in free agency. They hail from Raleigh, North Carolina. Jerome entered the league in the 2018 NBA Draft.",
-      "keywords": [
-        "1629010",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "jerome",
-        "north carolina",
-        "raleigh",
-        "robinson",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 22.7,
-      "goatRecentRank": 308
+      "goatRecentRank": 395
     },
     {
       "id": "jevon-carter-1628975",
       "name": "Jevon Carter",
+      "personId": "1628975",
       "team": "Phoenix Suns",
       "position": "G",
       "height": null,
@@ -8734,6 +8263,7 @@
     {
       "id": "jimmy-butler-202710",
       "name": "Jimmy Butler",
+      "personId": "202710",
       "team": "Miami Heat",
       "position": "F",
       "height": null,
@@ -8768,6 +8298,7 @@
     {
       "id": "jj-redick-200755",
       "name": "JJ Redick",
+      "personId": "200755",
       "team": "Dallas Mavericks",
       "position": "G",
       "height": "6'3\"",
@@ -8797,11 +8328,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 420
+      "goatRecentRank": 485
     },
     {
       "id": "joe-harris-203925",
       "name": "Joe Harris",
+      "personId": "203925",
       "team": "Brooklyn Nets",
       "position": "G / F",
       "height": "6'6\"",
@@ -8833,11 +8365,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.1,
-      "goatRecentRank": 302
+      "goatRecentRank": 299
     },
     {
       "id": "joe-ingles-204060",
       "name": "Joe Ingles",
+      "personId": "204060",
       "team": "Utah Jazz",
       "position": "G",
       "height": null,
@@ -8867,11 +8400,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.3,
-      "goatRecentRank": 211
+      "goatRecentRank": 210
     },
     {
       "id": "joel-embiid-203954",
       "name": "Joel Embiid",
+      "personId": "203954",
       "team": "Philadelphia 76ers",
       "position": "F / C",
       "height": "7'0\"",
@@ -8908,6 +8442,7 @@
     {
       "id": "john-collins-1628381",
       "name": "John Collins",
+      "personId": "1628381",
       "team": "Atlanta Hawks",
       "position": "F",
       "height": null,
@@ -8942,6 +8477,7 @@
     {
       "id": "john-konchar-1629723",
       "name": "John Konchar",
+      "personId": "1629723",
       "team": "Memphis Grizzlies",
       "position": "G",
       "height": null,
@@ -8971,11 +8507,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.7,
-      "goatRecentRank": 183
+      "goatRecentRank": 182
     },
     {
       "id": "john-wall-202322",
       "name": "John Wall",
+      "personId": "202322",
       "team": "Houston Rockets",
       "position": "G",
       "height": "6'3\"",
@@ -9005,11 +8542,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.2,
-      "goatRecentRank": 339
+      "goatRecentRank": 333
     },
     {
       "id": "jonas-valanciunas-202685",
       "name": "Jonas Valanciunas",
+      "personId": "202685",
       "team": "Memphis Grizzlies",
       "position": "C",
       "height": null,
@@ -9044,6 +8582,7 @@
     {
       "id": "jonathan-isaac-1628371",
       "name": "Jonathan Isaac",
+      "personId": "1628371",
       "team": "Orlando Magic",
       "position": "F",
       "height": null,
@@ -9078,6 +8617,7 @@
     {
       "id": "jontay-porter-1629007",
       "name": "Jontay Porter",
+      "personId": "1629007",
       "team": "Memphis Grizzlies",
       "position": "F / C",
       "height": "6'11\"",
@@ -9108,11 +8648,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 11.1,
-      "goatRecentRank": 387
+      "goatRecentRank": 377
     },
     {
       "id": "jordan-bell-1628395",
       "name": "Jordan Bell",
+      "personId": "1628395",
       "team": "Golden State Warriors",
       "position": "F",
       "height": "6'7\"",
@@ -9143,46 +8684,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 530
-    },
-    {
-      "id": "jordan-bone-1629648",
-      "name": "Jordan Bone",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'2\"",
-      "weight": "180 lbs",
-      "born": "November 5, 1997 · Nashville, Tennessee",
-      "origin": "Nashville, Tennessee",
-      "draft": "2019 · Pick 57 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 3.3,
-      "goatRank": 4068,
-      "goatTier": "Reserve",
-      "goatResume": "77 pts · 27 ast · 30 reb in 55 games",
-      "bio": "Jordan Bone is a guard currently available in free agency. They hail from Nashville, Tennessee. Jordan entered the league in the 2019 NBA Draft.",
-      "keywords": [
-        "1629648",
-        "agent",
-        "bone",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "jordan",
-        "nashville",
-        "reserve",
-        "tennessee"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 456
+      "goatRecentRank": 460
     },
     {
       "id": "jordan-clarkson-203903",
       "name": "Jordan Clarkson",
+      "personId": "203903",
       "team": "Utah Jazz",
       "position": "G",
       "height": null,
@@ -9212,11 +8719,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.9,
-      "goatRecentRank": 180
+      "goatRecentRank": 179
     },
     {
       "id": "jordan-mclaughlin-1629162",
       "name": "Jordan McLaughlin",
+      "personId": "1629162",
       "team": "Minnesota Timberwolves",
       "position": null,
       "height": null,
@@ -9244,11 +8752,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.2,
-      "goatRecentRank": 186
+      "goatRecentRank": 185
     },
     {
       "id": "jordan-nwora-1629670",
       "name": "Jordan Nwora",
+      "personId": "1629670",
       "team": "Milwaukee Bucks",
       "position": "F",
       "height": "6'9\"",
@@ -9277,11 +8786,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 31.9,
-      "goatRecentRank": 236
+      "goatRecentRank": 235
     },
     {
       "id": "jordan-poole-1629673",
       "name": "Jordan Poole",
+      "personId": "1629673",
       "team": "Golden State Warriors",
       "position": null,
       "height": null,
@@ -9315,6 +8825,7 @@
     {
       "id": "josh-green-1630182",
       "name": "Josh Green",
+      "personId": "1630182",
       "team": "Dallas Mavericks",
       "position": null,
       "height": null,
@@ -9340,11 +8851,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 36.5,
-      "goatRecentRank": 216
+      "goatRecentRank": 215
     },
     {
       "id": "josh-hall-1630221",
       "name": "Josh Hall",
+      "personId": "1630221",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": "6'9\"",
@@ -9374,11 +8886,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 505
+      "goatRecentRank": 453
     },
     {
       "id": "josh-hart-1628404",
       "name": "Josh Hart",
+      "personId": "1628404",
       "team": "New Orleans Pelicans",
       "position": null,
       "height": null,
@@ -9412,6 +8925,7 @@
     {
       "id": "josh-jackson-1628367",
       "name": "Josh Jackson",
+      "personId": "1628367",
       "team": "Detroit Pistons",
       "position": "G / F",
       "height": "6'8\"",
@@ -9443,11 +8957,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 15.5,
-      "goatRecentRank": 363
+      "goatRecentRank": 355
     },
     {
       "id": "josh-okogie-1629006",
       "name": "Josh Okogie",
+      "personId": "1629006",
       "team": "Minnesota Timberwolves",
       "position": "F",
       "height": null,
@@ -9482,6 +8997,7 @@
     {
       "id": "josh-richardson-1626196",
       "name": "Josh Richardson",
+      "personId": "1626196",
       "team": "Dallas Mavericks",
       "position": null,
       "height": null,
@@ -9509,11 +9025,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.3,
-      "goatRecentRank": 251
+      "goatRecentRank": 250
     },
     {
       "id": "jrue-holiday-201950",
       "name": "Jrue Holiday",
+      "personId": "201950",
       "team": "Milwaukee Bucks",
       "position": null,
       "height": null,
@@ -9546,6 +9063,7 @@
     {
       "id": "juan-toscano-anderson-1629308",
       "name": "Juan Toscano-Anderson",
+      "personId": "1629308",
       "team": "Golden State Warriors",
       "position": "F",
       "height": "6'6\"",
@@ -9576,11 +9094,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 17.3,
-      "goatRecentRank": 345
+      "goatRecentRank": 339
     },
     {
       "id": "juancho-hernangomez-1627823",
       "name": "Juancho Hernangomez",
+      "personId": "1627823",
       "team": "Minnesota Timberwolves",
       "position": null,
       "height": "6'9\"",
@@ -9607,11 +9126,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 17.1,
-      "goatRecentRank": 348
+      "goatRecentRank": 342
     },
     {
       "id": "julius-randle-203944",
       "name": "Julius Randle",
+      "personId": "203944",
       "team": "New York Knicks",
       "position": "F",
       "height": null,
@@ -9647,6 +9167,7 @@
     {
       "id": "justin-holiday-203200",
       "name": "Justin Holiday",
+      "personId": "203200",
       "team": "Indiana Pacers",
       "position": "G / F",
       "height": "6'6\"",
@@ -9678,11 +9199,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.0,
-      "goatRecentRank": 267
+      "goatRecentRank": 266
     },
     {
       "id": "justin-jackson-1628382",
       "name": "Justin Jackson",
+      "personId": "1628382",
       "team": "Milwaukee Bucks",
       "position": null,
       "height": "6'8\"",
@@ -9710,11 +9232,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 19.0,
-      "goatRecentRank": 334
+      "goatRecentRank": 328
     },
     {
       "id": "justin-james-1629713",
       "name": "Justin James",
+      "personId": "1629713",
       "team": "Sacramento Kings",
       "position": "G / F",
       "height": "6'7\"",
@@ -9746,80 +9269,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 489
-    },
-    {
-      "id": "justin-patton-1628383",
-      "name": "Justin Patton",
-      "team": "Free Agent",
-      "position": "C",
-      "height": "6'11\"",
-      "weight": "241 lbs",
-      "born": "June 14, 1997 · Riverdale, Georgia",
-      "origin": "Riverdale, Georgia",
-      "draft": "2017 · Pick 16 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern center",
-      "goatScore": 5.1,
-      "goatRank": 3120,
-      "goatTier": "Rotation",
-      "goatResume": "94 pts · 21 ast · 69 reb in 74 games",
-      "bio": "Justin Patton is a center currently available in free agency. They hail from Riverdale, Georgia. Justin entered the league in the 2017 NBA Draft.",
-      "keywords": [
-        "1628383",
-        "agent",
-        "c",
-        "center",
-        "free",
-        "free agent",
-        "georgia",
-        "goat",
-        "justin",
-        "patton",
-        "riverdale",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 468
-    },
-    {
-      "id": "justin-robinson-1629620",
-      "name": "Justin Robinson",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'1\"",
-      "weight": "195 lbs",
-      "born": "October 12, 1997 · USA",
-      "origin": "USA",
-      "draft": "2019 NBA Draft",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 5.4,
-      "goatRank": 2970,
-      "goatTier": "Rotation",
-      "goatResume": "154 pts · 66 ast · 43 reb in 72 games",
-      "bio": "Justin Robinson is a guard currently available in free agency. They hail from USA. Justin entered the league in the 2019 NBA Draft NBA Draft.",
-      "keywords": [
-        "1629620",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "justin",
-        "robinson",
-        "rotation",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 434
+      "goatRecentRank": 432
     },
     {
       "id": "justise-winslow-1626159",
       "name": "Justise Winslow",
+      "personId": "1626159",
       "team": "Memphis Grizzlies",
       "position": "G / F",
       "height": "6'6\"",
@@ -9851,11 +9306,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.0,
-      "goatRecentRank": 358
+      "goatRecentRank": 351
     },
     {
       "id": "jusuf-nurkic-203994",
       "name": "Jusuf Nurkic",
+      "personId": "203994",
       "team": "Portland Trail Blazers",
       "position": "C",
       "height": null,
@@ -9891,6 +9347,7 @@
     {
       "id": "juwan-morgan-1629752",
       "name": "Juwan Morgan",
+      "personId": "1629752",
       "team": "Utah Jazz",
       "position": "F",
       "height": "6'7\"",
@@ -9920,45 +9377,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 533
-    },
-    {
-      "id": "karim-mane-1630211",
-      "name": "Karim Mane",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'3\"",
-      "weight": "190 lbs",
-      "born": "May 16, 2000 · Senegal",
-      "origin": "Senegal",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern guard",
-      "goatScore": 2.6,
-      "goatRank": 4580,
-      "goatTier": "Reserve",
-      "goatResume": "11 pts · 4 ast · 16 reb in 35 games",
-      "bio": "Karim Mane is a guard currently available in free agency. They hail from Senegal. Karim entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1630211",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "karim",
-        "mane",
-        "reserve",
-        "senegal"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 479
+      "goatRecentRank": 461
     },
     {
       "id": "karl-anthony-towns-1626157",
       "name": "Karl-Anthony Towns",
+      "personId": "1626157",
       "team": "Minnesota Timberwolves",
       "position": null,
       "height": null,
@@ -9991,6 +9415,7 @@
     {
       "id": "kawhi-leonard-202695",
       "name": "Kawhi Leonard",
+      "personId": "202695",
       "team": "Los Angeles Clippers",
       "position": "F",
       "height": null,
@@ -10026,6 +9451,7 @@
     {
       "id": "keita-bates-diop-1628966",
       "name": "Keita Bates-Diop",
+      "personId": "1628966",
       "team": "San Antonio Spurs",
       "position": null,
       "height": null,
@@ -10054,11 +9480,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 30.2,
-      "goatRecentRank": 242
+      "goatRecentRank": 241
     },
     {
       "id": "kelan-martin-1629103",
       "name": "Kelan Martin",
+      "personId": "1629103",
       "team": "Indiana Pacers",
       "position": "F",
       "height": "6'5\"",
@@ -10088,11 +9515,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 11.6,
-      "goatRecentRank": 383
+      "goatRecentRank": 374
     },
     {
       "id": "keldon-johnson-1629640",
       "name": "Keldon Johnson",
+      "personId": "1629640",
       "team": "San Antonio Spurs",
       "position": null,
       "height": null,
@@ -10126,6 +9554,7 @@
     {
       "id": "keljin-blevins-1629833",
       "name": "Keljin Blevins",
+      "personId": "1629833",
       "team": "Portland Trail Blazers",
       "position": "G",
       "height": "6'4\"",
@@ -10155,11 +9584,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 523
+      "goatRecentRank": 493
     },
     {
       "id": "kelly-olynyk-203482",
       "name": "Kelly Olynyk",
+      "personId": "203482",
       "team": "Houston Rockets",
       "position": "C",
       "height": null,
@@ -10194,6 +9624,7 @@
     {
       "id": "kelly-oubre-jr-1626162",
       "name": "Kelly Oubre Jr.",
+      "personId": "1626162",
       "team": "Golden State Warriors",
       "position": null,
       "height": null,
@@ -10228,6 +9659,7 @@
     {
       "id": "kemba-walker-202689",
       "name": "Kemba Walker",
+      "personId": "202689",
       "team": "Boston Celtics",
       "position": "G",
       "height": "6'0\"",
@@ -10257,11 +9689,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 14.3,
-      "goatRecentRank": 368
+      "goatRecentRank": 360
     },
     {
       "id": "kendrick-nunn-1629134",
       "name": "Kendrick Nunn",
+      "personId": "1629134",
       "team": "Miami Heat",
       "position": "G",
       "height": "6'3\"",
@@ -10291,11 +9724,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 22.6,
-      "goatRecentRank": 310
+      "goatRecentRank": 306
     },
     {
       "id": "kenrich-williams-1629026",
       "name": "Kenrich Williams",
+      "personId": "1629026",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": null,
@@ -10331,6 +9765,7 @@
     {
       "id": "kent-bazemore-203145",
       "name": "Kent Bazemore",
+      "personId": "203145",
       "team": "Golden State Warriors",
       "position": "G / F",
       "height": "6'4\"",
@@ -10363,11 +9798,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.8,
-      "goatRecentRank": 258
+      "goatRecentRank": 257
     },
     {
       "id": "kentavious-caldwell-pope-203484",
       "name": "Kentavious Caldwell-Pope",
+      "personId": "203484",
       "team": "Los Angeles Lakers",
       "position": null,
       "height": null,
@@ -10401,6 +9837,7 @@
     {
       "id": "kenyon-martin-jr-1630231",
       "name": "Kenyon Martin Jr.",
+      "personId": "1630231",
       "team": "Houston Rockets",
       "position": "F",
       "height": "6'7\"",
@@ -10430,11 +9867,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.9,
-      "goatRecentRank": 207
+      "goatRecentRank": 206
     },
     {
       "id": "kevin-durant-201142",
       "name": "Kevin Durant",
+      "personId": "201142",
       "team": "Brooklyn Nets",
       "position": null,
       "height": null,
@@ -10469,6 +9907,7 @@
     {
       "id": "kevin-huerter-1628989",
       "name": "Kevin Huerter",
+      "personId": "1628989",
       "team": "Atlanta Hawks",
       "position": "G",
       "height": null,
@@ -10501,6 +9940,7 @@
     {
       "id": "kevin-knox-ii-1628995",
       "name": "Kevin Knox II",
+      "personId": "1628995",
       "team": "New York Knicks",
       "position": null,
       "height": null,
@@ -10528,11 +9968,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.4,
-      "goatRecentRank": 298
+      "goatRecentRank": 296
     },
     {
       "id": "kevin-love-201567",
       "name": "Kevin Love",
+      "personId": "201567",
       "team": "Cleveland Cavaliers",
       "position": "F",
       "height": null,
@@ -10567,6 +10008,7 @@
     {
       "id": "kevin-porter-jr-1629645",
       "name": "Kevin Porter Jr.",
+      "personId": "1629645",
       "team": "Houston Rockets",
       "position": "G",
       "height": null,
@@ -10602,6 +10044,7 @@
     {
       "id": "kevon-looney-1626172",
       "name": "Kevon Looney",
+      "personId": "1626172",
       "team": "Golden State Warriors",
       "position": null,
       "height": null,
@@ -10635,6 +10078,7 @@
     {
       "id": "khem-birch-203920",
       "name": "Khem Birch",
+      "personId": "203920",
       "team": "Toronto Raptors",
       "position": "C",
       "height": "6'8\"",
@@ -10664,11 +10108,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 14.8,
-      "goatRecentRank": 367
+      "goatRecentRank": 359
     },
     {
       "id": "khris-middleton-203114",
       "name": "Khris Middleton",
+      "personId": "203114",
       "team": "Milwaukee Bucks",
       "position": "G",
       "height": null,
@@ -10703,6 +10148,7 @@
     {
       "id": "khyri-thomas-1629017",
       "name": "Khyri Thomas",
+      "personId": "1629017",
       "team": "Houston Rockets",
       "position": "G",
       "height": "6'3\"",
@@ -10732,11 +10178,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 486
+      "goatRecentRank": 445
     },
     {
       "id": "killian-hayes-1630165",
       "name": "Killian Hayes",
+      "personId": "1630165",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'5\"",
@@ -10765,11 +10212,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 28.8,
-      "goatRecentRank": 256
+      "goatRecentRank": 255
     },
     {
       "id": "killian-tillie-1629681",
       "name": "Killian Tillie",
+      "personId": "1629681",
       "team": "Memphis Grizzlies",
       "position": "F / C",
       "height": "6'9\"",
@@ -10800,11 +10248,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 524
+      "goatRecentRank": 437
     },
     {
       "id": "kira-lewis-jr-1630184",
       "name": "Kira Lewis Jr.",
+      "personId": "1630184",
       "team": "New Orleans Pelicans",
       "position": "G",
       "height": "6'1\"",
@@ -10835,11 +10284,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.7,
-      "goatRecentRank": 337
+      "goatRecentRank": 331
     },
     {
       "id": "klay-thompson-202691",
       "name": "Klay Thompson",
+      "personId": "202691",
       "team": "Golden State Warriors",
       "position": "F",
       "height": null,
@@ -10875,6 +10325,7 @@
     {
       "id": "kostas-antetokounmpo-1628961",
       "name": "Kostas Antetokounmpo",
+      "personId": "1628961",
       "team": "Los Angeles Lakers",
       "position": "F",
       "height": "6'10\"",
@@ -10905,11 +10356,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 12.6,
-      "goatRecentRank": 377
+      "goatRecentRank": 368
     },
     {
       "id": "kris-dunn-1627739",
       "name": "Kris Dunn",
+      "personId": "1627739",
       "team": "Atlanta Hawks",
       "position": null,
       "height": null,
@@ -10942,6 +10394,7 @@
     {
       "id": "kristaps-porzingis-204001",
       "name": "Kristaps Porzingis",
+      "personId": "204001",
       "team": "Dallas Mavericks",
       "position": "C",
       "height": null,
@@ -10976,6 +10429,7 @@
     {
       "id": "kyle-anderson-203937",
       "name": "Kyle Anderson",
+      "personId": "203937",
       "team": "Memphis Grizzlies",
       "position": "F",
       "height": null,
@@ -11010,6 +10464,7 @@
     {
       "id": "kyle-guy-1629657",
       "name": "Kyle Guy",
+      "personId": "1629657",
       "team": "Sacramento Kings",
       "position": null,
       "height": "6'1\"",
@@ -11037,11 +10492,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 453
+      "goatRecentRank": 468
     },
     {
       "id": "kyle-kuzma-1628398",
       "name": "Kyle Kuzma",
+      "personId": "1628398",
       "team": "Los Angeles Lakers",
       "position": null,
       "height": null,
@@ -11075,6 +10531,7 @@
     {
       "id": "kyle-lowry-200768",
       "name": "Kyle Lowry",
+      "personId": "200768",
       "team": "Toronto Raptors",
       "position": null,
       "height": null,
@@ -11102,11 +10559,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 42.4,
-      "goatRecentRank": 179
+      "goatRecentRank": 178
     },
     {
       "id": "kyrie-irving-202681",
       "name": "Kyrie Irving",
+      "personId": "202681",
       "team": "Brooklyn Nets",
       "position": null,
       "height": null,
@@ -11139,6 +10597,7 @@
     {
       "id": "kz-okpala-1629644",
       "name": "KZ Okpala",
+      "personId": "1629644",
       "team": "Miami Heat",
       "position": "G / F",
       "height": "6'8\"",
@@ -11170,11 +10629,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 17.8,
-      "goatRecentRank": 343
+      "goatRecentRank": 337
     },
     {
       "id": "lamar-stevens-1630205",
       "name": "Lamar Stevens",
+      "personId": "1630205",
       "team": "Cleveland Cavaliers",
       "position": "F",
       "height": "6'6\"",
@@ -11203,48 +10663,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 33.5,
-      "goatRecentRank": 226
-    },
-    {
-      "id": "lamarcus-aldridge-200746",
-      "name": "LaMarcus Aldridge",
-      "team": "Free Agent",
-      "position": "F / C",
-      "height": "6'11\"",
-      "weight": "250 lbs",
-      "born": "July 19, 1985 · Dallas, Texas",
-      "origin": "Dallas, Texas",
-      "draft": "2006 · Pick 2 (1st round)",
-      "era": "2000s",
-      "archetype": "Hybrid forward-center",
-      "goatScore": 39.3,
-      "goatRank": 119,
-      "goatTier": "All-Star",
-      "goatResume": "22,989 pts · 2,295 ast · 9,740 reb in 1,298 games",
-      "bio": "LaMarcus Aldridge is a forward-center currently available in free agency. They hail from Dallas, Texas. LaMarcus entered the league in the 2006 NBA Draft.",
-      "keywords": [
-        "200746",
-        "agent",
-        "aldridge",
-        "all-star",
-        "c",
-        "center",
-        "dallas",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "lamarcus",
-        "texas"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 454
+      "goatRecentRank": 225
     },
     {
       "id": "lamelo-ball-1630163",
       "name": "LaMelo Ball",
+      "personId": "1630163",
       "team": "Charlotte Hornets",
       "position": null,
       "height": null,
@@ -11270,11 +10694,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 38.6,
-      "goatRecentRank": 204
+      "goatRecentRank": 203
     },
     {
       "id": "landry-shamet-1629013",
       "name": "Landry Shamet",
+      "personId": "1629013",
       "team": "Brooklyn Nets",
       "position": null,
       "height": null,
@@ -11302,11 +10727,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 32.8,
-      "goatRecentRank": 231
+      "goatRecentRank": 230
     },
     {
       "id": "langston-galloway-204038",
       "name": "Langston Galloway",
+      "personId": "204038",
       "team": "Phoenix Suns",
       "position": "G",
       "height": "6'1\"",
@@ -11336,11 +10762,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 10.2,
-      "goatRecentRank": 390
+      "goatRecentRank": 380
     },
     {
       "id": "larry-nance-jr-1626204",
       "name": "Larry Nance Jr.",
+      "personId": "1626204",
       "team": "Cleveland Cavaliers",
       "position": "F",
       "height": null,
@@ -11371,11 +10798,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.8,
-      "goatRecentRank": 181
+      "goatRecentRank": 180
     },
     {
       "id": "lauri-markkanen-1628374",
       "name": "Lauri Markkanen",
+      "personId": "1628374",
       "team": "Chicago Bulls",
       "position": null,
       "height": null,
@@ -11408,6 +10836,7 @@
     {
       "id": "lebron-james-2544",
       "name": "LeBron James",
+      "personId": "2544",
       "team": "Los Angeles Lakers",
       "position": "F",
       "height": null,
@@ -11444,6 +10873,7 @@
     {
       "id": "lonnie-walker-iv-1629022",
       "name": "Lonnie Walker IV",
+      "personId": "1629022",
       "team": "San Antonio Spurs",
       "position": "F",
       "height": null,
@@ -11473,11 +10903,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 35.2,
-      "goatRecentRank": 221
+      "goatRecentRank": 220
     },
     {
       "id": "lonzo-ball-1628366",
       "name": "Lonzo Ball",
+      "personId": "1628366",
       "team": "New Orleans Pelicans",
       "position": null,
       "height": null,
@@ -11506,11 +10937,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 19.6,
-      "goatRecentRank": 332
+      "goatRecentRank": 326
     },
     {
       "id": "lou-williams-101150",
       "name": "Lou Williams",
+      "personId": "101150",
       "team": "Atlanta Hawks",
       "position": "G",
       "height": "6'2\"",
@@ -11540,11 +10972,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 515
+      "goatRecentRank": 406
     },
     {
       "id": "louis-king-1629663",
       "name": "Louis King",
+      "personId": "1629663",
       "team": "Sacramento Kings",
       "position": "F",
       "height": "6'7\"",
@@ -11574,11 +11007,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 24.1,
-      "goatRecentRank": 287
+      "goatRecentRank": 285
     },
     {
       "id": "luca-vildoza-1630492",
       "name": "Luca Vildoza",
+      "personId": "1630492",
       "team": "New York Knicks",
       "position": "G",
       "height": "6'3\"",
@@ -11608,11 +11042,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.6,
-      "goatRecentRank": 412
+      "goatRecentRank": 398
     },
     {
       "id": "luguentz-dort-1629652",
       "name": "Luguentz Dort",
+      "personId": "1629652",
       "team": "Oklahoma City Thunder",
       "position": null,
       "height": null,
@@ -11646,7 +11081,8 @@
     {
       "id": "luka-doncic-1629029",
       "name": "Luka Doncic",
-      "team": "Dallas Mavericks",
+      "personId": "1629029",
+      "team": "Los Angeles Lakers",
       "position": "G / F",
       "height": "6'7\"",
       "weight": "230 lbs",
@@ -11659,20 +11095,21 @@
       "goatRank": 61,
       "goatTier": "All-Star",
       "goatResume": "14,898 pts · 4,207 ast · 4,483 reb in 538 games",
-      "bio": "Luka Doncic is a guard-forward for the Dallas Mavericks. They hail from Ljubljana, Slovenia (FRMR Yugoslavia). Luka entered the league in the 2018 NBA Draft.",
+      "bio": "Luka Doncic is a guard-forward for the Los Angeles Lakers. They hail from Ljubljana, Slovenia (FRMR Yugoslavia). Luka entered the league in the 2018 NBA Draft.",
       "keywords": [
         "1629029",
         "all-star",
-        "dallas",
+        "angeles",
         "doncic",
         "f",
         "forward",
         "g",
         "goat",
         "guard",
+        "lakers",
         "ljubljana",
+        "los",
         "luka",
-        "mavericks",
         "slovenia (frmr yugoslavia)"
       ],
       "metrics": {},
@@ -11682,6 +11119,7 @@
     {
       "id": "luka-samanic-1629677",
       "name": "Luka Samanic",
+      "personId": "1629677",
       "team": "San Antonio Spurs",
       "position": "F",
       "height": "6'10\"",
@@ -11712,11 +11150,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 17.5,
-      "goatRecentRank": 344
+      "goatRecentRank": 338
     },
     {
       "id": "luke-kennard-1628379",
       "name": "Luke Kennard",
+      "personId": "1628379",
       "team": "Los Angeles Clippers",
       "position": "G",
       "height": null,
@@ -11747,11 +11186,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.3,
-      "goatRecentRank": 192
+      "goatRecentRank": 191
     },
     {
       "id": "luke-kornet-1628436",
       "name": "Luke Kornet",
+      "personId": "1628436",
       "team": "Boston Celtics",
       "position": null,
       "height": null,
@@ -11784,6 +11224,7 @@
     {
       "id": "malachi-flynn-1630201",
       "name": "Malachi Flynn",
+      "personId": "1630201",
       "team": "Toronto Raptors",
       "position": "G",
       "height": "6'1\"",
@@ -11812,11 +11253,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 33.4,
-      "goatRecentRank": 227
+      "goatRecentRank": 226
     },
     {
       "id": "malcolm-brogdon-1627763",
       "name": "Malcolm Brogdon",
+      "personId": "1627763",
       "team": "Indiana Pacers",
       "position": "G",
       "height": "6'4\"",
@@ -11851,6 +11293,7 @@
     {
       "id": "malik-beasley-1627736",
       "name": "Malik Beasley",
+      "personId": "1627736",
       "team": "Minnesota Timberwolves",
       "position": "G",
       "height": null,
@@ -11883,42 +11326,9 @@
       "goatRecentRank": 119
     },
     {
-      "id": "malik-fitts-1630238",
-      "name": "Malik Fitts",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'5\"",
-      "weight": "230 lbs",
-      "born": "July 4, 1997 · USA",
-      "origin": "USA",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern forward",
-      "goatScore": 6.1,
-      "goatRank": 2707,
-      "goatTier": "Rotation",
-      "goatResume": "51 pts · 13 ast · 33 reb in 74 games",
-      "bio": "Malik Fitts is a forward currently available in free agency. They hail from USA. Malik entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1630238",
-        "agent",
-        "f",
-        "fitts",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "malik",
-        "rotation",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 1.8,
-      "goatRecentRank": 411
-    },
-    {
       "id": "malik-monk-1628370",
       "name": "Malik Monk",
+      "personId": "1628370",
       "team": "Charlotte Hornets",
       "position": null,
       "height": null,
@@ -11951,6 +11361,7 @@
     {
       "id": "mamadi-diakite-1629603",
       "name": "Mamadi Diakite",
+      "personId": "1629603",
       "team": "Milwaukee Bucks",
       "position": "F",
       "height": "6'9\"",
@@ -11979,11 +11390,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.8,
-      "goatRecentRank": 320
+      "goatRecentRank": 316
     },
     {
       "id": "marc-gasol-201188",
       "name": "Marc Gasol",
+      "personId": "201188",
       "team": "Los Angeles Lakers",
       "position": "C",
       "height": "6'11\"",
@@ -12014,11 +11426,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 442
+      "goatRecentRank": 446
     },
     {
       "id": "marcus-morris-sr-202694",
       "name": "Marcus Morris Sr.",
+      "personId": "202694",
       "team": "Los Angeles Clippers",
       "position": "F",
       "height": "6'8\"",
@@ -12049,11 +11462,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.7,
-      "goatRecentRank": 245
+      "goatRecentRank": 244
     },
     {
       "id": "marcus-smart-203935",
       "name": "Marcus Smart",
+      "personId": "203935",
       "team": "Boston Celtics",
       "position": "G",
       "height": "6'4\"",
@@ -12083,11 +11497,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.1,
-      "goatRecentRank": 194
+      "goatRecentRank": 193
     },
     {
       "id": "markelle-fultz-1628365",
       "name": "Markelle Fultz",
+      "personId": "1628365",
       "team": "Orlando Magic",
       "position": "G",
       "height": "6'4\"",
@@ -12117,11 +11532,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 37.9,
-      "goatRecentRank": 206
+      "goatRecentRank": 205
     },
     {
       "id": "markieff-morris-202693",
       "name": "Markieff Morris",
+      "personId": "202693",
       "team": "Los Angeles Lakers",
       "position": "F",
       "height": null,
@@ -12152,11 +11568,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 24.8,
-      "goatRecentRank": 283
+      "goatRecentRank": 281
     },
     {
       "id": "markus-howard-1630210",
       "name": "Markus Howard",
+      "personId": "1630210",
       "team": "Denver Nuggets",
       "position": "G",
       "height": "5'10\"",
@@ -12185,80 +11602,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 538
-    },
-    {
-      "id": "marques-bolden-1629716",
-      "name": "Marques Bolden",
-      "team": "Free Agent",
-      "position": "C",
-      "height": "6'10\"",
-      "weight": "249 lbs",
-      "born": "April 17, 1998 · USA",
-      "origin": "USA",
-      "draft": "2019 NBA Draft",
-      "era": "2010s",
-      "archetype": "Modern center",
-      "goatScore": 4.7,
-      "goatRank": 3297,
-      "goatTier": "Reserve",
-      "goatResume": "109 pts · 8 ast · 84 reb in 63 games",
-      "bio": "Marques Bolden is a center currently available in free agency. They hail from USA. Marques entered the league in the 2019 NBA Draft NBA Draft.",
-      "keywords": [
-        "1629716",
-        "agent",
-        "bolden",
-        "c",
-        "center",
-        "free",
-        "free agent",
-        "goat",
-        "marques",
-        "reserve",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 9.8,
-      "goatRecentRank": 393
-    },
-    {
-      "id": "marquese-chriss-1627737",
-      "name": "Marquese Chriss",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'9\"",
-      "weight": "240 lbs",
-      "born": "July 2, 1997 · Sacramento, California",
-      "origin": "Sacramento, California",
-      "draft": "2016 · Pick 8 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 14.1,
-      "goatRank": 1410,
-      "goatTier": "Rotation",
-      "goatResume": "2,427 pts · 331 ast · 1,510 reb in 379 games",
-      "bio": "Marquese Chriss is a forward currently available in free agency. They hail from Sacramento, California. Marquese entered the league in the 2016 NBA Draft.",
-      "keywords": [
-        "1627737",
-        "agent",
-        "california",
-        "chriss",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "marquese",
-        "rotation",
-        "sacramento"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 500
+      "goatRecentRank": 431
     },
     {
       "id": "marvin-bagley-iii-1628963",
       "name": "Marvin Bagley III",
+      "personId": "1628963",
       "team": "Sacramento Kings",
       "position": "F",
       "height": "6'10\"",
@@ -12289,42 +11638,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 31.8,
-      "goatRecentRank": 237
-    },
-    {
-      "id": "mason-jones-1630222",
-      "name": "Mason Jones",
-      "team": "Free Agent",
-      "position": null,
-      "height": null,
-      "weight": null,
-      "born": null,
-      "origin": null,
-      "draft": null,
-      "era": "2020s",
-      "archetype": "Versatile playmaker",
-      "goatScore": 3.4,
-      "goatRank": 4011,
-      "goatTier": "Reserve",
-      "goatResume": "253 pts · 70 ast · 98 reb in 114 games",
-      "bio": "Mason Jones is a multi-skilled player currently available in free agency. Draft details for Mason are currently unavailable.",
-      "keywords": [
-        "1630222",
-        "agent",
-        "free",
-        "free agent",
-        "goat",
-        "jones",
-        "mason",
-        "reserve"
-      ],
-      "metrics": {},
-      "goatRecentScore": 11.5,
-      "goatRecentRank": 384
+      "goatRecentRank": 236
     },
     {
       "id": "mason-plumlee-203486",
       "name": "Mason Plumlee",
+      "personId": "203486",
       "team": "Detroit Pistons",
       "position": "C",
       "height": null,
@@ -12359,6 +11678,7 @@
     {
       "id": "matisse-thybulle-1629680",
       "name": "Matisse Thybulle",
+      "personId": "1629680",
       "team": "Philadelphia 76ers",
       "position": "G / F",
       "height": "6'5\"",
@@ -12390,11 +11710,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 33.0,
-      "goatRecentRank": 230
+      "goatRecentRank": 229
     },
     {
       "id": "matt-thomas-1629744",
       "name": "Matt Thomas",
+      "personId": "1629744",
       "team": "Utah Jazz",
       "position": "G",
       "height": "6'3\"",
@@ -12424,11 +11745,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 443
+      "goatRecentRank": 482
     },
     {
       "id": "matthew-dellavedova-203521",
       "name": "Matthew Dellavedova",
+      "personId": "203521",
       "team": "Cleveland Cavaliers",
       "position": "G",
       "height": "6'3\"",
@@ -12458,11 +11780,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.3,
-      "goatRecentRank": 325
+      "goatRecentRank": 320
     },
     {
       "id": "maurice-harkless-203090",
       "name": "Maurice Harkless",
+      "personId": "203090",
       "team": "Sacramento Kings",
       "position": "G / F",
       "height": "6'7\"",
@@ -12494,11 +11817,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 484
+      "goatRecentRank": 458
     },
     {
       "id": "max-strus-1629622",
       "name": "Max Strus",
+      "personId": "1629622",
       "team": "Miami Heat",
       "position": null,
       "height": null,
@@ -12531,6 +11855,7 @@
     {
       "id": "maxi-kleber-1628467",
       "name": "Maxi Kleber",
+      "personId": "1628467",
       "team": "Dallas Mavericks",
       "position": null,
       "height": null,
@@ -12558,48 +11883,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 28.0,
-      "goatRecentRank": 257
-    },
-    {
-      "id": "meyers-leonard-203086",
-      "name": "Meyers Leonard",
-      "team": "Free Agent",
-      "position": "F / C",
-      "height": "7'0\"",
-      "weight": "260 lbs",
-      "born": "February 27, 1992 · Woodbridge, Virginia",
-      "origin": "Woodbridge, Virginia",
-      "draft": "2012 · Pick 11 (1st round)",
-      "era": "2010s",
-      "archetype": "Hybrid forward-center",
-      "goatScore": 15.8,
-      "goatRank": 1237,
-      "goatTier": "Starter",
-      "goatResume": "3,020 pts · 460 ast · 2,068 reb in 737 games",
-      "bio": "Meyers Leonard is a forward-center currently available in free agency. They hail from Woodbridge, Virginia. Meyers entered the league in the 2012 NBA Draft.",
-      "keywords": [
-        "203086",
-        "agent",
-        "c",
-        "center",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "leonard",
-        "meyers",
-        "starter",
-        "virginia",
-        "woodbridge"
-      ],
-      "metrics": {},
-      "goatRecentScore": 16.2,
-      "goatRecentRank": 355
+      "goatRecentRank": 256
     },
     {
       "id": "mfiondu-kabengele-1629662",
       "name": "Mfiondu Kabengele",
+      "personId": "1629662",
       "team": "Cleveland Cavaliers",
       "position": "C",
       "height": "6'10\"",
@@ -12629,11 +11918,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.1,
-      "goatRecentRank": 357
+      "goatRecentRank": 350
     },
     {
       "id": "michael-carter-williams-203487",
       "name": "Michael Carter-Williams",
+      "personId": "203487",
       "team": "Orlando Magic",
       "position": "G",
       "height": "6'5\"",
@@ -12663,11 +11953,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 6.4,
-      "goatRecentRank": 407
+      "goatRecentRank": 394
     },
     {
       "id": "michael-porter-jr-1629008",
       "name": "Michael Porter Jr.",
+      "personId": "1629008",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -12701,6 +11992,7 @@
     {
       "id": "mikal-bridges-1628969",
       "name": "Mikal Bridges",
+      "personId": "1628969",
       "team": "Phoenix Suns",
       "position": null,
       "height": null,
@@ -12733,6 +12025,7 @@
     {
       "id": "mike-conley-201144",
       "name": "Mike Conley",
+      "personId": "201144",
       "team": "Utah Jazz",
       "position": null,
       "height": null,
@@ -12765,6 +12058,7 @@
     {
       "id": "mike-james-1628455",
       "name": "Mike James",
+      "personId": "1628455",
       "team": "Brooklyn Nets",
       "position": "G",
       "height": "6'1\"",
@@ -12793,11 +12087,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 423
+      "goatRecentRank": 444
     },
     {
       "id": "mike-muscala-203488",
       "name": "Mike Muscala",
+      "personId": "203488",
       "team": "Oklahoma City Thunder",
       "position": "F / C",
       "height": "6'11\"",
@@ -12830,11 +12125,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.0,
-      "goatRecentRank": 254
+      "goatRecentRank": 253
     },
     {
       "id": "mike-scott-203118",
       "name": "Mike Scott",
+      "personId": "203118",
       "team": "Philadelphia 76ers",
       "position": "F",
       "height": "6'7\"",
@@ -12864,11 +12160,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 429
+      "goatRecentRank": 425
     },
     {
       "id": "miles-bridges-1628970",
       "name": "Miles Bridges",
+      "personId": "1628970",
       "team": "Charlotte Hornets",
       "position": null,
       "height": null,
@@ -12896,11 +12193,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 34.1,
-      "goatRecentRank": 224
+      "goatRecentRank": 223
     },
     {
       "id": "mitchell-robinson-1629011",
       "name": "Mitchell Robinson",
+      "personId": "1629011",
       "team": "New York Knicks",
       "position": "F / C",
       "height": "7'0\"",
@@ -12938,6 +12236,7 @@
     {
       "id": "miye-oni-1629671",
       "name": "Miye Oni",
+      "personId": "1629671",
       "team": "Utah Jazz",
       "position": "G / F",
       "height": "6'5\"",
@@ -12968,11 +12267,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 12.0,
-      "goatRecentRank": 381
+      "goatRecentRank": 372
     },
     {
       "id": "mo-bamba-1628964",
       "name": "Mo Bamba",
+      "personId": "1628964",
       "team": "Orlando Magic",
       "position": "C",
       "height": null,
@@ -13000,11 +12300,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 42.4,
-      "goatRecentRank": 178
+      "goatRecentRank": 177
     },
     {
       "id": "monte-morris-1628420",
       "name": "Monte Morris",
+      "personId": "1628420",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -13032,11 +12333,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 39.2,
-      "goatRecentRank": 201
+      "goatRecentRank": 200
     },
     {
       "id": "montrezl-harrell-1626149",
       "name": "Montrezl Harrell",
+      "personId": "1626149",
       "team": "Los Angeles Lakers",
       "position": "F / C",
       "height": "6'7\"",
@@ -13069,11 +12371,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.3,
-      "goatRecentRank": 265
+      "goatRecentRank": 264
     },
     {
       "id": "moritz-wagner-1629021",
       "name": "Moritz Wagner",
+      "personId": "1629021",
       "team": "Orlando Magic",
       "position": "F / C",
       "height": "6'11\"",
@@ -13110,6 +12413,7 @@
     {
       "id": "moses-brown-1629650",
       "name": "Moses Brown",
+      "personId": "1629650",
       "team": "Oklahoma City Thunder",
       "position": "C",
       "height": "7'2\"",
@@ -13140,11 +12444,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.4,
-      "goatRecentRank": 276
+      "goatRecentRank": 274
     },
     {
       "id": "mychal-mulder-1628539",
       "name": "Mychal Mulder",
+      "personId": "1628539",
       "team": "Golden State Warriors",
       "position": "G",
       "height": "6'3\"",
@@ -13174,11 +12479,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 7.8,
-      "goatRecentRank": 398
+      "goatRecentRank": 387
     },
     {
       "id": "myles-turner-1626167",
       "name": "Myles Turner",
+      "personId": "1626167",
       "team": "Indiana Pacers",
       "position": null,
       "height": null,
@@ -13211,6 +12517,7 @@
     {
       "id": "naji-marshall-1630230",
       "name": "Naji Marshall",
+      "personId": "1630230",
       "team": "New Orleans Pelicans",
       "position": "F",
       "height": "6'7\"",
@@ -13245,6 +12552,7 @@
     {
       "id": "nassir-little-1629642",
       "name": "Nassir Little",
+      "personId": "1629642",
       "team": "Portland Trail Blazers",
       "position": "G / F",
       "height": "6'5\"",
@@ -13277,11 +12585,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 26.7,
-      "goatRecentRank": 271
+      "goatRecentRank": 270
     },
     {
       "id": "nate-darling-1630268",
       "name": "Nate Darling",
+      "personId": "1630268",
       "team": "Charlotte Hornets",
       "position": null,
       "height": null,
@@ -13307,11 +12616,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 8.2,
-      "goatRecentRank": 396
+      "goatRecentRank": 385
     },
     {
       "id": "nate-hinton-1630207",
       "name": "Nate Hinton",
+      "personId": "1630207",
       "team": "Dallas Mavericks",
       "position": "G / F",
       "height": "6'5\"",
@@ -13342,11 +12652,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.5,
-      "goatRecentRank": 354
+      "goatRecentRank": 348
     },
     {
       "id": "nathan-knight-1630233",
       "name": "Nathan Knight",
+      "personId": "1630233",
       "team": "Atlanta Hawks",
       "position": "F / C",
       "height": "6'8\"",
@@ -13377,11 +12688,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.7,
-      "goatRecentRank": 323
+      "goatRecentRank": 318
     },
     {
       "id": "naz-reid-1629675",
       "name": "Naz Reid",
+      "personId": "1629675",
       "team": "Minnesota Timberwolves",
       "position": null,
       "height": null,
@@ -13414,6 +12726,7 @@
     {
       "id": "nemanja-bjelica-202357",
       "name": "Nemanja Bjelica",
+      "personId": "202357",
       "team": "Miami Heat",
       "position": "F",
       "height": "6'9\"",
@@ -13443,11 +12756,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 525
+      "goatRecentRank": 474
     },
     {
       "id": "nerlens-noel-203457",
       "name": "Nerlens Noel",
+      "personId": "203457",
       "team": "New York Knicks",
       "position": "F / C",
       "height": "6'10\"",
@@ -13480,11 +12794,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 7.1,
-      "goatRecentRank": 403
+      "goatRecentRank": 392
     },
     {
       "id": "nic-claxton-1629651",
       "name": "Nic Claxton",
+      "personId": "1629651",
       "team": "Brooklyn Nets",
       "position": null,
       "height": null,
@@ -13517,6 +12832,7 @@
     {
       "id": "nick-richards-1630208",
       "name": "Nick Richards",
+      "personId": "1630208",
       "team": "Charlotte Hornets",
       "position": null,
       "height": null,
@@ -13547,6 +12863,7 @@
     {
       "id": "nickeil-alexander-walker-1629638",
       "name": "Nickeil Alexander-Walker",
+      "personId": "1629638",
       "team": "New Orleans Pelicans",
       "position": "G",
       "height": null,
@@ -13582,6 +12899,7 @@
     {
       "id": "nico-mannion-1630185",
       "name": "Nico Mannion",
+      "personId": "1630185",
       "team": "Golden State Warriors",
       "position": "G",
       "height": "6'2\"",
@@ -13611,11 +12929,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 452
+      "goatRecentRank": 404
     },
     {
       "id": "nicolas-batum-201587",
       "name": "Nicolas Batum",
+      "personId": "201587",
       "team": "Los Angeles Clippers",
       "position": "F",
       "height": null,
@@ -13651,6 +12970,7 @@
     {
       "id": "nicolo-melli-1629740",
       "name": "Nicolo Melli",
+      "personId": "1629740",
       "team": "Dallas Mavericks",
       "position": "F",
       "height": "6'9\"",
@@ -13680,11 +13000,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 440
+      "goatRecentRank": 428
     },
     {
       "id": "nikola-jokic-203999",
       "name": "Nikola Jokic",
+      "personId": "203999",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -13719,6 +13040,7 @@
     {
       "id": "nikola-vucevic-202696",
       "name": "Nikola Vucevic",
+      "personId": "202696",
       "team": "Chicago Bulls",
       "position": null,
       "height": null,
@@ -13749,43 +13071,9 @@
       "goatRecentRank": 31
     },
     {
-      "id": "noah-vonleh-203943",
-      "name": "Noah Vonleh",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'10\"",
-      "weight": "257 lbs",
-      "born": "August 24, 1995 · Salem, Massachusetts",
-      "origin": "Salem, Massachusetts",
-      "draft": "2014 · Pick 9 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 12.5,
-      "goatRank": 1557,
-      "goatTier": "Rotation",
-      "goatResume": "1,871 pts · 290 ast · 2,006 reb in 538 games",
-      "bio": "Noah Vonleh is a forward currently available in free agency. They hail from Salem, Massachusetts. Noah entered the league in the 2014 NBA Draft.",
-      "keywords": [
-        "203943",
-        "agent",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "massachusetts",
-        "noah",
-        "rotation",
-        "salem",
-        "vonleh"
-      ],
-      "metrics": {},
-      "goatRecentScore": 20.7,
-      "goatRecentRank": 322
-    },
-    {
       "id": "norman-powell-1626181",
       "name": "Norman Powell",
+      "personId": "1626181",
       "team": "Portland Trail Blazers",
       "position": null,
       "height": null,
@@ -13819,6 +13107,7 @@
     {
       "id": "norvel-pelle-203658",
       "name": "Norvel Pelle",
+      "personId": "203658",
       "team": "New York Knicks",
       "position": "C",
       "height": "6'10\"",
@@ -13849,11 +13138,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 507
+      "goatRecentRank": 504
     },
     {
       "id": "obi-toppin-1630167",
       "name": "Obi Toppin",
+      "personId": "1630167",
       "team": "New York Knicks",
       "position": "F",
       "height": null,
@@ -13887,6 +13177,7 @@
     {
       "id": "og-anunoby-1628384",
       "name": "OG Anunoby",
+      "personId": "1628384",
       "team": "Toronto Raptors",
       "position": null,
       "height": null,
@@ -13919,6 +13210,7 @@
     {
       "id": "omer-yurtseven-1630209",
       "name": "Omer Yurtseven",
+      "personId": "1630209",
       "team": "Miami Heat",
       "position": "C",
       "height": "6'11\"",
@@ -13947,11 +13239,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 21.1,
-      "goatRecentRank": 318
+      "goatRecentRank": 314
     },
     {
       "id": "onyeka-okongwu-1630168",
       "name": "Onyeka Okongwu",
+      "personId": "1630168",
       "team": "Atlanta Hawks",
       "position": null,
       "height": null,
@@ -13982,6 +13275,7 @@
     {
       "id": "oshae-brissett-1629052",
       "name": "Oshae Brissett",
+      "personId": "1629052",
       "team": "Indiana Pacers",
       "position": "G / F",
       "height": "6'7\"",
@@ -14012,11 +13306,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 36.2,
-      "goatRecentRank": 217
+      "goatRecentRank": 216
     },
     {
       "id": "otto-porter-jr-203490",
       "name": "Otto Porter Jr.",
+      "personId": "203490",
       "team": "Orlando Magic",
       "position": "F",
       "height": "6'8\"",
@@ -14046,11 +13341,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 14.1,
-      "goatRecentRank": 369
+      "goatRecentRank": 361
     },
     {
       "id": "p-j-tucker-200782",
       "name": "P.J. Tucker",
+      "personId": "200782",
       "team": "Milwaukee Bucks",
       "position": "F",
       "height": null,
@@ -14080,11 +13376,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 24.8,
-      "goatRecentRank": 284
+      "goatRecentRank": 282
     },
     {
       "id": "p-j-washington-1629023",
       "name": "P.J. Washington",
+      "personId": "1629023",
       "team": "Charlotte Hornets",
       "position": null,
       "height": null,
@@ -14115,6 +13412,7 @@
     {
       "id": "pascal-siakam-1627783",
       "name": "Pascal Siakam",
+      "personId": "1627783",
       "team": "Toronto Raptors",
       "position": null,
       "height": null,
@@ -14147,6 +13445,7 @@
     {
       "id": "pat-connaughton-1626192",
       "name": "Pat Connaughton",
+      "personId": "1626192",
       "team": "Milwaukee Bucks",
       "position": "F",
       "height": null,
@@ -14176,11 +13475,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.4,
-      "goatRecentRank": 185
+      "goatRecentRank": 184
     },
     {
       "id": "patrick-beverley-201976",
       "name": "Patrick Beverley",
+      "personId": "201976",
       "team": "Los Angeles Clippers",
       "position": "G",
       "height": "6'2\"",
@@ -14211,46 +13511,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 35.2,
-      "goatRecentRank": 222
-    },
-    {
-      "id": "patrick-mccaw-1627775",
-      "name": "Patrick McCaw",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'7\"",
-      "weight": "181 lbs",
-      "born": "October 25, 1995 · St. Louis, Missouri",
-      "origin": "St. Louis, Missouri",
-      "draft": "2016 · Pick 38 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 12.2,
-      "goatRank": 1611,
-      "goatTier": "Rotation",
-      "goatResume": "921 pts · 314 ast · 382 reb in 285 games",
-      "bio": "Patrick McCaw is a guard currently available in free agency. They hail from St. Louis, Missouri. Patrick entered the league in the 2016 NBA Draft.",
-      "keywords": [
-        "1627775",
-        "agent",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "mccaw",
-        "missouri",
-        "patrick",
-        "rotation",
-        "st. louis"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 514
+      "goatRecentRank": 221
     },
     {
       "id": "patrick-patterson-202335",
       "name": "Patrick Patterson",
+      "personId": "202335",
       "team": "Los Angeles Clippers",
       "position": "F",
       "height": "6'8\"",
@@ -14281,11 +13547,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 439
+      "goatRecentRank": 495
     },
     {
       "id": "patrick-williams-1630172",
       "name": "Patrick Williams",
+      "personId": "1630172",
       "team": "Chicago Bulls",
       "position": null,
       "height": null,
@@ -14311,11 +13578,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 41.2,
-      "goatRecentRank": 187
+      "goatRecentRank": 186
     },
     {
       "id": "patty-mills-201988",
       "name": "Patty Mills",
+      "personId": "201988",
       "team": "San Antonio Spurs",
       "position": null,
       "height": null,
@@ -14344,11 +13612,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.5,
-      "goatRecentRank": 275
+      "goatRecentRank": 273
     },
     {
       "id": "paul-george-202331",
       "name": "Paul George",
+      "personId": "202331",
       "team": "Los Angeles Clippers",
       "position": null,
       "height": null,
@@ -14382,6 +13651,7 @@
     {
       "id": "paul-millsap-200794",
       "name": "Paul Millsap",
+      "personId": "200794",
       "team": "Denver Nuggets",
       "position": "F",
       "height": "6'7\"",
@@ -14411,11 +13681,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 493
+      "goatRecentRank": 440
     },
     {
       "id": "paul-reed-1630194",
       "name": "Paul Reed",
+      "personId": "1630194",
       "team": "Philadelphia 76ers",
       "position": null,
       "height": null,
@@ -14446,6 +13717,7 @@
     {
       "id": "paul-watson-1628778",
       "name": "Paul Watson",
+      "personId": "1628778",
       "team": "Toronto Raptors",
       "position": "G",
       "height": "6'6\"",
@@ -14475,11 +13747,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 532
+      "goatRecentRank": 447
     },
     {
       "id": "payton-pritchard-1630202",
       "name": "Payton Pritchard",
+      "personId": "1630202",
       "team": "Boston Celtics",
       "position": "G",
       "height": null,
@@ -14512,6 +13785,7 @@
     {
       "id": "pj-dozier-1628408",
       "name": "PJ Dozier",
+      "personId": "1628408",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -14539,11 +13813,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.3,
-      "goatRecentRank": 338
+      "goatRecentRank": 332
     },
     {
       "id": "precious-achiuwa-1630173",
       "name": "Precious Achiuwa",
+      "personId": "1630173",
       "team": "Miami Heat",
       "position": "F",
       "height": null,
@@ -14574,43 +13849,9 @@
       "goatRecentRank": 104
     },
     {
-      "id": "quinn-cook-1626188",
-      "name": "Quinn Cook",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'1\"",
-      "weight": "180 lbs",
-      "born": "March 23, 1993 · Washington, D.C.",
-      "origin": "Washington, D.C.",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern guard",
-      "goatScore": 14.3,
-      "goatRank": 1391,
-      "goatTier": "Rotation",
-      "goatResume": "1,571 pts · 389 ast · 399 reb in 349 games",
-      "bio": "Quinn Cook is a guard currently available in free agency. They hail from Washington, D.C.. Quinn entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1626188",
-        "agent",
-        "cook",
-        "d.c.",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "quinn",
-        "rotation",
-        "washington"
-      ],
-      "metrics": {},
-      "goatRecentScore": 25.8,
-      "goatRecentRank": 273
-    },
-    {
       "id": "quinndary-weatherspoon-1629683",
       "name": "Quinndary Weatherspoon",
+      "personId": "1629683",
       "team": "San Antonio Spurs",
       "position": "G",
       "height": "6'3\"",
@@ -14641,11 +13882,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 19.8,
-      "goatRecentRank": 331
+      "goatRecentRank": 325
     },
     {
       "id": "r-j-hampton-1630181",
       "name": "R.J. Hampton",
+      "personId": "1630181",
       "team": "Orlando Magic",
       "position": "G",
       "height": "6'4\"",
@@ -14674,11 +13916,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 15.0,
-      "goatRecentRank": 366
+      "goatRecentRank": 358
     },
     {
       "id": "rajon-rondo-200765",
       "name": "Rajon Rondo",
+      "personId": "200765",
       "team": "Los Angeles Clippers",
       "position": "G",
       "height": "6'1\"",
@@ -14711,11 +13954,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 419
+      "goatRecentRank": 429
     },
     {
       "id": "raul-neto-203526",
       "name": "Raul Neto",
+      "personId": "203526",
       "team": "Washington Wizards",
       "position": "G",
       "height": "6'2\"",
@@ -14745,45 +13989,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 22.3,
-      "goatRecentRank": 313
-    },
-    {
-      "id": "ray-spalding-1629034",
-      "name": "Ray Spalding",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'9\"",
-      "weight": "225 lbs",
-      "born": "March 11, 1997 · USA",
-      "origin": "USA",
-      "draft": "2018 · Pick 56 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 4.7,
-      "goatRank": 3280,
-      "goatTier": "Reserve",
-      "goatResume": "66 pts · 5 ast · 55 reb in 36 games",
-      "bio": "Ray Spalding is a forward currently available in free agency. They hail from USA. Ray entered the league in the 2018 NBA Draft.",
-      "keywords": [
-        "1629034",
-        "agent",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "ray",
-        "reserve",
-        "spalding",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 471
+      "goatRecentRank": 309
     },
     {
       "id": "rayjon-tucker-1629730",
       "name": "Rayjon Tucker",
+      "personId": "1629730",
       "team": "Philadelphia 76ers",
       "position": "G",
       "height": "6'3\"",
@@ -14812,11 +14023,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 519
+      "goatRecentRank": 410
     },
     {
       "id": "reggie-bullock-203493",
       "name": "Reggie Bullock",
+      "personId": "203493",
       "team": "New York Knicks",
       "position": "G / F",
       "height": "6'6\"",
@@ -14849,11 +14061,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 24.9,
-      "goatRecentRank": 282
+      "goatRecentRank": 280
     },
     {
       "id": "reggie-jackson-202704",
       "name": "Reggie Jackson",
+      "personId": "202704",
       "team": "Los Angeles Clippers",
       "position": null,
       "height": null,
@@ -14887,6 +14100,7 @@
     {
       "id": "reggie-perry-1629617",
       "name": "Reggie Perry",
+      "personId": "1629617",
       "team": "Brooklyn Nets",
       "position": "F / C",
       "height": "6'8\"",
@@ -14917,11 +14131,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 451
+      "goatRecentRank": 443
     },
     {
       "id": "richaun-holmes-1626158",
       "name": "Richaun Holmes",
+      "personId": "1626158",
       "team": "Sacramento Kings",
       "position": "C",
       "height": null,
@@ -14951,11 +14166,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 31.6,
-      "goatRecentRank": 238
+      "goatRecentRank": 237
     },
     {
       "id": "ricky-rubio-201937",
       "name": "Ricky Rubio",
+      "personId": "201937",
       "team": "Minnesota Timberwolves",
       "position": "G",
       "height": "6'2\"",
@@ -14985,11 +14201,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 21.6,
-      "goatRecentRank": 314
+      "goatRecentRank": 310
     },
     {
       "id": "rj-barrett-1629628",
       "name": "RJ Barrett",
+      "personId": "1629628",
       "team": "New York Knicks",
       "position": null,
       "height": null,
@@ -15023,6 +14240,7 @@
     {
       "id": "robert-covington-203496",
       "name": "Robert Covington",
+      "personId": "203496",
       "team": "Portland Trail Blazers",
       "position": "F",
       "height": "6'7\"",
@@ -15053,43 +14271,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.7,
-      "goatRecentRank": 259
-    },
-    {
-      "id": "robert-franks-1629606",
-      "name": "Robert Franks",
-      "team": "Free Agent",
-      "position": null,
-      "height": "6'7\"",
-      "weight": "1629606 lbs",
-      "born": "December 18, 1996 · USA",
-      "origin": "USA",
-      "draft": "-22 · Pick -22 (-22th round)",
-      "era": "-30s",
-      "archetype": "Versatile playmaker",
-      "goatScore": 2.4,
-      "goatRank": 4710,
-      "goatTier": "Reserve",
-      "goatResume": "57 pts · 5 ast · 16 reb in 17 games",
-      "bio": "Robert Franks is a multi-skilled player currently available in free agency. They hail from USA. Robert entered the league in the -22 NBA Draft.",
-      "keywords": [
-        "1629606",
-        "agent",
-        "franks",
-        "free",
-        "free agent",
-        "goat",
-        "reserve",
-        "robert",
-        "usa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 417
+      "goatRecentRank": 258
     },
     {
       "id": "robert-williams-iii-1629057",
       "name": "Robert Williams III",
+      "personId": "1629057",
       "team": "Boston Celtics",
       "position": null,
       "height": null,
@@ -15116,11 +14303,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 30.0,
-      "goatRecentRank": 243
+      "goatRecentRank": 242
     },
     {
       "id": "robert-woodard-ii-1630218",
       "name": "Robert Woodard II",
+      "personId": "1630218",
       "team": "Sacramento Kings",
       "position": "F",
       "height": "6'6\"",
@@ -15150,11 +14338,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.2,
-      "goatRecentRank": 415
+      "goatRecentRank": 401
     },
     {
       "id": "robin-lopez-201577",
       "name": "Robin Lopez",
+      "personId": "201577",
       "team": "Washington Wizards",
       "position": "C",
       "height": "7'0\"",
@@ -15184,45 +14373,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.4,
-      "goatRecentRank": 299
-    },
-    {
-      "id": "rodions-kurucs-1629066",
-      "name": "Rodions Kurucs",
-      "team": "Free Agent",
-      "position": "F",
-      "height": "6'9\"",
-      "weight": "228 lbs",
-      "born": "February 5, 1998 · Latvia",
-      "origin": "Latvia",
-      "draft": "2018 · Pick 40 (2nd round)",
-      "era": "2010s",
-      "archetype": "Modern forward",
-      "goatScore": 7.2,
-      "goatRank": 2422,
-      "goatTier": "Rotation",
-      "goatResume": "908 pts · 127 ast · 487 reb in 214 games",
-      "bio": "Rodions Kurucs is a forward currently available in free agency. They hail from Latvia. Rodions entered the league in the 2018 NBA Draft.",
-      "keywords": [
-        "1629066",
-        "agent",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "kurucs",
-        "latvia",
-        "rodions",
-        "rotation"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 541
+      "goatRecentRank": 297
     },
     {
       "id": "rodney-hood-203918",
       "name": "Rodney Hood",
+      "personId": "203918",
       "team": "Toronto Raptors",
       "position": "G / F",
       "height": "6'8\"",
@@ -15254,11 +14410,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 482
+      "goatRecentRank": 503
     },
     {
       "id": "rodney-mcgruder-203585",
       "name": "Rodney McGruder",
+      "personId": "203585",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'4\"",
@@ -15288,11 +14445,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 7.3,
-      "goatRecentRank": 401
+      "goatRecentRank": 390
     },
     {
       "id": "romeo-langford-1629641",
       "name": "Romeo Langford",
+      "personId": "1629641",
       "team": "Boston Celtics",
       "position": "G / F",
       "height": "6'5\"",
@@ -15324,11 +14482,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 13.2,
-      "goatRecentRank": 376
+      "goatRecentRank": 367
     },
     {
       "id": "rondae-hollis-jefferson-1626178",
       "name": "Rondae Hollis-Jefferson",
+      "personId": "1626178",
       "team": "Portland Trail Blazers",
       "position": "F",
       "height": "6'6\"",
@@ -15359,11 +14518,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 425
+      "goatRecentRank": 424
     },
     {
       "id": "royce-o-neale-1626220",
       "name": "Royce O'Neale",
+      "personId": "1626220",
       "team": "Utah Jazz",
       "position": "F",
       "height": null,
@@ -15398,6 +14558,7 @@
     {
       "id": "rudy-gay-200752",
       "name": "Rudy Gay",
+      "personId": "200752",
       "team": "San Antonio Spurs",
       "position": "G / F",
       "height": "6'8\"",
@@ -15430,11 +14591,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 21.5,
-      "goatRecentRank": 315
+      "goatRecentRank": 311
     },
     {
       "id": "rudy-gobert-203497",
       "name": "Rudy Gobert",
+      "personId": "203497",
       "team": "Utah Jazz",
       "position": null,
       "height": null,
@@ -15467,6 +14629,7 @@
     {
       "id": "rui-hachimura-1629060",
       "name": "Rui Hachimura",
+      "personId": "1629060",
       "team": "Washington Wizards",
       "position": null,
       "height": null,
@@ -15499,6 +14662,7 @@
     {
       "id": "russell-westbrook-201566",
       "name": "Russell Westbrook",
+      "personId": "201566",
       "team": "Washington Wizards",
       "position": "G",
       "height": null,
@@ -15535,6 +14699,7 @@
     {
       "id": "ryan-arcidiacono-1627853",
       "name": "Ryan Arcidiacono",
+      "personId": "1627853",
       "team": "Chicago Bulls",
       "position": "G",
       "height": "6'3\"",
@@ -15563,11 +14728,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.1,
-      "goatRecentRank": 341
+      "goatRecentRank": 335
     },
     {
       "id": "saben-lee-1630240",
       "name": "Saben Lee",
+      "personId": "1630240",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'2\"",
@@ -15596,11 +14762,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.2,
-      "goatRecentRank": 277
+      "goatRecentRank": 275
     },
     {
       "id": "saddiq-bey-1630180",
       "name": "Saddiq Bey",
+      "personId": "1630180",
       "team": "Detroit Pistons",
       "position": "F",
       "height": "6'7\"",
@@ -15629,11 +14796,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 33.1,
-      "goatRecentRank": 229
+      "goatRecentRank": 228
     },
     {
       "id": "sam-merrill-1630241",
       "name": "Sam Merrill",
+      "personId": "1630241",
       "team": "Milwaukee Bucks",
       "position": "G",
       "height": null,
@@ -15661,11 +14829,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 39.5,
-      "goatRecentRank": 199
+      "goatRecentRank": 198
     },
     {
       "id": "sean-mcdermott-1630253",
       "name": "Sean McDermott",
+      "personId": "1630253",
       "team": "Memphis Grizzlies",
       "position": "F",
       "height": "6'6\"",
@@ -15694,11 +14863,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 485
+      "goatRecentRank": 472
     },
     {
       "id": "sekou-doumbouya-1629635",
       "name": "Sekou Doumbouya",
+      "personId": "1629635",
       "team": "Detroit Pistons",
       "position": "F",
       "height": "6'9\"",
@@ -15728,11 +14898,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 499
+      "goatRecentRank": 467
     },
     {
       "id": "semi-ojeleye-1628400",
       "name": "Semi Ojeleye",
+      "personId": "1628400",
       "team": "Boston Celtics",
       "position": "F",
       "height": "6'6\"",
@@ -15762,11 +14933,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 465
+      "goatRecentRank": 415
     },
     {
       "id": "serge-ibaka-201586",
       "name": "Serge Ibaka",
+      "personId": "201586",
       "team": "Los Angeles Clippers",
       "position": null,
       "height": "6'11\"",
@@ -15795,11 +14967,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.0,
-      "goatRecentRank": 359
+      "goatRecentRank": 352
     },
     {
       "id": "seth-curry-203552",
       "name": "Seth Curry",
+      "personId": "203552",
       "team": "Philadelphia 76ers",
       "position": "G",
       "height": null,
@@ -15829,11 +15002,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 35.7,
-      "goatRecentRank": 220
+      "goatRecentRank": 219
     },
     {
       "id": "shai-gilgeous-alexander-1628983",
       "name": "Shai Gilgeous-Alexander",
+      "personId": "1628983",
       "team": "Oklahoma City Thunder",
       "position": null,
       "height": null,
@@ -15867,6 +15041,7 @@
     {
       "id": "shake-milton-1629003",
       "name": "Shake Milton",
+      "personId": "1629003",
       "team": "Philadelphia 76ers",
       "position": "G",
       "height": null,
@@ -15901,6 +15076,7 @@
     {
       "id": "shaquille-harrison-1627885",
       "name": "Shaquille Harrison",
+      "personId": "1627885",
       "team": "Denver Nuggets",
       "position": "G",
       "height": "6'4\"",
@@ -15930,11 +15106,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 11.2,
-      "goatRecentRank": 386
+      "goatRecentRank": 376
     },
     {
       "id": "sindarius-thornwell-1628414",
       "name": "Sindarius Thornwell",
+      "personId": "1628414",
       "team": "Orlando Magic",
       "position": "G",
       "height": "6'4\"",
@@ -15964,11 +15141,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 449
+      "goatRecentRank": 405
     },
     {
       "id": "skylar-mays-1630219",
       "name": "Skylar Mays",
+      "personId": "1630219",
       "team": "Atlanta Hawks",
       "position": null,
       "height": null,
@@ -15994,11 +15172,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 16.1,
-      "goatRecentRank": 356
+      "goatRecentRank": 349
     },
     {
       "id": "solomon-hill-203524",
       "name": "Solomon Hill",
+      "personId": "203524",
       "team": "Atlanta Hawks",
       "position": "F",
       "height": "6'6\"",
@@ -16028,11 +15207,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 430
+      "goatRecentRank": 479
     },
     {
       "id": "spencer-dinwiddie-203915",
       "name": "Spencer Dinwiddie",
+      "personId": "203915",
       "team": "Brooklyn Nets",
       "position": "G",
       "height": null,
@@ -16067,6 +15247,7 @@
     {
       "id": "stanley-johnson-1626169",
       "name": "Stanley Johnson",
+      "personId": "1626169",
       "team": "Toronto Raptors",
       "position": null,
       "height": "6'6\"",
@@ -16094,11 +15275,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 10.2,
-      "goatRecentRank": 391
+      "goatRecentRank": 381
     },
     {
       "id": "stephen-curry-201939",
       "name": "Stephen Curry",
+      "personId": "201939",
       "team": "Golden State Warriors",
       "position": null,
       "height": null,
@@ -16134,6 +15316,7 @@
     {
       "id": "sterling-brown-1628425",
       "name": "Sterling Brown",
+      "personId": "1628425",
       "team": "Houston Rockets",
       "position": "G / F",
       "height": "6'5\"",
@@ -16165,11 +15348,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 12.1,
-      "goatRecentRank": 378
+      "goatRecentRank": 369
     },
     {
       "id": "steven-adams-203500",
       "name": "Steven Adams",
+      "personId": "203500",
       "team": "New Orleans Pelicans",
       "position": "C",
       "height": null,
@@ -16200,11 +15384,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 40.2,
-      "goatRecentRank": 193
+      "goatRecentRank": 192
     },
     {
       "id": "svi-mykhailiuk-1629004",
       "name": "Svi Mykhailiuk",
+      "personId": "1629004",
       "team": "Oklahoma City Thunder",
       "position": "F",
       "height": null,
@@ -16233,11 +15418,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 30.9,
-      "goatRecentRank": 240
+      "goatRecentRank": 239
     },
     {
       "id": "t-j-leaf-1628388",
       "name": "T.J. Leaf",
+      "personId": "1628388",
       "team": "Portland Trail Blazers",
       "position": "F",
       "height": "6'10\"",
@@ -16268,11 +15454,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 476
+      "goatRecentRank": 505
     },
     {
       "id": "t-j-mcconnell-204456",
       "name": "T.J. McConnell",
+      "personId": "204456",
       "team": "Indiana Pacers",
       "position": "G",
       "height": null,
@@ -16305,6 +15492,7 @@
     {
       "id": "t-j-warren-203933",
       "name": "T.J. Warren",
+      "personId": "203933",
       "team": "Indiana Pacers",
       "position": "F",
       "height": "6'8\"",
@@ -16334,11 +15522,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.8,
-      "goatRecentRank": 274
+      "goatRecentRank": 272
     },
     {
       "id": "tacko-fall-1629605",
       "name": "Tacko Fall",
+      "personId": "1629605",
       "team": "Boston Celtics",
       "position": "C",
       "height": "7'6\"",
@@ -16368,11 +15557,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 474
+      "goatRecentRank": 420
     },
     {
       "id": "taj-gibson-201959",
       "name": "Taj Gibson",
+      "personId": "201959",
       "team": "New York Knicks",
       "position": "C",
       "height": null,
@@ -16403,11 +15593,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.2,
-      "goatRecentRank": 279
+      "goatRecentRank": 277
     },
     {
       "id": "talen-horton-tucker-1629659",
       "name": "Talen Horton-Tucker",
+      "personId": "1629659",
       "team": "Los Angeles Lakers",
       "position": null,
       "height": null,
@@ -16441,6 +15632,7 @@
     {
       "id": "taurean-prince-1627752",
       "name": "Taurean Prince",
+      "personId": "1627752",
       "team": "Cleveland Cavaliers",
       "position": null,
       "height": null,
@@ -16473,6 +15665,7 @@
     {
       "id": "terance-mann-1629611",
       "name": "Terance Mann",
+      "personId": "1629611",
       "team": "Los Angeles Clippers",
       "position": "G",
       "height": null,
@@ -16508,6 +15701,7 @@
     {
       "id": "terence-davis-1629056",
       "name": "Terence Davis",
+      "personId": "1629056",
       "team": "Sacramento Kings",
       "position": "G",
       "height": "6'4\"",
@@ -16537,46 +15731,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 29.1,
-      "goatRecentRank": 252
-    },
-    {
-      "id": "terrance-ferguson-1628390",
-      "name": "Terrance Ferguson",
-      "team": "Free Agent",
-      "position": "G",
-      "height": "6'6\"",
-      "weight": "190 lbs",
-      "born": "May 17, 1998 · Tulsa, Oklahoma",
-      "origin": "Tulsa, Oklahoma",
-      "draft": "2017 · Pick 21 (1st round)",
-      "era": "2010s",
-      "archetype": "Modern guard",
-      "goatScore": 7.3,
-      "goatRank": 2417,
-      "goatTier": "Rotation",
-      "goatResume": "992 pts · 156 ast · 291 reb in 283 games",
-      "bio": "Terrance Ferguson is a guard currently available in free agency. They hail from Tulsa, Oklahoma. Terrance entered the league in the 2017 NBA Draft.",
-      "keywords": [
-        "1628390",
-        "agent",
-        "ferguson",
-        "free",
-        "free agent",
-        "g",
-        "goat",
-        "guard",
-        "oklahoma",
-        "rotation",
-        "terrance",
-        "tulsa"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 503
+      "goatRecentRank": 251
     },
     {
       "id": "terrence-ross-203082",
       "name": "Terrence Ross",
+      "personId": "203082",
       "team": "Orlando Magic",
       "position": "G / F",
       "height": "6'7\"",
@@ -16608,11 +15768,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.6,
-      "goatRecentRank": 324
+      "goatRecentRank": 319
     },
     {
       "id": "terry-rozier-1626179",
       "name": "Terry Rozier",
+      "personId": "1626179",
       "team": "Charlotte Hornets",
       "position": "G",
       "height": null,
@@ -16647,6 +15808,7 @@
     {
       "id": "thaddeus-young-201152",
       "name": "Thaddeus Young",
+      "personId": "201152",
       "team": "Chicago Bulls",
       "position": "F",
       "height": "6'8\"",
@@ -16676,11 +15838,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 26.6,
-      "goatRecentRank": 272
+      "goatRecentRank": 271
     },
     {
       "id": "thanasis-antetokounmpo-203648",
       "name": "Thanasis Antetokounmpo",
+      "personId": "203648",
       "team": "Milwaukee Bucks",
       "position": "F",
       "height": "6'7\"",
@@ -16710,11 +15873,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.6,
-      "goatRecentRank": 292
+      "goatRecentRank": 290
     },
     {
       "id": "theo-maledon-1630177",
       "name": "Theo Maledon",
+      "personId": "1630177",
       "team": "Oklahoma City Thunder",
       "position": "G",
       "height": "6'5\"",
@@ -16744,11 +15908,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.2,
-      "goatRecentRank": 340
+      "goatRecentRank": 334
     },
     {
       "id": "theo-pinson-1629033",
       "name": "Theo Pinson",
+      "personId": "1629033",
       "team": "New York Knicks",
       "position": "G / F",
       "height": "6'7\"",
@@ -16781,11 +15946,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 17.1,
-      "goatRecentRank": 347
+      "goatRecentRank": 341
     },
     {
       "id": "thomas-bryant-1628418",
       "name": "Thomas Bryant",
+      "personId": "1628418",
       "team": "Washington Wizards",
       "position": "C",
       "height": null,
@@ -16818,45 +15984,9 @@
       "goatRecentRank": 94
     },
     {
-      "id": "thon-maker-1627748",
-      "name": "Thon Maker",
-      "team": "Free Agent",
-      "position": "F / C",
-      "height": "7'0\"",
-      "weight": "221 lbs",
-      "born": "February 25, 1997 · Wau, Sudan",
-      "origin": "Wau, Sudan",
-      "draft": "2016 · Pick 10 (1st round)",
-      "era": "2010s",
-      "archetype": "Hybrid forward-center",
-      "goatScore": 10.5,
-      "goatRank": 1846,
-      "goatTier": "Rotation",
-      "goatResume": "1,372 pts · 198 ast · 841 reb in 356 games",
-      "bio": "Thon Maker is a forward-center currently available in free agency. They hail from Wau, Sudan. Thon entered the league in the 2016 NBA Draft.",
-      "keywords": [
-        "1627748",
-        "agent",
-        "c",
-        "center",
-        "f",
-        "forward",
-        "free",
-        "free agent",
-        "goat",
-        "maker",
-        "rotation",
-        "sudan",
-        "thon",
-        "wau"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 431
-    },
-    {
       "id": "tim-frazier-204025",
       "name": "Tim Frazier",
+      "personId": "204025",
       "team": "Memphis Grizzlies",
       "position": "G",
       "height": "6'0\"",
@@ -16885,11 +16015,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 433
+      "goatRecentRank": 464
     },
     {
       "id": "tim-hardaway-jr-203501",
       "name": "Tim Hardaway Jr.",
+      "personId": "203501",
       "team": "Dallas Mavericks",
       "position": null,
       "height": null,
@@ -16923,6 +16054,7 @@
     {
       "id": "timothe-luwawu-cabarrot-1627789",
       "name": "Timothe Luwawu-Cabarrot",
+      "personId": "1627789",
       "team": "Brooklyn Nets",
       "position": "G / F",
       "height": "6'7\"",
@@ -16954,11 +16086,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 10.6,
-      "goatRecentRank": 388
+      "goatRecentRank": 378
     },
     {
       "id": "tobias-harris-202699",
       "name": "Tobias Harris",
+      "personId": "202699",
       "team": "Philadelphia 76ers",
       "position": null,
       "height": null,
@@ -16991,6 +16124,7 @@
     {
       "id": "tomas-satoransky-203107",
       "name": "Tomas Satoransky",
+      "personId": "203107",
       "team": "Chicago Bulls",
       "position": "G",
       "height": "6'7\"",
@@ -17020,11 +16154,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 504
+      "goatRecentRank": 430
     },
     {
       "id": "tony-bradley-1628396",
       "name": "Tony Bradley",
+      "personId": "1628396",
       "team": "Oklahoma City Thunder",
       "position": "F / C",
       "height": "6'11\"",
@@ -17057,11 +16192,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 21.2,
-      "goatRecentRank": 317
+      "goatRecentRank": 313
     },
     {
       "id": "tony-snell-203503",
       "name": "Tony Snell",
+      "personId": "203503",
       "team": "Atlanta Hawks",
       "position": "G",
       "height": "6'6\"",
@@ -17091,11 +16227,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 537
+      "goatRecentRank": 470
     },
     {
       "id": "torrey-craig-1628470",
       "name": "Torrey Craig",
+      "personId": "1628470",
       "team": "Phoenix Suns",
       "position": "F",
       "height": "6'7\"",
@@ -17125,11 +16262,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 39.8,
-      "goatRecentRank": 197
+      "goatRecentRank": 196
     },
     {
       "id": "trae-young-1629027",
       "name": "Trae Young",
+      "personId": "1629027",
       "team": "Atlanta Hawks",
       "position": null,
       "height": null,
@@ -17162,6 +16300,7 @@
     {
       "id": "tre-jones-1630200",
       "name": "Tre Jones",
+      "personId": "1630200",
       "team": "San Antonio Spurs",
       "position": "G",
       "height": null,
@@ -17195,6 +16334,7 @@
     {
       "id": "tremont-waters-1629682",
       "name": "Tremont Waters",
+      "personId": "1629682",
       "team": "Boston Celtics",
       "position": "G",
       "height": "5'10\"",
@@ -17224,11 +16364,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 467
+      "goatRecentRank": 457
     },
     {
       "id": "trent-forrest-1630235",
       "name": "Trent Forrest",
+      "personId": "1630235",
       "team": "Utah Jazz",
       "position": "G",
       "height": "6'4\"",
@@ -17257,11 +16398,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.1,
-      "goatRecentRank": 328
+      "goatRecentRank": 323
     },
     {
       "id": "trevor-ariza-2772",
       "name": "Trevor Ariza",
+      "personId": "2772",
       "team": "Miami Heat",
       "position": "F",
       "height": "6'8\"",
@@ -17290,11 +16432,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 480
+      "goatRecentRank": 490
     },
     {
       "id": "trey-burke-203504",
       "name": "Trey Burke",
+      "personId": "203504",
       "team": "Dallas Mavericks",
       "position": "G",
       "height": "6'0\"",
@@ -17324,11 +16467,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 463
+      "goatRecentRank": 435
     },
     {
       "id": "trey-lyles-1626168",
       "name": "Trey Lyles",
+      "personId": "1626168",
       "team": "San Antonio Spurs",
       "position": "F",
       "height": null,
@@ -17364,6 +16508,7 @@
     {
       "id": "tristan-thompson-202684",
       "name": "Tristan Thompson",
+      "personId": "202684",
       "team": "Boston Celtics",
       "position": null,
       "height": null,
@@ -17391,11 +16536,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 32.6,
-      "goatRecentRank": 232
+      "goatRecentRank": 231
     },
     {
       "id": "troy-brown-jr-1628972",
       "name": "Troy Brown Jr.",
+      "personId": "1628972",
       "team": "Chicago Bulls",
       "position": "G / F",
       "height": "6'7\"",
@@ -17428,11 +16574,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 32.1,
-      "goatRecentRank": 234
+      "goatRecentRank": 233
     },
     {
       "id": "ty-jerome-1629660",
       "name": "Ty Jerome",
+      "personId": "1629660",
       "team": "Oklahoma City Thunder",
       "position": "G",
       "height": null,
@@ -17468,6 +16615,7 @@
     {
       "id": "ty-shon-alexander-1630234",
       "name": "Ty-Shon Alexander",
+      "personId": "1630234",
       "team": "Phoenix Suns",
       "position": "G",
       "height": "6'3\"",
@@ -17496,11 +16644,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 436
+      "goatRecentRank": 471
     },
     {
       "id": "tyler-bey-1630189",
       "name": "Tyler Bey",
+      "personId": "1630189",
       "team": "Dallas Mavericks",
       "position": "F",
       "height": "6'7\"",
@@ -17529,11 +16678,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 545
+      "goatRecentRank": 408
     },
     {
       "id": "tyler-cook-1629076",
       "name": "Tyler Cook",
+      "personId": "1629076",
       "team": "Detroit Pistons",
       "position": "F",
       "height": "6'8\"",
@@ -17562,11 +16712,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 437
+      "goatRecentRank": 451
     },
     {
       "id": "tyler-herro-1629639",
       "name": "Tyler Herro",
+      "personId": "1629639",
       "team": "Miami Heat",
       "position": null,
       "height": null,
@@ -17599,6 +16750,7 @@
     {
       "id": "tyler-johnson-204020",
       "name": "Tyler Johnson",
+      "personId": "204020",
       "team": "Brooklyn Nets",
       "position": "G",
       "height": "6'3\"",
@@ -17627,11 +16779,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 464
+      "goatRecentRank": 483
     },
     {
       "id": "tyrell-terry-1630179",
       "name": "Tyrell Terry",
+      "personId": "1630179",
       "team": "Dallas Mavericks",
       "position": "G",
       "height": "6'2\"",
@@ -17660,11 +16813,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 534
+      "goatRecentRank": 498
     },
     {
       "id": "tyrese-haliburton-1630169",
       "name": "Tyrese Haliburton",
+      "personId": "1630169",
       "team": "Sacramento Kings",
       "position": null,
       "height": null,
@@ -17695,6 +16849,7 @@
     {
       "id": "tyrese-maxey-1630178",
       "name": "Tyrese Maxey",
+      "personId": "1630178",
       "team": "Philadelphia 76ers",
       "position": null,
       "height": null,
@@ -17725,6 +16880,7 @@
     {
       "id": "tyus-jones-1626145",
       "name": "Tyus Jones",
+      "personId": "1626145",
       "team": "Memphis Grizzlies",
       "position": null,
       "height": null,
@@ -17757,6 +16913,7 @@
     {
       "id": "udoka-azubuike-1628962",
       "name": "Udoka Azubuike",
+      "personId": "1628962",
       "team": "Utah Jazz",
       "position": "F / C",
       "height": "6'11\"",
@@ -17787,11 +16944,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.4,
-      "goatRecentRank": 296
+      "goatRecentRank": 294
     },
     {
       "id": "udonis-haslem-2617",
       "name": "Udonis Haslem",
+      "personId": "2617",
       "team": "Miami Heat",
       "position": "F",
       "height": "6'7\"",
@@ -17820,11 +16978,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 15.3,
-      "goatRecentRank": 364
+      "goatRecentRank": 356
     },
     {
       "id": "vernon-carey-jr-1630176",
       "name": "Vernon Carey Jr.",
+      "personId": "1630176",
       "team": "Charlotte Hornets",
       "position": "C",
       "height": "6'10\"",
@@ -17854,11 +17013,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 18.7,
-      "goatRecentRank": 336
+      "goatRecentRank": 330
     },
     {
       "id": "victor-oladipo-203506",
       "name": "Victor Oladipo",
+      "personId": "203506",
       "team": "Miami Heat",
       "position": "G",
       "height": "6'3\"",
@@ -17888,48 +17048,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.9,
-      "goatRecentRank": 319
-    },
-    {
-      "id": "vincent-poirier-1629738",
-      "name": "Vincent Poirier",
-      "team": "Free Agent",
-      "position": "F / C",
-      "height": "7'0\"",
-      "weight": "235 lbs",
-      "born": "October 17, 1993 · Clamart, France",
-      "origin": "Clamart, France",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Hybrid forward-center",
-      "goatScore": 5.7,
-      "goatRank": 2847,
-      "goatTier": "Rotation",
-      "goatResume": "68 pts · 14 ast · 82 reb in 89 games",
-      "bio": "Vincent Poirier is a forward-center currently available in free agency. They hail from Clamart, France. Vincent entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1629738",
-        "agent",
-        "c",
-        "center",
-        "clamart",
-        "f",
-        "forward",
-        "france",
-        "free",
-        "free agent",
-        "goat",
-        "poirier",
-        "rotation",
-        "vincent"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 522
+      "goatRecentRank": 315
     },
     {
       "id": "vlatko-cancar-1628427",
       "name": "Vlatko Cancar",
+      "personId": "1628427",
       "team": "Denver Nuggets",
       "position": null,
       "height": null,
@@ -17957,11 +17081,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.2,
-      "goatRecentRank": 278
+      "goatRecentRank": 276
     },
     {
       "id": "wayne-ellington-201961",
       "name": "Wayne Ellington",
+      "personId": "201961",
       "team": "Detroit Pistons",
       "position": "G",
       "height": "6'4\"",
@@ -17991,11 +17116,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 459
+      "goatRecentRank": 469
     },
     {
       "id": "wendell-carter-jr-1628976",
       "name": "Wendell Carter Jr.",
+      "personId": "1628976",
       "team": "Orlando Magic",
       "position": null,
       "height": null,
@@ -18029,6 +17155,7 @@
     {
       "id": "wenyen-gabriel-1629117",
       "name": "Wenyen Gabriel",
+      "personId": "1629117",
       "team": "New Orleans Pelicans",
       "position": "F",
       "height": "6'9\"",
@@ -18058,11 +17185,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 27.2,
-      "goatRecentRank": 266
+      "goatRecentRank": 265
     },
     {
       "id": "wes-iwundu-1628411",
       "name": "Wes Iwundu",
+      "personId": "1628411",
       "team": "New Orleans Pelicans",
       "position": "F",
       "height": "6'6\"",
@@ -18093,11 +17221,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 447
+      "goatRecentRank": 456
     },
     {
       "id": "wesley-matthews-202083",
       "name": "Wesley Matthews",
+      "personId": "202083",
       "team": "Los Angeles Lakers",
       "position": "G",
       "height": "6'5\"",
@@ -18128,11 +17257,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 23.0,
-      "goatRecentRank": 305
+      "goatRecentRank": 302
     },
     {
       "id": "will-barton-203115",
       "name": "Will Barton",
+      "personId": "203115",
       "team": "Denver Nuggets",
       "position": "G",
       "height": "6'5\"",
@@ -18162,45 +17292,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 20.3,
-      "goatRecentRank": 326
-    },
-    {
-      "id": "will-magnay-1630266",
-      "name": "Will Magnay",
-      "team": "Free Agent",
-      "position": "C",
-      "height": "6'10\"",
-      "weight": "234 lbs",
-      "born": "June 10, 1998 · Australia",
-      "origin": "Australia",
-      "draft": "-1 · Pick -1 (-1th round)",
-      "era": "-10s",
-      "archetype": "Modern center",
-      "goatScore": 2.3,
-      "goatRank": 4790,
-      "goatTier": "Reserve",
-      "goatResume": "0 pts · 0 ast · 0 reb in 23 games",
-      "bio": "Will Magnay is a center currently available in free agency. They hail from Australia. Will entered the league in the -1 NBA Draft.",
-      "keywords": [
-        "1630266",
-        "agent",
-        "australia",
-        "c",
-        "center",
-        "free",
-        "free agent",
-        "goat",
-        "magnay",
-        "reserve",
-        "will"
-      ],
-      "metrics": {},
-      "goatRecentScore": 0.0,
-      "goatRecentRank": 428
+      "goatRecentRank": 321
     },
     {
       "id": "willie-cauley-stein-1626161",
       "name": "Willie Cauley-Stein",
+      "personId": "1626161",
       "team": "Dallas Mavericks",
       "position": "C",
       "height": "7'0\"",
@@ -18230,11 +17327,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 448
+      "goatRecentRank": 473
     },
     {
       "id": "willy-hernangomez-1626195",
       "name": "Willy Hernangomez",
+      "personId": "1626195",
       "team": "New Orleans Pelicans",
       "position": "F / C",
       "height": "6'11\"",
@@ -18267,11 +17365,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 24.5,
-      "goatRecentRank": 285
+      "goatRecentRank": 283
     },
     {
       "id": "xavier-tillman-1630214",
       "name": "Xavier Tillman",
+      "personId": "1630214",
       "team": "Memphis Grizzlies",
       "position": "F",
       "height": null,
@@ -18304,6 +17403,7 @@
     {
       "id": "yogi-ferrell-1627812",
       "name": "Yogi Ferrell",
+      "personId": "1627812",
       "team": "Los Angeles Clippers",
       "position": "G",
       "height": "6'0\"",
@@ -18334,11 +17434,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 0.0,
-      "goatRecentRank": 424
+      "goatRecentRank": 465
     },
     {
       "id": "yuta-watanabe-1629139",
       "name": "Yuta Watanabe",
+      "personId": "1629139",
       "team": "Toronto Raptors",
       "position": "G / F",
       "height": "6'9\"",
@@ -18370,11 +17471,12 @@
       ],
       "metrics": {},
       "goatRecentScore": 25.0,
-      "goatRecentRank": 281
+      "goatRecentRank": 279
     },
     {
       "id": "zach-collins-1628380",
       "name": "Zach Collins",
+      "personId": "1628380",
       "team": "Portland Trail Blazers",
       "position": "C",
       "height": null,
@@ -18410,6 +17512,7 @@
     {
       "id": "zach-lavine-203897",
       "name": "Zach LaVine",
+      "personId": "203897",
       "team": "Chicago Bulls",
       "position": null,
       "height": null,
@@ -18442,6 +17545,7 @@
     {
       "id": "zeke-nnaji-1630192",
       "name": "Zeke Nnaji",
+      "personId": "1630192",
       "team": "Denver Nuggets",
       "position": "F",
       "height": null,
@@ -18474,6 +17578,7 @@
     {
       "id": "zion-williamson-1629627",
       "name": "Zion Williamson",
+      "personId": "1629627",
       "team": "New Orleans Pelicans",
       "position": null,
       "height": null,

--- a/scripts/goat_metrics.py
+++ b/scripts/goat_metrics.py
@@ -1,0 +1,226 @@
+"""Shared helpers for computing GOAT scoring snapshots."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime
+from typing import Any, Collection, Iterable, Mapping
+
+RECENT_SEASON_START = 2022
+RECENT_SEASON_SPAN = 3  # 2022-23 through 2024-25
+RECENT_SEASON_YEARS = {
+    RECENT_SEASON_START + offset for offset in range(RECENT_SEASON_SPAN)
+}
+RECENT_SEASON_MAX_GAMES = 82 * RECENT_SEASON_SPAN
+
+
+def _parse_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        number = float(value)
+    else:
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            number = float(text)
+        except ValueError:
+            return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _parse_game_date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        pass
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _season_year_from_date(value: str | None) -> int | None:
+    parsed = _parse_game_date(value)
+    if not parsed:
+        return None
+    anchor_year = parsed.year
+    if parsed.month >= 7:
+        return anchor_year
+    return anchor_year - 1
+
+
+def format_season_label(start_year: int) -> str:
+    end_year = start_year + 1
+    return f"{start_year}-{str(end_year)[-2:]}"
+
+
+def format_season_span(seasons: Iterable[int]) -> str | None:
+    years: list[int] = []
+    seen: set[int] = set()
+    for year in seasons:
+        if not isinstance(year, int):
+            continue
+        if year in seen:
+            continue
+        seen.add(year)
+        years.append(year)
+    if not years:
+        return None
+    years.sort()
+    labels = [format_season_label(year) for year in years]
+    if len(labels) == 1:
+        return labels[0]
+    return f"{labels[0]}–{labels[-1]}"
+
+
+def format_season_window(start_year: int, span: int) -> str:
+    if span <= 0:
+        return format_season_label(start_year)
+    end_year = start_year + span - 1
+    return f"{format_season_label(start_year)} to {format_season_label(end_year)}"
+
+
+def compute_recent_goat_scores(
+    rows: Iterable[Mapping[str, Any]],
+    active_ids: Collection[str],
+) -> dict[str, dict[str, Any]]:
+    """Aggregate last-three-season GOAT scores for the provided players."""
+
+    normalized_ids = {str(person_id).strip() for person_id in active_ids if str(person_id).strip()}
+    if not normalized_ids:
+        return {}
+
+    aggregates: dict[str, dict[str, Any]] = {
+        person_id: {
+            "games": 0,
+            "wins": 0,
+            "minutes": 0.0,
+            "points": 0.0,
+            "assists": 0.0,
+            "rebounds": 0.0,
+            "steals": 0.0,
+            "blocks": 0.0,
+            "plus_minus": 0.0,
+            "seasons": set(),
+            "last_game": None,
+            "team_name": None,
+            "team_city": None,
+        }
+        for person_id in normalized_ids
+    }
+
+    for row in rows:
+        person_raw = row.get("personId")
+        person_id = str(person_raw).strip() if person_raw is not None else ""
+        if person_id not in aggregates:
+            continue
+
+        season_year = _season_year_from_date(row.get("gameDate"))
+        if season_year not in RECENT_SEASON_YEARS:
+            continue
+
+        minutes = _parse_float(row.get("numMinutes")) or 0.0
+        if minutes <= 0:
+            continue
+
+        bucket = aggregates[person_id]
+        bucket["games"] += 1
+        if (row.get("win") or "").strip() == "1":
+            bucket["wins"] += 1
+        bucket["minutes"] += minutes
+        bucket["points"] += _parse_float(row.get("points")) or 0.0
+        bucket["assists"] += _parse_float(row.get("assists")) or 0.0
+        bucket["rebounds"] += _parse_float(row.get("reboundsTotal")) or 0.0
+        bucket["steals"] += _parse_float(row.get("steals")) or 0.0
+        bucket["blocks"] += _parse_float(row.get("blocks")) or 0.0
+        bucket["plus_minus"] += _parse_float(row.get("plusMinusPoints")) or 0.0
+        bucket["seasons"].add(season_year)
+
+        game_date = _parse_game_date(row.get("gameDate"))
+        if game_date is not None:
+            last_game = bucket.get("last_game")
+            if last_game is None or game_date > last_game:
+                bucket["last_game"] = game_date
+                bucket["team_name"] = (row.get("playerteamName") or "").strip() or None
+                bucket["team_city"] = (row.get("playerteamCity") or "").strip() or None
+
+    raw_values: list[float] = []
+    for bucket in aggregates.values():
+        minutes = bucket["minutes"]
+        if minutes <= 0:
+            bucket["raw"] = 0.0
+            raw_values.append(0.0)
+            continue
+
+        per36_points = (bucket["points"] / minutes) * 36.0 if minutes else 0.0
+        per36_assists = (bucket["assists"] / minutes) * 36.0 if minutes else 0.0
+        per36_rebounds = (bucket["rebounds"] / minutes) * 36.0 if minutes else 0.0
+        per36_stocks = ((bucket["steals"] + bucket["blocks"]) / minutes) * 36.0 if minutes else 0.0
+
+        availability = min(bucket["games"] / RECENT_SEASON_MAX_GAMES, 1.0)
+        win_pct = (bucket["wins"] / bucket["games"]) if bucket["games"] else 0.0
+        plus_minus = (bucket["plus_minus"] / bucket["games"]) if bucket["games"] else 0.0
+
+        impact = max(
+            per36_points
+            + 1.6 * per36_assists
+            + 1.1 * per36_rebounds
+            + 3.0 * per36_stocks,
+            0.0,
+        )
+
+        raw_score = impact * availability
+        if win_pct > 0:
+            raw_score += win_pct * 18.0
+        if plus_minus > 0:
+            raw_score += plus_minus * 0.4
+
+        bucket["raw"] = max(raw_score, 0.0)
+        raw_values.append(bucket["raw"])
+
+    if not raw_values:
+        return {person_id: {"score": None, "rank": None} for person_id in normalized_ids}
+
+    min_raw = min(raw_values)
+    max_raw = max(raw_values)
+    span = max_raw - min_raw
+    rankings: dict[str, int] = {}
+    sorted_entries = sorted(
+        aggregates.items(), key=lambda item: item[1]["raw"], reverse=True
+    )
+    for index, (person_id, _bucket) in enumerate(sorted_entries):
+        rankings[person_id] = index + 1
+
+    recent_scores: dict[str, dict[str, Any]] = {}
+    for person_id, bucket in aggregates.items():
+        raw = bucket["raw"]
+        if span <= 0:
+            score = 0.0
+        else:
+            normalized = (raw - min_raw) / span
+            clamped = min(max(normalized, 0.0), 1.0)
+            score = round(clamped * 100.0, 1)
+        last_game = bucket.get("last_game")
+        recent_scores[person_id] = {
+            "score": score,
+            "rank": rankings.get(person_id),
+            "games": bucket["games"],
+            "wins": bucket["wins"],
+            "seasons": sorted(bucket["seasons"]),
+            "teamName": bucket.get("team_name"),
+            "teamCity": bucket.get("team_city"),
+            "lastGame": last_game.date().isoformat() if isinstance(last_game, datetime) else None,
+        }
+
+    return recent_scores

--- a/tests/test_goat_recent.py
+++ b/tests/test_goat_recent.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.goat_metrics import (
+    RECENT_SEASON_SPAN,
+    RECENT_SEASON_START,
+    format_season_window,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "public" / "data"
+
+
+def _load_json(name: str) -> dict:
+    path = DATA_DIR / name
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def test_goat_recent_structure() -> None:
+    payload = _load_json("goat_recent.json")
+    assert payload.get("metric") == "Rolling three-year GOAT index"
+    assert payload.get("window") == format_season_window(RECENT_SEASON_START, RECENT_SEASON_SPAN)
+
+    players = payload.get("players") or []
+    assert players, "GOAT recent payload should include players"
+
+    previous_score = float("inf")
+    for expected_rank, entry in enumerate(players, start=1):
+        assert entry.get("rank") == expected_rank
+        score = entry.get("score")
+        assert isinstance(score, (int, float)) and 0 <= score <= 100
+        assert score <= previous_score + 1e-9
+        previous_score = score
+        assert isinstance(entry.get("personId"), str) and entry["personId"].strip()
+        assert isinstance(entry.get("name"), str) and entry["name"].strip()
+        assert isinstance(entry.get("team"), str)
+        assert isinstance(entry.get("blurb"), str)
+
+
+def test_goat_recent_matches_profiles() -> None:
+    recent = _load_json("goat_recent.json").get("players") or []
+    profiles = _load_json("player_profiles.json").get("players") or []
+    profile_by_id = {
+        str(profile.get("personId")): profile
+        for profile in profiles
+        if profile.get("personId")
+    }
+    assert profile_by_id, "Player profiles payload should expose personId fields"
+
+    for entry in recent:
+        person_id = str(entry.get("personId"))
+        assert person_id in profile_by_id, f"Missing player profile for {person_id}"
+        profile = profile_by_id[person_id]
+        assert profile.get("goatRecentScore") == entry.get("score")
+        assert profile.get("goatRecentRank") == entry.get("rank")


### PR DESCRIPTION
## Summary
- add a shared goat_metrics module to normalize recent-season scoring across scripts
- update build_player_profiles to emit goat_recent.json alongside player_profiles and to embed stable personId/goat recency fields
- add coverage for the new leaderboard payload and regenerate goat_recent/player_profiles data using the automated pipeline

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da98d1b4c88327810c204274c7d325