### PR TITLE
Use Ball Don't Lie active players feed for roster builds

### DIFF
--- a/scripts/dev/verify_bdl.ts
+++ b/scripts/dev/verify_bdl.ts
@@ -1,74 +1,100 @@
 import { pathToFileURL } from "url";
 
 import {
+  PRESEASON_DEFAULT_MAX,
+  REGULAR_SEASON_MAX,
+  REGULAR_SEASON_MIN,
   fetchActiveRosters,
-  MAX_ACTIVE_ROSTER,
-  MIN_ACTIVE_ROSTER,
+  getLastActiveRosterFetchMeta,
 } from "../fetch/bdl_active_rosters.js";
 import { TEAM_METADATA } from "../lib/teams.js";
 
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
 function allowPreseason(): boolean {
-  const v = process.env.ALLOW_PRESEASON_SIZES ?? "";
-  const n = v.trim().toLowerCase();
-  return n === "1" || n === "true" || n === "yes";
+  return parseBoolean(process.env.ALLOW_PRESEASON_SIZES);
 }
 
 function preseasonMax(): number {
   const raw = Number(process.env.PRESEASON_ROSTER_MAX);
-  // default 25 if not set or invalid
-  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : 25;
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : PRESEASON_DEFAULT_MAX;
+}
+
+function useCache(): boolean {
+  return parseBoolean(process.env.USE_BDL_CACHE);
+}
+
+function inCi(): boolean {
+  return parseBoolean(process.env.CI);
 }
 
 async function verify(): Promise<void> {
   const rosters = await fetchActiveRosters();
-  const empties = TEAM_METADATA.filter((team) => {
-    const record = rosters[team.tricode];
-    return !Array.isArray(record) || record.length === 0;
-  });
 
-  if (empties.length > 0) {
-    const missingAbbrs = empties.map((team) => team.tricode).join(", ");
+  const missing = TEAM_METADATA.filter((team) => !Array.isArray(rosters[team.tricode]));
+  if (missing.length > 0) {
+    const missingCodes = missing.map((team) => team.tricode).join(", ");
     throw new Error(
-      `BDL verify failed: missing active rosters for ${empties.length} team(s) (${missingAbbrs})`,
+      `BDL verify failed: missing active roster entries for ${missing.length} team(s) (${missingCodes})`,
     );
   }
 
-  // Respect preseason bounds when enabled
-  const maxAllowed = allowPreseason() ? preseasonMax() : MAX_ACTIVE_ROSTER;
-  const minAllowed = MIN_ACTIVE_ROSTER;
+  const preseason = allowPreseason();
+  const minAllowed = REGULAR_SEASON_MIN;
+  const maxAllowed = preseason ? preseasonMax() : REGULAR_SEASON_MAX;
 
-  const outOfRange = TEAM_METADATA.filter((team) => {
-    const record = rosters[team.tricode] ?? [];
-    const len = record.length;
-    return len < minAllowed || len > maxAllowed;
-  });
+  if (preseason) {
+    console.warn(`BDL verify: preseason roster bounds in effect (min=${minAllowed}, max=${maxAllowed}).`);
+  } else {
+    console.log(`BDL verify: regular-season roster bounds (min=${minAllowed}, max=${maxAllowed}).`);
+  }
+
+  const outOfRange = TEAM_METADATA.reduce<Array<{ tricode: string; size: number }>>((acc, team) => {
+    const tricode = team.tricode;
+    const roster = rosters[tricode] ?? [];
+    const size = roster.length;
+    if (!Array.isArray(roster) || size === 0) {
+      throw new Error(`BDL verify failed: empty roster for ${tricode}`);
+    }
+    if (size < minAllowed || size > maxAllowed) {
+      acc.push({ tricode, size });
+    }
+    return acc;
+  }, []);
 
   if (outOfRange.length > 0) {
-    const sample = outOfRange.map((team) => `${team.tricode}:${rosters[team.tricode]?.length ?? 0}`);
-    throw new Error(
-      `BDL verify failed: roster size out of bounds (min=${minAllowed}, max=${maxAllowed}) — ${sample.join(", ")}`,
+    const summary = outOfRange.map(({ tricode, size }) => `${tricode}:${size}`).join(", ");
+    if (preseason) {
+      console.warn(
+        `BDL verify: preseason roster bounds exceeded (min=${minAllowed}, max=${maxAllowed}) — ${summary}`,
+      );
+    } else {
+      throw new Error(
+        `BDL verify failed: roster size out of bounds (min=${minAllowed}, max=${maxAllowed}) — ${summary}`,
+      );
+    }
+  }
+
+  const meta = getLastActiveRosterFetchMeta();
+  if (meta) {
+    const multiPage = meta.totalPlayers > meta.maxPageSize;
+    if (multiPage && !meta.usedNextCursor) {
+      throw new Error(
+        `BDL verify failed: pagination incomplete — total_players=${meta.totalPlayers}, max_page_size=${meta.maxPageSize}, cursor_used=${meta.usedNextCursor}`,
+      );
+    }
+    console.log(
+      `BDL verify: pagination summary pages=${meta.pages}, per_page=${meta.perPage}, total_players=${meta.totalPlayers}, used_cursor=${meta.usedNextCursor}`,
     );
   }
 
   console.log("BDL OK — all active rosters populated within expected bounds");
-}
-
-function useCache(): boolean {
-  const value = process.env.USE_BDL_CACHE;
-  if (!value) {
-    return false;
-  }
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes";
-}
-
-function inCi(): boolean {
-  const value = process.env.CI;
-  if (!value) {
-    return false;
-  }
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true" || normalized === "yes";
 }
 
 async function run(): Promise<void> {
@@ -76,13 +102,19 @@ async function run(): Promise<void> {
     await verify();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (message.includes("Missing BDL_API_KEY") && useCache()) {
-      console.log("BDL check skipped — using cached data (USE_BDL_CACHE)");
-      return;
-    }
-    if (message.includes("Missing BDL_API_KEY") && inCi()) {
-      console.log("BDL check skipped — missing BDL_API_KEY in CI environment");
-      return;
+    if (message.includes("Missing BDL_API_KEY")) {
+      if (useCache() && inCi()) {
+        console.log("BDL verify skipped — missing BDL_API_KEY in CI with USE_BDL_CACHE=1");
+        return;
+      }
+      if (useCache()) {
+        console.log("BDL verify skipped — using cached roster data (USE_BDL_CACHE)");
+        return;
+      }
+      if (inCi()) {
+        console.log("BDL verify skipped — missing BDL_API_KEY in CI environment");
+        return;
+      }
     }
     throw error;
   }


### PR DESCRIPTION
## Summary
- rework the BDL active roster fetcher to page through the players/active endpoint once, map NBA teams to tricodes, and expose pagination metadata
- ensure roster fetch results are sorted, deduplicated, and enriched with Ball Don't Lie team ids for downstream consumers
- update the development verifier to apply preseason bounds, surface pagination diagnostics, and skip gracefully when the API key is unavailable in cached CI runs

## Testing
- pnpm vitest run scripts/fetch/bdl.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dbdd89319c8327a7b28ac6aba5b6a4