### PR TITLE
Refactor rosters pipeline to use Ball Don't Lie active endpoint

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -19,6 +19,8 @@ jobs:
   build-previews:
     runs-on: ubuntu-latest
     environment: previews
+    env:
+      BALLDONTLIE_API_KEY: ${{ secrets.BALLDONTLIE_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,14 +31,10 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install pnpm (and fix PATH)
-        shell: bash
-        run: |
-          npm i -g pnpm@9.12.1
-          prefix="$(npm config get prefix)"
-          echo "$prefix/bin" >> "$GITHUB_PATH"
-          pnpm -v
-          which pnpm
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
 
       - name: Use dedicated pnpm store
         run: pnpm config set store-dir ~/.pnpm-store
@@ -51,36 +49,32 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Provision Ball Don't Lie key
-        shell: bash
-        env:
-          RAW_BDL_API_KEY: ${{ secrets.BDL_API_KEY || vars.BDL_API_KEY }}
+      - name: Ensure Ball Don't Lie key configured
         run: |
-          set -euo pipefail
-          if [ -z "${RAW_BDL_API_KEY:-}" ]; then
-            echo "BDL_API_KEY secret not configured for previews workflow" >&2
-            echo "Provide a repository or environment secret named BDL_API_KEY." >&2
+          if [ -z "${BALLDONTLIE_API_KEY:-}" ]; then
+            echo "BALLDONTLIE_API_KEY secret not configured" >&2
             exit 1
           fi
-          mkdir -p secrets
-          printf '%s' "$RAW_BDL_API_KEY" > secrets/bdl_api_key
-          chmod 600 secrets/bdl_api_key
-          echo "BDL_API_KEY=$RAW_BDL_API_KEY" >> "$GITHUB_ENV"
 
       - name: Stamp date
         id: metadata
         run: echo "date=$(date -u +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Verify Ball Don't Lie API access
+        env:
+          BALLDONTLIE_API_KEY: ${{ secrets.BALLDONTLIE_API_KEY }}
         run: pnpm verify:bdl
 
       - name: Build and validate previews
         env:
           USE_NBA_STATS: "0"
           USE_BREF: "0"
+          BALLDONTLIE_API_KEY: ${{ secrets.BALLDONTLIE_API_KEY }}
         run: pnpm previews
 
       - name: Validate previews
+        env:
+          BALLDONTLIE_API_KEY: ${{ secrets.BALLDONTLIE_API_KEY }}
         run: pnpm run validate:previews
 
       - name: Detect changes

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "validate:previews": "tsx scripts/validate/previews_staleness.ts && tsx scripts/validate/links.ts && tsx scripts/validate/rosters_nonempty.ts",
     "previews": "pnpm build:data && pnpm gen:previews && pnpm validate:previews",
     "fetch:rosters": "tsx scripts/fetch_rosters.ts",
-    "validate:rosters": "tsx scripts/validate_rosters.ts",
+    "validate:rosters": "tsx scripts/validate/rosters.ts",
     "predeploy": "pnpm fetch:rosters",
     "deploy": "echo 'static site build only'",
     "test": "vitest run",

--- a/scripts/fetch/bdl.test.ts
+++ b/scripts/fetch/bdl.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi, type MockInstance } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi, type MockInstance } from "vitest";
 import { z } from "zod";
 
 import { BallDontLieClient } from "./ball_dont_lie_client.js";
