### PR TITLE
Rename Hall of Fame GOAT tier label

### DIFF
--- a/public/scripts/goat.js
+++ b/public/scripts/goat.js
@@ -32,7 +32,7 @@ const TIER_PRIORITY = new Map([
 ]);
 
 const TIER_LABEL_OVERRIDES = new Map([
-  ['Hall of Fame', '- All-NBA'],
+  ['Hall of Fame', 'All-NBA'],
 ]);
 
 const gaugeLabelPlugin = {

--- a/public/scripts/goat.js
+++ b/public/scripts/goat.js
@@ -31,6 +31,10 @@ const TIER_PRIORITY = new Map([
   ['Prospect', 8],
 ]);
 
+const TIER_LABEL_OVERRIDES = new Map([
+  ['Hall of Fame', '- All-NBA'],
+]);
+
 const gaugeLabelPlugin = {
   id: 'gaugeLabel',
   beforeDraw(chart, _args, opts) {
@@ -193,7 +197,7 @@ function buildLeaderboard(players) {
 
     const label = document.createElement('span');
     label.className = 'goat-tier__summary-label';
-    label.textContent = group.tier;
+    label.textContent = TIER_LABEL_OVERRIDES.get(group.tier) ?? group.tier;
 
     const count = group.players.length;
     const playerWord = count === 1 ? 'player' : 'players';


### PR DESCRIPTION
## Summary
- update the GOAT index tier label overrides so the former "Hall of Fame" grouping now displays as "- All-NBA"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc01ca13ec83278661d7cc0b25ddb0