### PR TITLE
Fix pnpm version mismatch in previews workflow

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.12.1
+          version: 9.1.0
 
       - name: Use dedicated pnpm store
         run: pnpm config set store-dir ~/.pnpm-store


### PR DESCRIPTION
## Summary
- align the pnpm/action-setup version with the repository's packageManager setting to avoid version conflicts during previews builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd42620848327be6fed9bc1e300b9