@@ -65,6 +65,11 @@ describe("BallDontLieClient.getActivePlayersByTeam", () => {
 
   beforeEach(() => {
     mockRequest.mockReset();
+    process.env.NO_CACHE = "1";
+  });
+
+  afterEach(() => {
+    delete process.env.NO_CACHE;
   });
 
   it("requests season-scoped active rosters when a start year is provided", async () => {

--- a/scripts/fetch/bdl_active_rosters.ts
+++ b/scripts/fetch/bdl_active_rosters.ts
@@ -1,0 +1,236 @@
+import { promises as fs } from "node:fs";
+
+import { getTeams, normalizeTeamName } from "./bdl.js";
+import { TEAM_METADATA } from "../lib/teams.js";
+import type { SourcePlayerRecord } from "../lib/types.js";
+
+const API = "https://api.balldontlie.io/v1";
+const KEY =
+  process.env.BALLDONTLIE_API_KEY?.trim() ??
+  process.env.BDL_API_KEY?.trim() ??
+  process.env.BALL_DONT_LIE_API_KEY?.trim();
+
+if (!KEY) {
+  throw new Error("Missing BALLDONTLIE_API_KEY");
+}
+
+interface BLTeam {
+  id: number;
+  abbreviation: string;
+  full_name: string;
+}
+
+interface BLPlayer {
+  id: number;
+  first_name: string;
+  last_name: string;
+  position: string | null;
+  height?: string | null;
+  weight?: string | null;
+  jersey_number?: string | null;
+  team: BLTeam | null;
+}
+
+interface Page {
+  data: BLPlayer[];
+  meta?: { next_cursor?: number | null };
+}
+
+export interface ActiveRosterPlayer {
+  id: number;
+  first_name: string;
+  last_name: string;
+  position: string;
+  height: string;
+  weight: string;
+  jersey_number: string;
+  team_abbr: string;
+  team_bdl_id: number;
+}
+
+export type ActiveRosterMap = Record<string, ActiveRosterPlayer[]>;
+
+function buildUrl(path: string, params: Record<string, unknown> = {}): URL {
+  const url = new URL(API + path);
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        url.searchParams.append(`${key}[]`, String(entry));
+      }
+    } else if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url;
+}
+
+async function http(path: string, params: Record<string, unknown> = {}): Promise<Page> {
+  const url = buildUrl(path, params);
+  const response = await fetch(url, {
+    headers: { Authorization: KEY },
+  });
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText} for ${url}`);
+  }
+  return (await response.json()) as Page;
+}
+
+async function fetchActivePlayersByTeam(bdlTeamId: number): Promise<BLPlayer[]> {
+  const players: BLPlayer[] = [];
+  const seen = new Set<number>();
+  let cursor: number | undefined;
+
+  while (true) {
+    const page = await http("/players/active", {
+      team_ids: [bdlTeamId],
+      per_page: 100,
+      cursor,
+    });
+
+    const nullTeam = page.data.filter((player) => player.team === null);
+    if (nullTeam.length) {
+      const sample = nullTeam
+        .slice(0, 3)
+        .map((player) => `${player.first_name} ${player.last_name}`.trim())
+        .join(", ");
+      throw new Error(
+        `Active endpoint returned players without teams for BDL ${bdlTeamId}: ${sample}${
+          nullTeam.length > 3 ? " …" : ""
+        }`,
+      );
+    }
+
+    for (const player of page.data) {
+      if (player.team?.id !== bdlTeamId) {
+        continue;
+      }
+      if (seen.has(player.id)) {
+        continue;
+      }
+      seen.add(player.id);
+      players.push(player);
+    }
+
+    const nextCursor = page.meta?.next_cursor ?? undefined;
+    if (!nextCursor) {
+      break;
+    }
+    cursor = nextCursor;
+  }
+
+  return players;
+}
+
+function formatFullName(first: string, last: string): string {
+  return [first, last].filter(Boolean).join(" ").trim();
+}
+
+export async function fetchActiveRosters(): Promise<Record<string, SourcePlayerRecord[]>> {
+  const bdlTeams = await getTeams();
+  if (!bdlTeams.length) {
+    throw new Error("Ball Don't Lie returned no teams");
+  }
+
+  const byAbbr = new Map<string, BLTeam>();
+  for (const team of bdlTeams) {
+    byAbbr.set(team.abbreviation.toUpperCase(), team);
+  }
+
+  const rosters: Record<string, SourcePlayerRecord[]> = {};
+  const blakeHits: string[] = [];
+  const assignments = new Map<number, string>();
+
+  for (const meta of TEAM_METADATA) {
+    const abbr = meta.tricode.toUpperCase();
+    const bdlTeam = byAbbr.get(abbr);
+    if (!bdlTeam) {
+      throw new Error(`Missing Ball Don't Lie team mapping for ${meta.tricode}`);
+    }
+
+    const expectedName = normalizeTeamName(`${meta.market} ${meta.name}`);
+    const actualName = normalizeTeamName(bdlTeam.full_name);
+    if (expectedName !== actualName) {
+      throw new Error(
+        `Team name mismatch for ${meta.tricode}: expected ${meta.market} ${meta.name}, got ${bdlTeam.full_name}`,
+      );
+    }
+
+    const players = await fetchActivePlayersByTeam(bdlTeam.id);
+
+    const mapped = players.map<SourcePlayerRecord>((player) => {
+      const fullName = formatFullName(player.first_name, player.last_name);
+      if (player.first_name === "Blake" && player.last_name === "Griffin") {
+        blakeHits.push(`${fullName} (${meta.tricode})`);
+      }
+      const previousTeam = assignments.get(player.id);
+      if (previousTeam && previousTeam !== meta.tricode) {
+        throw new Error(
+          `Player ${fullName} (ID ${player.id}) appears on multiple teams: ${previousTeam}, ${meta.tricode}`,
+        );
+      }
+      assignments.set(player.id, meta.tricode);
+      return {
+        playerId: String(player.id),
+        name: fullName,
+        position: player.position ?? undefined,
+        teamId: meta.teamId,
+        teamTricode: meta.tricode,
+        id: player.id,
+        first_name: player.first_name,
+        last_name: player.last_name,
+        jersey_number: player.jersey_number ?? "",
+        height: player.height ?? "",
+        weight: player.weight ?? "",
+        team_abbr: meta.tricode,
+        team_bdl_id: bdlTeam.id,
+      };
+    });
+
+    if (mapped.length < 13 || mapped.length > 21) {
+      throw new Error(`Roster size out of bounds for ${meta.tricode}: ${mapped.length}`);
+    }
+
+    rosters[meta.tricode] = mapped;
+  }
+
+  if (blakeHits.length) {
+    throw new Error(`Historical leak detected: ${blakeHits.join(", ")}`);
+  }
+
+  const serializable: ActiveRosterMap = Object.fromEntries(
+    Object.entries(rosters).map(([abbr, players]) => [
+      abbr,
+      players.map((player) => ({
+        id: player.id!,
+        first_name: player.first_name ?? "",
+        last_name: player.last_name ?? "",
+        position: player.position ?? "",
+        height: player.height ?? "",
+        weight: player.weight ?? "",
+        jersey_number: player.jersey_number ?? "",
+        team_abbr: player.team_abbr ?? abbr,
+        team_bdl_id: player.team_bdl_id!,
+      })),
+    ]),
+  );
+
+  await fs.mkdir("data", { recursive: true });
+  await fs.writeFile(
+    "data/bdl_active_rosters.json",
+    JSON.stringify({ rosters: serializable }, null, 2) + "\n",
+    "utf8",
+  );
+
+  return rosters;
+}
+
+if (process.argv[1]?.endsWith("bdl_active_rosters.ts")) {
+  fetchActiveRosters()
+    .then(() => {
+      console.log("Wrote data/bdl_active_rosters.json");
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}

--- a/scripts/lib/types.ts
+++ b/scripts/lib/types.ts
@@ -73,6 +73,14 @@ export interface SourcePlayerRecord {
   teamTricode?: string;
   status?: string;
   isNewAddition?: boolean;
+  id?: number;
+  first_name?: string;
+  last_name?: string;
+  jersey_number?: string;
+  height?: string;
+  weight?: string;
+  team_abbr?: string;
+  team_bdl_id?: number;
 }
 
 export interface OverridesConfig {

--- a/scripts/validate/rosters.ts
+++ b/scripts/validate/rosters.ts
@@ -1,0 +1,109 @@
+import { readFile } from "node:fs/promises";
+
+import { TEAM_METADATA } from "../lib/teams.js";
+
+interface ActiveRosterPlayer {
+  id: number;
+  first_name: string;
+  last_name: string;
+  position: string;
+  height: string;
+  weight: string;
+  jersey_number: string;
+  team_abbr: string;
+  team_bdl_id: number;
+}
+
+interface ActiveRosterDoc {
+  rosters: Record<string, ActiveRosterPlayer[]>;
+}
+
+function ensureRosterDoc(raw: unknown): ActiveRosterDoc {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("Active roster JSON is not an object");
+  }
+  const rosters = (raw as { rosters?: unknown }).rosters;
+  if (!rosters || typeof rosters !== "object") {
+    throw new Error("Active roster JSON missing 'rosters' map");
+  }
+  return { rosters: rosters as Record<string, ActiveRosterPlayer[]> };
+}
+
+function summarizeSample(players: ActiveRosterPlayer[]): string {
+  const sample = players
+    .slice()
+    .sort((a, b) => {
+      const aKey = `${a.last_name ?? ""} ${a.first_name ?? ""}`.toLowerCase();
+      const bKey = `${b.last_name ?? ""} ${b.first_name ?? ""}`.toLowerCase();
+      return aKey.localeCompare(bKey);
+    })
+    .slice(0, 3)
+    .map((player) => player.last_name || player.first_name || String(player.id));
+
+  return sample.join(", ");
+}
+
+async function main(): Promise<void> {
+  const raw = await readFile("data/bdl_active_rosters.json", "utf8");
+  const parsed = JSON.parse(raw) as unknown;
+  const doc = ensureRosterDoc(parsed);
+
+  const missingTeams: string[] = [];
+  const rangeViolations: string[] = [];
+  const duplicateViolations: string[] = [];
+  const blakeHits: string[] = [];
+  const nullTeamViolations: string[] = [];
+
+  for (const meta of TEAM_METADATA) {
+    const roster = doc.rosters[meta.tricode];
+    if (!Array.isArray(roster) || roster.length === 0) {
+      missingTeams.push(meta.tricode);
+      continue;
+    }
+
+    if (roster.length < 13 || roster.length > 21) {
+      rangeViolations.push(`${meta.tricode}:${roster.length}`);
+    }
+
+    const seen = new Set<number>();
+    for (const player of roster) {
+      if (typeof player.id !== "number" || Number.isNaN(player.id)) {
+        throw new Error(`Invalid player id for ${meta.tricode}`);
+      }
+      if (!player.team_abbr || player.team_abbr !== meta.tricode) {
+        nullTeamViolations.push(`${meta.tricode}:${player.id}`);
+      }
+      if (seen.has(player.id)) {
+        duplicateViolations.push(`${meta.tricode}:${player.id}`);
+      }
+      seen.add(player.id);
+      if (player.first_name === "Blake" && player.last_name === "Griffin") {
+        blakeHits.push(`${meta.tricode}:${player.id}`);
+      }
+    }
+
+    const summary = summarizeSample(roster);
+    console.log(`${meta.tricode}: ${roster.length} players (sample: ${summary})`);
+  }
+
+  if (missingTeams.length) {
+    throw new Error(`Missing rosters for: ${missingTeams.join(", ")}`);
+  }
+  if (rangeViolations.length) {
+    throw new Error(`Roster size out of bounds: ${rangeViolations.join(", ")}`);
+  }
+  if (duplicateViolations.length) {
+    throw new Error(`Duplicate player ids detected: ${duplicateViolations.join(", ")}`);
+  }
+  if (nullTeamViolations.length) {
+    throw new Error(`Players missing team assignments: ${nullTeamViolations.join(", ")}`);
+  }
+  if (blakeHits.length) {
+    throw new Error(`Blake Griffin detected in active data: ${blakeHits.join(", ")}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- replace the legacy Ball Don't Lie roster merge with a direct `/players/active` fetcher that enforces team-level sanity and writes `data/bdl_active_rosters.json`
- update canonical build, roster fetch, verification, and validation scripts to use the new active roster map exclusively
- wire the new data path into CI by adjusting the preview workflow, TypeScript types, and tests

## Testing
- `BALLDONTLIE_API_KEY=test pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68db32829b90832786cd0c9fa8d54dc9