### PR TITLE
Document Ball Don't Lie roster fetch failure (blocked domain)

### DIFF
--- a/public/data/rosters.failed.json
+++ b/public/data/rosters.failed.json
@@ -49,5 +49,11 @@
   ],
   "message": "Failed to fetch one or more team rosters.",
   "fallback": "manual_roster_reference",
-  "at": "2025-09-29T13:46:58.598Z"
+  "at": "2025-09-29T23:48:16.069456+00:00",
+  "notes": [
+    {
+      "at": "2025-09-29T23:48:16.069456+00:00",
+      "context": "Environment could not reach api.balldontlie.io (HTTP 403 via proxy)."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- record the latest attempt to refresh rosters and note the proxy 403 blocking api.balldontlie.io

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db18655ea8832789d511ffcecc8c1f