### PR TITLE
Use Ball Don't Lie active players endpoint for rosters

### DIFF
--- a/scripts/fetch/ball_dont_lie_client.ts
+++ b/scripts/fetch/ball_dont_lie_client.ts
@@ -187,15 +187,10 @@ export class BallDontLieClient {
   async getActivePlayersByTeam(teamId: number, season?: number): Promise<BdlPlayer[]> {
     const cacheKey = season !== undefined ? `players-active-${teamId}-${season}` : `players-active-${teamId}`;
     return withCache(cacheKey, this.#ttlMs, async () => {
-      const basePath = season !== undefined ? "/v1/players" : "/v1/players/active";
       const params: Record<string, QueryValue> = { "team_ids[]": teamId };
-      if (season !== undefined) {
-        params.active = "true";
-        params["seasons[]"] = season;
-      }
 
       const players = await this.paginate<BdlPlayer>(
-        basePath,
+        "/v1/players/active",
         params,
         100,
         undefined,

--- a/scripts/fetch/bdl.test.ts
+++ b/scripts/fetch/bdl.test.ts
@@ -97,9 +97,9 @@ describe("BallDontLieClient.getActivePlayersByTeam", () => {
 
     expect(mockRequest).toHaveBeenCalledTimes(1);
     const [url] = mockRequest.mock.calls[0];
-    expect(url).toContain("/v1/players");
-    expect(url).toContain("active=true");
-    expect(url).toContain("seasons%5B%5D=2025");
+    expect(url).toContain("/v1/players/active");
+    expect(url).toContain("team_ids%5B%5D=42");
+    expect(url).not.toContain("seasons%5B%5D");
     expect(players).toEqual([
       {
         id: 1,
@@ -135,6 +135,7 @@ describe("BallDontLieClient.getActivePlayersByTeam", () => {
     expect(mockRequest).toHaveBeenCalledTimes(1);
     const [url] = mockRequest.mock.calls[0];
     expect(url).toContain("/v1/players/active");
+    expect(url).toContain("team_ids%5B%5D=7");
     expect(url).not.toContain("seasons%5B%5D");
     expect(players).toEqual([
       {

--- a/scripts/fetch_rosters.ts
+++ b/scripts/fetch_rosters.ts
@@ -163,7 +163,7 @@ async function buildRosterFromBallDontLie(): Promise<RostersDoc> {
 
   for (const team of teams) {
     try {
-      const rawPlayers = await getActivePlayersByTeam(team.id, TARGET_SEASON_START_YEAR);
+      const rawPlayers = await getActivePlayersByTeam(team.id);
       const roster = rawPlayers.map(normalizePlayer).sort((a, b) => {
         const aName = `${a.last_name} ${a.first_name}`.toLowerCase();
         const bName = `${b.last_name} ${b.first_name}`.toLowerCase();


### PR DESCRIPTION
## Summary
- update the Ball Don't Lie client to always read active players from the /v1/players/active endpoint
- refresh roster fetching to rely on the new active endpoint and keep the player scouting atlas in sync
- adjust the Ball Don't Lie client tests to reflect the active endpoint usage

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db2c5cbe548327aaca6338c4c46964