### PR TITLE
Fix Ball Don't Lie roster fetch to include season scope

### DIFF
--- a/scripts/fetch/ball_dont_lie_client.ts
+++ b/scripts/fetch/ball_dont_lie_client.ts
@@ -188,6 +188,9 @@ export class BallDontLieClient {
     const cacheKey = season !== undefined ? `players-active-${teamId}-${season}` : `players-active-${teamId}`;
     return withCache(cacheKey, this.#ttlMs, async () => {
       const params: Record<string, QueryValue> = { "team_ids[]": teamId };
+      if (season !== undefined) {
+        params["seasons[]"] = season;
+      }
 
       const players = await this.paginate<BdlPlayer>(
         "/v1/players/active",

--- a/scripts/fetch/bdl.test.ts
+++ b/scripts/fetch/bdl.test.ts
@@ -99,7 +99,7 @@ describe("BallDontLieClient.getActivePlayersByTeam", () => {
     const [url] = mockRequest.mock.calls[0];
     expect(url).toContain("/v1/players/active");
     expect(url).toContain("team_ids%5B%5D=42");
-    expect(url).not.toContain("seasons%5B%5D");
+    expect(url).toContain("seasons%5B%5D=2025");
     expect(players).toEqual([
       {
         id: 1,

--- a/scripts/fetch_rosters.ts
+++ b/scripts/fetch_rosters.ts
@@ -163,7 +163,7 @@ async function buildRosterFromBallDontLie(): Promise<RostersDoc> {
 
   for (const team of teams) {
     try {
-      const rawPlayers = await getActivePlayersByTeam(team.id);
+      const rawPlayers = await getActivePlayersByTeam(team.id, TARGET_SEASON_START_YEAR);
       const roster = rawPlayers.map(normalizePlayer).sort((a, b) => {
         const aName = `${a.last_name} ${a.first_name}`.toLowerCase();
         const bName = `${b.last_name} ${b.first_name}`.toLowerCase();


### PR DESCRIPTION
## Summary
- include the season start year when requesting active rosters from Ball Don't Lie
- update the roster fetcher to pass the target season start year into the active player calls
- adjust the Ball Don't Lie client test expectations to cover the season-scoped query parameter

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db2e8d24f88327ae51644f154bbc37