### PR TITLE
Add collapsible tier tree to GOAT Index

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -42,22 +42,9 @@
           </div>
           <div class="goat-leaderboard__layout">
             <div class="goat-table-wrapper">
-              <table class="goat-table" data-goat-table aria-describedby="goat-table-footnote">
-                <thead>
-                  <tr>
-                    <th scope="col">Rank</th>
-                    <th scope="col">Player</th>
-                    <th scope="col">GOAT</th>
-                    <th scope="col">Δ 12 mo.</th>
-                    <th scope="col">Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td colspan="5">Computing pantheon order…</td>
-                  </tr>
-                </tbody>
-              </table>
+              <div class="goat-tree" data-goat-tree aria-describedby="goat-table-footnote">
+                <p class="goat-tree__placeholder">Computing pantheon order…</p>
+              </div>
               <p id="goat-table-footnote" class="goat-table-footnote">
                 Δ indicates the twelve-month swing in GOAT points after factoring fresh data and retroactive era adjustments.
               </p>
@@ -65,7 +52,7 @@
             <aside class="goat-detail" data-goat-detail>
               <header>
                 <h3 data-goat-name>Select a player</h3>
-                <p class="goat-detail__meta" data-goat-meta>Pick a name from the table to see the GOAT recipe.</p>
+                <p class="goat-detail__meta" data-goat-meta>Pick a name from the tier tree to see the GOAT recipe.</p>
               </header>
               <div class="goat-detail__summary">
                 <p class="goat-detail__resume" data-goat-resume></p>

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -2741,6 +2741,178 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   overflow: hidden;
 }
 
+.goat-tree {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.goat-tree__placeholder {
+  margin: 0;
+  padding: 1.2rem 1.4rem;
+  font-size: 0.92rem;
+  color: var(--text-subtle);
+}
+
+.goat-tier {
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+}
+
+.goat-tier:last-of-type {
+  border-bottom: none;
+}
+
+.goat-tier__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.95rem 1.2rem;
+  list-style: none;
+  cursor: pointer;
+  font-weight: 700;
+  color: var(--navy);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.1) 40%, rgba(255, 255, 255, 0.9) 60%);
+  transition: background 0.2s ease;
+}
+
+.goat-tier__summary:hover {
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.14) 45%, rgba(255, 255, 255, 0.88) 55%);
+}
+
+.goat-tier__summary::-webkit-details-marker {
+  display: none;
+}
+
+.goat-tier__summary::after {
+  content: '';
+  width: 0.75rem;
+  height: 0.75rem;
+  border: 2px solid currentColor;
+  border-top: transparent;
+  border-left: transparent;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.goat-tier[open] > .goat-tier__summary::after {
+  transform: rotate(225deg);
+}
+
+.goat-tier__summary-label {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.goat-tier__summary-count {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+.goat-tier__list {
+  margin: 0;
+  padding: 0 1.2rem 1.2rem;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.goat-tier__item {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.goat-tier__player {
+  display: grid;
+  grid-template-columns: minmax(0, 3ch) minmax(0, 1fr) minmax(0, 6ch) minmax(0, 8ch);
+  grid-template-areas: 'rank name score delta';
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.96) 70%, rgba(17, 86, 214, 0.05) 30%);
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+}
+
+.goat-tier__player:hover {
+  border-color: color-mix(in srgb, var(--royal) 32%, transparent);
+  box-shadow: 0 4px 18px rgba(17, 86, 214, 0.15);
+}
+
+.goat-tier__player:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--royal) 45%, transparent);
+  box-shadow: 0 0 0 3px rgba(17, 86, 214, 0.25);
+}
+
+.goat-tier__player.is-selected {
+  border-color: color-mix(in srgb, var(--royal) 48%, transparent);
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.18), rgba(31, 123, 255, 0.14));
+  box-shadow: inset 2px 0 0 rgba(17, 86, 214, 0.75);
+}
+
+.goat-tier__player-rank {
+  grid-area: rank;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--navy);
+}
+
+.goat-tier__player-name {
+  grid-area: name;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.goat-tier__player-score {
+  grid-area: score;
+  justify-self: end;
+}
+
+.goat-tier__player-delta {
+  grid-area: delta;
+  justify-self: end;
+  font-weight: 600;
+}
+
+.goat-status--inline {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-top: 0.2rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.12) 60%, rgba(255, 255, 255, 0.85) 40%);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+@media (max-width: 640px) {
+  .goat-tier__player {
+    grid-template-columns: minmax(0, 3ch) minmax(0, 1fr);
+    grid-template-areas:
+      'rank name'
+      '. score'
+      '. delta';
+    gap: 0.5rem 0.75rem;
+  }
+
+  .goat-tier__player-score,
+  .goat-tier__player-delta {
+    justify-self: flex-start;
+  }
+}
+
 .goat-table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## Summary
- replace the GOAT leaderboard table with a tier-based collapsible tree
- group players by tier, update interactions, and default the detail panel based on the tree selection
- style the new tree layout and inline status chips to match the hub aesthetic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe3bf9da08327b44bc620665cd07c