### PR TITLE
Adjust BallDon'tLie roster bounds

### DIFF
--- a/scripts/dev/verify_bdl.ts
+++ b/scripts/dev/verify_bdl.ts
@@ -1,6 +1,10 @@
 import { pathToFileURL } from "url";
 
-import { fetchActiveRosters } from "../fetch/bdl_active_rosters.js";
+import {
+  fetchActiveRosters,
+  MAX_ACTIVE_ROSTER,
+  MIN_ACTIVE_ROSTER,
+} from "../fetch/bdl_active_rosters.js";
 import { TEAM_METADATA } from "../lib/teams.js";
 
 async function verify(): Promise<void> {
@@ -19,7 +23,7 @@ async function verify(): Promise<void> {
 
   const outOfRange = TEAM_METADATA.filter((team) => {
     const record = rosters[team.tricode] ?? [];
-    return record.length < 13 || record.length > 21;
+    return record.length < MIN_ACTIVE_ROSTER || record.length > MAX_ACTIVE_ROSTER;
   });
 
   if (outOfRange.length > 0) {

--- a/scripts/fetch/bdl_active_rosters.ts
+++ b/scripts/fetch/bdl_active_rosters.ts
@@ -92,8 +92,13 @@ async function fetchActivePlayersForTeam(teamId: number): Promise<BLPlayer[]> {
   return out;
 }
 
+export const MIN_ACTIVE_ROSTER = 13;
+// Training camp and two-way slots can push Ball Don't Lie's "active" response
+// above the in-season 21-player ceiling, so allow up to 23.
+export const MAX_ACTIVE_ROSTER = 23;
+
 function guardRoster(teamAbbr: string, players: BLPlayer[]) {
-  if (players.length < 13 || players.length > 21) {
+  if (players.length < MIN_ACTIVE_ROSTER || players.length > MAX_ACTIVE_ROSTER) {
     throw new Error(`Roster size out of bounds for ${teamAbbr}: ${players.length}`);
   }
   if (players.some(p => p.first_name === "Blake" && p.last_name === "Griffin")) {


### PR DESCRIPTION
## Summary
- export shared roster size bounds from the BDL fetcher
- raise the maximum allowed active roster size to cover larger training camp counts

## Testing
- pnpm verify:bdl *(fails: Missing BDL_API_KEY — set your Ball Don't Lie All-Star key or enable USE_BDL_CACHE=1)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd67839588327a8e974e748818bc8