### PR TITLE
Limit player atlas to 2025-26 Ball Don't Lie rosters

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -37,8 +37,8 @@
           <header class="players-lab__section-header">
             <h2>Player scouting atlas</h2>
             <p class="players-lab__lede">
-              Search across eras to surface bespoke scouting percentiles for the game's icons. Choose a player to
-              instantly render his GOAT index snapshot, vitals, and twelve curated visual reads.
+              Search the active 2025-26 roster pool to surface bespoke scouting percentiles for every player. Choose a
+              player to instantly render his GOAT index snapshot, vitals, and twelve curated visual reads.
             </p>
           </header>
           <div class="player-atlas__layout">
@@ -79,7 +79,7 @@
             <div class="player-atlas__teams" data-player-teams hidden>
               <h3 class="player-atlas__teams-title">Browse by franchise</h3>
               <p class="player-atlas__teams-copy">
-                Expand a team to scan its roster and jump straight to a player's scouting card.
+                Expand a team to scan its 2025-26 roster and jump straight to a player's scouting card.
               </p>
               <div class="player-atlas__teams-tree" data-player-team-tree></div>
             </div>


### PR DESCRIPTION
## Summary
- restrict the player atlas to the active Ball Don't Lie roster snapshot for 2025-26 and rebuild indices when rosters refresh
- add helper state to drive team browsing/search solely from current rosters with improved empty-state handling
- update player atlas copy to emphasize the 2025-26 roster focus

## Testing
- not run (front-end changes only)


------
https://chatgpt.com/codex/tasks/task_e_68db0ac7cd908327bb0295dd59537bdc