### PR TITLE
Allow Ball Don't Lie key to load from secret file

### DIFF
--- a/scripts/fetch/bdl_active_rosters.ts
+++ b/scripts/fetch/bdl_active_rosters.ts
@@ -1,13 +1,37 @@
 import { promises as fs } from "node:fs";
 import { pathToFileURL } from "node:url";
 import type { SourcePlayerRecord } from "../lib/types.js";
+import { loadSecret } from "../lib/secrets.js";
 
 const API = "https://api.balldontlie.io/v1";
 
+function resolveBdlKey(): string | undefined {
+  const candidates = [
+    process.env.BDL_API_KEY,
+    process.env.BALLDONTLIE_API_KEY,
+    process.env.BALL_DONT_LIE_API_KEY,
+  ];
+
+  for (const value of candidates) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  const fileKey = loadSecret("bdl_api_key", {
+    aliases: ["ball_dont_lie_api_key", "balldontlie_api_key", "ball-dont-lie"],
+  });
+
+  return fileKey?.trim() || undefined;
+}
+
 function requireKey(): string {
-  const key = process.env.BALLDONTLIE_API_KEY?.trim();
+  const key = resolveBdlKey();
   if (!key) {
-    throw new Error("Missing BALLDONTLIE_API_KEY");
+    throw new Error(
+      "Missing BDL_API_KEY — set your Ball Don't Lie All-Star key or enable USE_BDL_CACHE=1",
+    );
   }
   return key;
 }


### PR DESCRIPTION
## Summary
- resolve the Ball Don't Lie API key in `bdl_active_rosters` using environment aliases or the secrets file fallback
- align the missing key error message with other fetch helpers so the pipeline guides contributors to USE_BDL_CACHE

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbd4df5da88327a1414e1f76a9a812