### PR TITLE
Refactor injury monitor to use Ball Don't Lie feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "esbuild components/main.ts --bundle --format=esm --target=es2019 --minify --outfile=assets/js/main.tmp.js && node scripts/finalize-hash.js && node scripts/build-players.js",
     "fetch:active-rosters": "tsx scripts/fetch/bdl_active_rosters.ts",
-    "build:data": "pnpm fetch:active-rosters && tsx scripts/data/build_canonical.ts && tsx scripts/data/build_preseason_schedule.ts",
+    "fetch:injuries": "tsx scripts/fetch_injuries.ts",
+    "build:data": "pnpm fetch:active-rosters && pnpm fetch:injuries && tsx scripts/data/build_canonical.ts && tsx scripts/data/build_preseason_schedule.ts",
     "build:players-index": "tsx scripts/build_players_index.ts",
     "build:history:catalog": "tsx scripts/history/build_player_catalog.ts",
     "build:history": "pnpm build:history:catalog",
@@ -18,7 +19,7 @@
     "validate:previews": "tsx scripts/validate/previews_staleness.ts && tsx scripts/validate/links.ts && tsx scripts/validate/rosters_nonempty.ts",
     "previews": "pnpm build:data && pnpm gen:previews && pnpm validate:previews",
     "validate:rosters": "tsx scripts/validate/rosters.ts",
-    "predeploy": "pnpm fetch:active-rosters",
+    "predeploy": "pnpm fetch:active-rosters && pnpm fetch:injuries",
     "deploy": "echo 'static site build only'",
     "test": "vitest run",
     "verify:bdl": "tsx scripts/dev/verify_bdl.ts",

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -162,89 +162,6 @@ const preseasonPowerIndex = [
     note: 'Some young core pieces exist, but the rest of the roster lacks depth and star impact. They’ll likely be at or near bottom unless things break favorably.',
   },
 ];
-const injuryAvailabilityPulse = [
-  {
-    team: 'Philadelphia 76ers',
-    player: 'Joel Embiid',
-    role: 'C · MVP 2023',
-    statusLabel: 'Cleared for camp',
-    statusLevel: 'ready',
-    readiness: 88,
-    timeline: 'Full participant as of Sept 27 media day',
-    impact: '+12.1 net swing when active',
-    note: 'Post-meniscus rehab has Embiid back in full practices; staff is holding him near 30 minutes while conditioning catches up.',
-  },
-  {
-    team: 'Los Angeles Clippers',
-    player: 'Kawhi Leonard',
-    role: 'F · Playoff fulcrum',
-    statusLabel: 'Managed minutes',
-    statusLevel: 'monitor',
-    readiness: 74,
-    timeline: 'Cleared for preseason scrimmages · Back-to-back calls remain day-of',
-    impact: '+8.2 lineup net rating with him on the floor',
-    note: 'Following a May knee cleanup, Leonard is practicing 5-on-5 but the Clippers will sit him for one leg of back-to-backs through November.',
-  },
-  {
-    team: 'Memphis Grizzlies',
-    player: 'Ja Morant',
-    role: 'G · Lead creator',
-    statusLabel: 'No restrictions',
-    statusLevel: 'ready',
-    readiness: 91,
-    timeline: 'Returned to full-contact work Sept 26',
-    impact: '+9.1 pace swing when active',
-    note: 'Morant says the surgically repaired shoulder feels 100 percent; Memphis is leaning on core-strength maintenance rather than contact limitations.',
-  },
-];
-
-const seasonEndingAbsences = [
-  {
-    team: 'Chicago Bulls',
-    player: 'Lonzo Ball',
-    role: 'G · Connector guard',
-    statusLabel: 'Season shutdown',
-    statusLevel: 'season',
-    injury: 'Left knee cartilage transplant follow-up',
-    timeline: 'Out for 2025-26 · Next medical review Feb 2026',
-    impact: 'Chicago leans on Coby White-led playmaking committee.',
-    note: "Ball has resumed light individual work, but the Bulls have ruled him out for the season to prioritize cartilage transplant durability before returning to contact.",
-  },
-  {
-    team: 'Indiana Pacers',
-    player: 'Tyrese Haliburton',
-    role: 'G · Franchise lead guard',
-    statusLabel: 'Season-ending',
-    statusLevel: 'season',
-    injury: 'Ruptured right Achilles tendon',
-    timeline: 'Surgery Jun 18, 2025 · Long-term check July 2026',
-    impact: 'Indiana shifts primary creation to Pascal Siakam and Bennedict Mathurin.',
-    note: 'Haliburton tore his Achilles in Game 5 of the Finals and immediately underwent repair; the Pacers mapped a 12-month recovery before he resumes on-court work.',
-  },
-  {
-    team: 'Houston Rockets',
-    player: 'Steven Adams',
-    role: 'C · Interior anchor',
-    statusLabel: 'Season shutdown',
-    statusLevel: 'season',
-    injury: 'Right knee PCL reconstruction',
-    timeline: 'Re-evaluation slated for March 2026',
-    impact: 'Houston will ride Alperen Şengün and small-ball looks at the five.',
-    note: 'While Adams has progressed to controlled scrimmages, recurring swelling prompted Houston to shelve him for the year and lean on long-term strength programming.',
-  },
-  {
-    team: 'Portland Trail Blazers',
-    player: 'Robert Williams III',
-    role: 'C · Rim protector',
-    statusLabel: 'Season shutdown',
-    statusLevel: 'season',
-    injury: 'Ligament repair on right knee',
-    timeline: 'Re-evaluation after 2026 All-Star break',
-    impact: 'Portland elevates Deandre Ayton and Jabari Walker in the rotation.',
-    note: 'Williams is still addressing chronic knee irritation following ligament repair, keeping Portland focused on a long runway before clearing him for game action.',
-  },
-];
-
 const projectedTempoLeaders = [
   {
     team: 'Indiana Pacers',
@@ -1218,7 +1135,7 @@ function renderStoryCards(storyData) {
   });
 }
 
-function renderInjuryPulse() {
+async function renderInjuryPulse() {
   const container = document.querySelector('[data-injury-report]');
   const footnote = document.querySelector('[data-injury-footnote]');
   if (!container) {
@@ -1226,128 +1143,147 @@ function renderInjuryPulse() {
   }
 
   container.innerHTML = '';
-
-  const createInjuryCard = (entry, { hideReadiness = false, variant } = {}) => {
-    const card = document.createElement('article');
-    card.className = 'injury-card';
-    if (variant) {
-      card.classList.add(`injury-card--${variant}`);
-    }
-
-    const header = document.createElement('header');
-    header.className = 'injury-card__header';
-
-    const identity = document.createElement('div');
-    identity.className = 'injury-card__identity';
-    identity.appendChild(createTeamLogo(entry.team, 'team-logo team-logo--small'));
-
-    const label = document.createElement('div');
-    label.className = 'injury-card__label';
-    const name = document.createElement('strong');
-    name.textContent = entry.player;
-    label.appendChild(name);
-    if (entry.role) {
-      const role = document.createElement('span');
-      role.textContent = entry.role;
-      label.appendChild(role);
-    }
-    identity.appendChild(label);
-    header.appendChild(identity);
-
-    if (entry.statusLabel) {
-      const status = document.createElement('span');
-      const allowedStatuses = new Set(['ready', 'monitor', 'caution', 'season']);
-      const level = allowedStatuses.has(entry.statusLevel) ? entry.statusLevel : 'monitor';
-      status.className = `injury-card__status injury-card__status--${level}`;
-      status.textContent = entry.statusLabel;
-      header.appendChild(status);
-    }
-
-    card.appendChild(header);
-
-    const metrics = document.createElement('dl');
-    metrics.className = 'injury-card__metrics';
-
-    const addMetric = (labelText, valueText) => {
-      if (!labelText || !valueText) return;
-      const row = document.createElement('div');
-      row.className = 'injury-card__metric';
-      const term = document.createElement('dt');
-      term.textContent = labelText;
-      const detail = document.createElement('dd');
-      detail.textContent = valueText;
-      row.append(term, detail);
-      metrics.appendChild(row);
-    };
-
-    addMetric('Timeline', entry.timeline);
-    addMetric('Impact', entry.impact);
-    addMetric('Injury', entry.injury);
-    addMetric('Return plan', entry.returnPlan);
-
-    if (metrics.childElementCount) {
-      card.appendChild(metrics);
-    }
-
-    if (!hideReadiness) {
-      const readiness = clampPercent(entry.readiness);
-      const readinessBar = document.createElement('div');
-      readinessBar.className = 'injury-card__readiness';
-      readinessBar.style.setProperty('--fill', `${readiness}%`);
-      card.appendChild(readinessBar);
-
-      const readinessLabel = document.createElement('span');
-      readinessLabel.className = 'injury-card__readiness-label';
-      readinessLabel.textContent = `Readiness index: ${helpers.formatNumber(readiness, 0)} / 100`;
-      card.appendChild(readinessLabel);
-    }
-
-    if (entry.note) {
-      const note = document.createElement('p');
-      note.className = 'injury-card__note';
-      note.textContent = entry.note;
-      card.appendChild(note);
-    }
-
-    return card;
-  };
-
-  const hasActiveEntries = Array.isArray(injuryAvailabilityPulse) && injuryAvailabilityPulse.length > 0;
-  const hasSeasonLongEntries = Array.isArray(seasonEndingAbsences) && seasonEndingAbsences.length > 0;
-
-  if (!hasActiveEntries && !hasSeasonLongEntries) {
-    const placeholder = document.createElement('p');
-    placeholder.className = 'injury-grid__placeholder';
-    placeholder.textContent = 'Injury board updates once medical reports finalize.';
-    container.appendChild(placeholder);
-  } else {
-    if (hasActiveEntries) {
-      injuryAvailabilityPulse.forEach((entry) => {
-        container.appendChild(createInjuryCard(entry));
-      });
-    }
-
-    if (hasSeasonLongEntries) {
-      if (hasActiveEntries) {
-        const divider = document.createElement('div');
-        divider.className = 'injury-grid__divider';
-        container.appendChild(divider);
-      }
-
-      const heading = document.createElement('h4');
-      heading.className = 'injury-grid__section-title';
-      heading.textContent = 'Season-long absences';
-      container.appendChild(heading);
-
-      seasonEndingAbsences.forEach((entry) => {
-        container.appendChild(createInjuryCard(entry, { hideReadiness: true, variant: 'season' }));
-      });
-    }
+  if (footnote) {
+    footnote.textContent = '';
   }
 
+  const loading = document.createElement('p');
+  loading.className = 'injury-grid__placeholder';
+  loading.textContent = 'Syncing Ball Don\'t Lie injury feed...';
+  container.appendChild(loading);
+
+  const payload = await fetchJsonSafe('data/player_injuries.json');
+  container.innerHTML = '';
+
+  if (!payload || !Array.isArray(payload.items)) {
+    const errorMessage = document.createElement('p');
+    errorMessage.className = 'injury-grid__placeholder';
+    errorMessage.textContent = 'Unable to load Ball Don\'t Lie injury feed right now.';
+    container.appendChild(errorMessage);
+    if (footnote) {
+      footnote.textContent = 'Injury feed temporarily unavailable.';
+    }
+    return;
+  }
+
+  const entries = payload.items.slice(0, 10);
+  if (!entries.length) {
+    const placeholder = document.createElement('p');
+    placeholder.className = 'injury-grid__placeholder';
+    placeholder.textContent = 'No current injury reports from Ball Don\'t Lie.';
+    container.appendChild(placeholder);
+  } else {
+    const allowedStatuses = new Set(['season', 'caution', 'monitor', 'ready']);
+
+    entries.forEach((entry) => {
+      const card = document.createElement('article');
+      card.className = 'injury-card';
+
+      const header = document.createElement('header');
+      header.className = 'injury-card__header';
+
+      const identity = document.createElement('div');
+      identity.className = 'injury-card__identity';
+      const teamIdentifier = entry.team_tricode || entry.team_name || '';
+      identity.appendChild(createTeamLogo(teamIdentifier || 'NBA', 'team-logo team-logo--small'));
+
+      const label = document.createElement('div');
+      label.className = 'injury-card__label';
+      const name = document.createElement('strong');
+      name.textContent = entry.player || 'Unnamed player';
+      label.appendChild(name);
+      const teamText = entry.team_name || entry.team_tricode;
+      if (teamText) {
+        const team = document.createElement('span');
+        team.textContent = teamText;
+        label.appendChild(team);
+      }
+      identity.appendChild(label);
+      header.appendChild(identity);
+
+      const status = document.createElement('span');
+      const level = typeof entry.status_level === 'string' ? entry.status_level.toLowerCase() : 'monitor';
+      const safeLevel = allowedStatuses.has(level) ? level : 'monitor';
+      status.className = `injury-card__status injury-card__status--${safeLevel}`;
+      status.textContent = entry.status || 'Status unavailable';
+      header.appendChild(status);
+
+      card.appendChild(header);
+
+      const metrics = document.createElement('dl');
+      metrics.className = 'injury-card__metrics';
+
+      const addMetric = (labelText, valueText) => {
+        if (!labelText || !valueText) {
+          return;
+        }
+        const row = document.createElement('div');
+        row.className = 'injury-card__metric';
+        const term = document.createElement('dt');
+        term.textContent = labelText;
+        const detail = document.createElement('dd');
+        detail.textContent = valueText;
+        row.append(term, detail);
+        metrics.appendChild(row);
+      };
+
+      const reportLabel = (() => {
+        if (typeof entry.report_label === 'string' && entry.report_label.trim()) {
+          return entry.report_label.trim();
+        }
+        if (typeof entry.last_updated === 'string') {
+          const formatted = formatDateLabel(entry.last_updated, { month: 'short', day: 'numeric' });
+          if (formatted) {
+            return formatted;
+          }
+        }
+        return '';
+      })();
+
+      if (reportLabel) {
+        addMetric('Report', reportLabel);
+      }
+
+      if (typeof entry.return_date === 'string' && entry.return_date.trim()) {
+        addMetric('Return', entry.return_date.trim());
+      }
+
+      if (metrics.childElementCount) {
+        card.appendChild(metrics);
+      }
+
+      if (typeof entry.description === 'string' && entry.description.trim()) {
+        const note = document.createElement('p');
+        note.className = 'injury-card__note';
+        note.textContent = entry.description.trim();
+        card.appendChild(note);
+      }
+
+      container.appendChild(card);
+    });
+  }
+
+  const source = typeof payload.source === 'string' && payload.source.trim() ? payload.source.trim() : 'Ball Don\'t Lie';
+  const fetchedAt = typeof payload.fetched_at === 'string' ? payload.fetched_at : '';
+  let footnoteText =
+    typeof payload.note === 'string' && payload.note.trim()
+      ? payload.note.trim()
+      : `Source: ${source} injury feed.`;
+  if (fetchedAt) {
+    const fetchedDate = new Date(fetchedAt);
+    if (!Number.isNaN(fetchedDate.getTime())) {
+      const formatter = new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: 'UTC',
+      });
+      footnoteText = `${footnoteText} Updated ${formatter.format(fetchedDate)} UTC.`;
+    }
+  }
   if (footnote) {
-    footnote.textContent =
-      'Readiness index blends ramp-up participation, travel tolerance, and medical reports—100 signals full go. Season-long absences spotlight players ruled out through 2025-26 and the rehab logic behind each shutdown.';
+    footnote.textContent = footnoteText;
   }
 }
 
@@ -1711,7 +1647,7 @@ async function bootstrap() {
     fetchJsonSafe('data/preseason_openers.json'),
   ]);
 
-  renderInjuryPulse();
+  await renderInjuryPulse();
   renderPaceRadar();
   renderSpacingLab();
   hydrateHero(teamData);

--- a/scripts/fetch/bdl_player_injuries.ts
+++ b/scripts/fetch/bdl_player_injuries.ts
@@ -1,0 +1,162 @@
+import { request } from "./http.js";
+
+const API_URL = "https://api.balldontlie.io/v1/player_injuries";
+const MAX_PER_PAGE = 100;
+
+export interface BdlPlayerSummary {
+  id?: number;
+  first_name?: string | null;
+  last_name?: string | null;
+  position?: string | null;
+  height?: string | null;
+  weight?: string | null;
+  jersey_number?: string | null;
+  college?: string | null;
+  country?: string | null;
+  draft_year?: number | null;
+  draft_round?: number | null;
+  draft_number?: number | null;
+  team_id?: number | null;
+  team?: { id?: number | null; abbreviation?: string | null; full_name?: string | null } | null;
+}
+
+export interface BdlPlayerInjury {
+  id?: number;
+  player?: BdlPlayerSummary | null;
+  return_date?: string | null;
+  description?: string | null;
+  status?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+interface PlayerInjuryPage {
+  data?: unknown;
+  meta?: {
+    next_cursor?: string | number | null;
+    next_page?: number | null;
+    current_page?: number | null;
+    total_pages?: number | null;
+    per_page?: number | null;
+  } | null;
+}
+
+export interface PlayerInjuryFetchOptions {
+  perPage?: number;
+  pageLimit?: number;
+  cursor?: string | number | null;
+  maxItems?: number;
+  teamIds?: Array<number | string>;
+  playerIds?: Array<number | string>;
+}
+
+function clampPerPage(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return MAX_PER_PAGE;
+  }
+  const parsed = Math.floor(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return MAX_PER_PAGE;
+  }
+  return Math.min(Math.max(parsed, 1), MAX_PER_PAGE);
+}
+
+function isCursorLike(value: unknown): value is string | number {
+  if (value === null || value === undefined) {
+    return false;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return true;
+  }
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
+  return false;
+}
+
+function appendArrayParams(search: URLSearchParams, key: string, values: Array<number | string> | undefined) {
+  if (!Array.isArray(values)) {
+    return;
+  }
+  for (const value of values) {
+    const text = String(value ?? "").trim();
+    if (text.length) {
+      search.append(`${key}[]`, text);
+    }
+  }
+}
+
+export async function fetchPlayerInjuries(options: PlayerInjuryFetchOptions = {}): Promise<BdlPlayerInjury[]> {
+  const perPage = clampPerPage(options.perPage);
+  const pageLimit = options.pageLimit && options.pageLimit > 0 ? Math.floor(options.pageLimit) : undefined;
+  const maxItems = options.maxItems && options.maxItems > 0 ? Math.floor(options.maxItems) : undefined;
+
+  const entries: BdlPlayerInjury[] = [];
+  let cursor: string | number | null = isCursorLike(options.cursor) ? (options.cursor as string | number) : null;
+  let nextPage: number | undefined;
+  let attempts = 0;
+
+  while (true) {
+    attempts += 1;
+    if (pageLimit && attempts > pageLimit) {
+      break;
+    }
+
+    const search = new URLSearchParams();
+    search.set("per_page", String(perPage));
+    if (cursor !== null && cursor !== undefined) {
+      search.set("cursor", String(cursor));
+    } else if (nextPage !== undefined) {
+      search.set("page", String(nextPage));
+    }
+
+    appendArrayParams(search, "team_ids", options.teamIds);
+    appendArrayParams(search, "player_ids", options.playerIds);
+
+    const url = `${API_URL}?${search.toString()}`;
+    const payload = await request<PlayerInjuryPage>(url);
+    const pageData = Array.isArray(payload?.data) ? (payload?.data as unknown[]) : [];
+
+    for (const entry of pageData) {
+      entries.push(entry as BdlPlayerInjury);
+    }
+
+    if (maxItems && entries.length >= maxItems) {
+      break;
+    }
+
+    const meta = payload?.meta ?? {};
+    const nextCursor = meta?.next_cursor;
+    if (isCursorLike(nextCursor)) {
+      cursor = nextCursor;
+      nextPage = undefined;
+      continue;
+    }
+
+    const rawNextPage = meta?.next_page;
+    const metaNextPage = typeof rawNextPage === "number" && Number.isFinite(rawNextPage)
+      ? rawNextPage
+      : undefined;
+    if (metaNextPage !== undefined) {
+      cursor = null;
+      nextPage = metaNextPage;
+      continue;
+    }
+
+    const totalPages = typeof meta?.total_pages === "number" ? meta.total_pages : undefined;
+    const currentPage = typeof meta?.current_page === "number" ? meta.current_page : undefined;
+    if (totalPages !== undefined && currentPage !== undefined && currentPage < totalPages) {
+      cursor = null;
+      nextPage = currentPage + 1;
+      continue;
+    }
+
+    break;
+  }
+
+  if (maxItems && entries.length > maxItems) {
+    return entries.slice(0, maxItems);
+  }
+
+  return entries;
+}

--- a/scripts/fetch/bdl_team_mappings.ts
+++ b/scripts/fetch/bdl_team_mappings.ts
@@ -1,0 +1,87 @@
+import { TEAM_METADATA } from "../lib/teams.js";
+
+export interface BdlTeamMapping {
+  bdlId: number;
+  bdlAbbr: string;
+  tricode: string;
+}
+
+export const BDL_TEAM_MAPPINGS: readonly BdlTeamMapping[] = [
+  { bdlId: 1, bdlAbbr: "ATL", tricode: "ATL" },
+  { bdlId: 2, bdlAbbr: "BOS", tricode: "BOS" },
+  { bdlId: 3, bdlAbbr: "BKN", tricode: "BKN" },
+  { bdlId: 4, bdlAbbr: "CHA", tricode: "CHA" },
+  { bdlId: 5, bdlAbbr: "CHI", tricode: "CHI" },
+  { bdlId: 6, bdlAbbr: "CLE", tricode: "CLE" },
+  { bdlId: 7, bdlAbbr: "DAL", tricode: "DAL" },
+  { bdlId: 8, bdlAbbr: "DEN", tricode: "DEN" },
+  { bdlId: 9, bdlAbbr: "DET", tricode: "DET" },
+  { bdlId: 10, bdlAbbr: "GSW", tricode: "GSW" },
+  { bdlId: 11, bdlAbbr: "HOU", tricode: "HOU" },
+  { bdlId: 12, bdlAbbr: "IND", tricode: "IND" },
+  { bdlId: 13, bdlAbbr: "LAC", tricode: "LAC" },
+  { bdlId: 14, bdlAbbr: "LAL", tricode: "LAL" },
+  { bdlId: 15, bdlAbbr: "MEM", tricode: "MEM" },
+  { bdlId: 16, bdlAbbr: "MIA", tricode: "MIA" },
+  { bdlId: 17, bdlAbbr: "MIL", tricode: "MIL" },
+  { bdlId: 18, bdlAbbr: "MIN", tricode: "MIN" },
+  { bdlId: 19, bdlAbbr: "NOP", tricode: "NOP" },
+  { bdlId: 20, bdlAbbr: "NYK", tricode: "NYK" },
+  { bdlId: 21, bdlAbbr: "OKC", tricode: "OKC" },
+  { bdlId: 22, bdlAbbr: "ORL", tricode: "ORL" },
+  { bdlId: 23, bdlAbbr: "PHI", tricode: "PHI" },
+  { bdlId: 24, bdlAbbr: "PHX", tricode: "PHX" },
+  { bdlId: 25, bdlAbbr: "POR", tricode: "POR" },
+  { bdlId: 26, bdlAbbr: "SAC", tricode: "SAC" },
+  { bdlId: 27, bdlAbbr: "SAS", tricode: "SAS" },
+  { bdlId: 28, bdlAbbr: "TOR", tricode: "TOR" },
+  { bdlId: 29, bdlAbbr: "UTA", tricode: "UTA" },
+  { bdlId: 30, bdlAbbr: "WAS", tricode: "WAS" },
+];
+
+const KNOWN_TRICODES = new Set(TEAM_METADATA.map((team) => team.tricode.toUpperCase()));
+
+export const BDL_TEAM_ID_TO_TRICODE = new Map<number, string>(
+  BDL_TEAM_MAPPINGS.map((mapping) => [mapping.bdlId, mapping.tricode]),
+);
+
+export const BDL_TEAM_ABBR_TO_TRICODE = new Map<string, string>(
+  BDL_TEAM_MAPPINGS.map((mapping) => [mapping.bdlAbbr, mapping.tricode]),
+);
+
+export function mapBdlTeamToTricode(team: { id?: unknown; abbreviation?: unknown }): string {
+  const teamId = typeof team.id === "number" ? team.id : undefined;
+  const rawAbbr = typeof team.abbreviation === "string" ? team.abbreviation.toUpperCase() : undefined;
+
+  if (rawAbbr) {
+    const mapped =
+      BDL_TEAM_ABBR_TO_TRICODE.get(rawAbbr) ?? (KNOWN_TRICODES.has(rawAbbr) ? rawAbbr : undefined);
+    if (mapped) {
+      return mapped;
+    }
+  }
+
+  if (teamId !== undefined) {
+    const mapped = BDL_TEAM_ID_TO_TRICODE.get(teamId);
+    if (mapped) {
+      return mapped;
+    }
+  }
+
+  throw new Error(
+    `Unable to map Ball Don't Lie team to local tricode (id=${String(teamId)}, abbreviation=${String(
+      rawAbbr ?? "",
+    )})`,
+  );
+}
+
+export function lookupTricodeByBdlId(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return BDL_TEAM_ID_TO_TRICODE.get(value);
+  }
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (Number.isFinite(parsed)) {
+    return BDL_TEAM_ID_TO_TRICODE.get(parsed);
+  }
+  return undefined;
+}

--- a/scripts/fetch_injuries.ts
+++ b/scripts/fetch_injuries.ts
@@ -1,0 +1,362 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { fetchPlayerInjuries, BdlPlayerInjury, BdlPlayerSummary } from "./fetch/bdl_player_injuries.js";
+import { lookupTricodeByBdlId, mapBdlTeamToTricode } from "./fetch/bdl_team_mappings.js";
+import { TRICODE_TO_TEAM } from "./lib/teams.js";
+
+const OUTPUT_DIR = path.join(process.cwd(), "public", "data");
+const OUTPUT_FILE = path.join(OUTPUT_DIR, "player_injuries.json");
+const FAILURE_FILE = path.join(OUTPUT_DIR, "player_injuries.failed.json");
+
+export type InjuryStatusLevel = "season" | "caution" | "monitor" | "ready";
+
+const STATUS_PRIORITIES: Record<InjuryStatusLevel, number> = {
+  season: 0,
+  caution: 1,
+  monitor: 2,
+  ready: 3,
+};
+
+const DEFAULT_MAX_ITEMS = 10;
+
+export interface InjuryMonitorItem {
+  player: string;
+  status: string;
+  status_level: InjuryStatusLevel;
+  player_id?: number;
+  team_tricode?: string;
+  team_name?: string;
+  return_date?: string;
+  description?: string;
+  report_label?: string;
+  last_updated?: string;
+}
+
+export interface InjuryMonitorSnapshot {
+  fetched_at: string;
+  source: string;
+  items: InjuryMonitorItem[];
+  note: string;
+}
+
+interface InternalInjuryEntry {
+  playerId?: number;
+  playerKey: string;
+  playerName: string;
+  teamTricode?: string;
+  teamName?: string;
+  status: string;
+  statusLevel: InjuryStatusLevel;
+  returnDate?: string;
+  description?: string;
+  reportLabel?: string;
+  priority: number;
+  timestamp: number;
+  index: number;
+}
+
+function safeTrim(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function classifyInjuryStatus(
+  statusRaw: string | null | undefined,
+  descriptionRaw: string | null | undefined,
+): { level: InjuryStatusLevel; priority: number } {
+  const statusText = safeTrim(statusRaw).toLowerCase();
+  const descriptionText = safeTrim(descriptionRaw).toLowerCase();
+  const combined = `${statusText} ${descriptionText}`;
+
+  const seasonPatterns = [
+    /season[-\s]?ending/, // season-ending or season ending
+    /out for the season/,
+    /ruled out for the season/,
+    /shut down for the season/,
+    /rest of the season/,
+  ];
+
+  if (seasonPatterns.some((pattern) => pattern.test(combined))) {
+    return { level: "season", priority: STATUS_PRIORITIES.season };
+  }
+
+  if (statusText.includes("out")) {
+    return { level: "caution", priority: STATUS_PRIORITIES.caution };
+  }
+
+  if (
+    /doubtful/.test(statusText) ||
+    /questionable/.test(statusText) ||
+    /day[-\s]?to[-\s]?day/.test(statusText) ||
+    /game[-\s]?time/.test(statusText)
+  ) {
+    return { level: "monitor", priority: STATUS_PRIORITIES.monitor };
+  }
+
+  if (/probable/.test(statusText) || /available/.test(statusText)) {
+    return { level: "ready", priority: STATUS_PRIORITIES.ready };
+  }
+
+  if (combined.includes("indefinitely")) {
+    return { level: "caution", priority: STATUS_PRIORITIES.caution };
+  }
+
+  return { level: "monitor", priority: STATUS_PRIORITIES.monitor };
+}
+
+function normalizePlayerSummary(player: BdlPlayerSummary | null | undefined): {
+  playerId?: number;
+  name: string;
+  key: string;
+} | null {
+  if (!player) {
+    return null;
+  }
+
+  const playerId = typeof player.id === "number" && Number.isFinite(player.id) ? player.id : undefined;
+  const first = safeTrim(player.first_name);
+  const last = safeTrim(player.last_name);
+  const name = `${first} ${last}`.trim();
+
+  if (!name) {
+    return null;
+  }
+
+  const key = playerId !== undefined ? `id:${playerId}` : `name:${name.toLowerCase()}`;
+
+  return { playerId, name, key };
+}
+
+function resolveTeamTricode(player: BdlPlayerSummary | null | undefined): string | undefined {
+  if (!player) {
+    return undefined;
+  }
+
+  const direct = lookupTricodeByBdlId(player.team_id ?? player.team?.id ?? null);
+  if (direct) {
+    return direct;
+  }
+
+  const abbreviation = safeTrim(player.team?.abbreviation);
+  if (abbreviation) {
+    try {
+      return mapBdlTeamToTricode({ abbreviation });
+    } catch {
+      // ignore mapping error
+    }
+  }
+
+  return undefined;
+}
+
+function resolveTeamName(tricode: string | undefined): string | undefined {
+  if (!tricode) {
+    return undefined;
+  }
+  const metadata = TRICODE_TO_TEAM.get(tricode.toUpperCase());
+  if (!metadata) {
+    return undefined;
+  }
+  return `${metadata.market} ${metadata.name}`.trim();
+}
+
+function extractReportLabel(description: string | null | undefined): string | undefined {
+  const text = safeTrim(description);
+  if (!text) {
+    return undefined;
+  }
+  const colonIndex = text.indexOf(":");
+  if (colonIndex > 0) {
+    const label = text.slice(0, colonIndex).trim();
+    if (label) {
+      return label;
+    }
+  }
+  return undefined;
+}
+
+function parseTimestamp(...values: Array<string | null | undefined>): number {
+  for (const value of values) {
+    if (!value) {
+      continue;
+    }
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+}
+
+export function normalizeInjuryEntry(injury: BdlPlayerInjury, index: number): InternalInjuryEntry | null {
+  const summary = normalizePlayerSummary(injury.player);
+  if (!summary) {
+    return null;
+  }
+
+  const statusText = safeTrim(injury.status) || "Status unavailable";
+  const { level, priority } = classifyInjuryStatus(injury.status, injury.description);
+
+  const teamTricode = resolveTeamTricode(injury.player ?? undefined);
+  const teamName = resolveTeamName(teamTricode);
+  const reportLabel = extractReportLabel(injury.description);
+  const timestamp = parseTimestamp(injury.updated_at, injury.created_at);
+
+  return {
+    playerId: summary.playerId,
+    playerKey: summary.key,
+    playerName: summary.name,
+    teamTricode: teamTricode,
+    teamName,
+    status: statusText,
+    statusLevel: level,
+    returnDate: safeTrim(injury.return_date) || undefined,
+    description: safeTrim(injury.description) || undefined,
+    reportLabel,
+    priority,
+    timestamp,
+    index,
+  };
+}
+
+export async function collectMonitorEntries(options: {
+  maxItems?: number;
+  perPage?: number;
+  pageLimit?: number;
+} = {}): Promise<InternalInjuryEntry[]> {
+  const maxItems = options.maxItems ?? DEFAULT_MAX_ITEMS;
+  const perPage = options.perPage ?? 100;
+  const pageLimit = options.pageLimit ?? 4;
+
+  const rawInjuries = await fetchPlayerInjuries({ perPage, pageLimit });
+  const deduped = new Map<string, InternalInjuryEntry>();
+
+  rawInjuries.forEach((injury, index) => {
+    const normalized = normalizeInjuryEntry(injury, index);
+    if (!normalized) {
+      return;
+    }
+
+    const existing = deduped.get(normalized.playerKey);
+    if (!existing) {
+      deduped.set(normalized.playerKey, normalized);
+      return;
+    }
+
+    if (normalized.priority < existing.priority) {
+      deduped.set(normalized.playerKey, normalized);
+      return;
+    }
+
+    if (normalized.priority === existing.priority) {
+      if (normalized.timestamp > existing.timestamp) {
+        deduped.set(normalized.playerKey, normalized);
+        return;
+      }
+      if (normalized.timestamp === existing.timestamp && normalized.index < existing.index) {
+        deduped.set(normalized.playerKey, normalized);
+      }
+    }
+  });
+
+  const entries = Array.from(deduped.values());
+  entries.sort((a, b) => {
+    if (a.priority !== b.priority) {
+      return a.priority - b.priority;
+    }
+    if (a.timestamp !== b.timestamp) {
+      return b.timestamp - a.timestamp;
+    }
+    return a.index - b.index;
+  });
+
+  return entries.slice(0, maxItems);
+}
+
+export async function buildInjuryMonitorSnapshot(options: {
+  maxItems?: number;
+  perPage?: number;
+  pageLimit?: number;
+} = {}): Promise<InjuryMonitorSnapshot> {
+  const maxItems = options.maxItems ?? DEFAULT_MAX_ITEMS;
+  const entries = await collectMonitorEntries({
+    maxItems,
+    perPage: options.perPage,
+    pageLimit: options.pageLimit,
+  });
+
+  const items: InjuryMonitorItem[] = entries.map((entry) => {
+    const item: InjuryMonitorItem = {
+      player: entry.playerName,
+      status: entry.status,
+      status_level: entry.statusLevel,
+    };
+    if (entry.playerId !== undefined) {
+      item.player_id = entry.playerId;
+    }
+    if (entry.teamTricode) {
+      item.team_tricode = entry.teamTricode;
+    }
+    if (entry.teamName) {
+      item.team_name = entry.teamName;
+    }
+    if (entry.returnDate) {
+      item.return_date = entry.returnDate;
+    }
+    if (entry.description) {
+      item.description = entry.description;
+    }
+    if (entry.reportLabel) {
+      item.report_label = entry.reportLabel;
+    }
+    if (entry.timestamp > 0) {
+      item.last_updated = new Date(entry.timestamp).toISOString();
+    }
+    return item;
+  });
+
+  return {
+    fetched_at: new Date().toISOString(),
+    source: "Ball Don't Lie",
+    items,
+    note: "Source: Ball Don't Lie player injuries feed. Displaying the 10 most relevant recent reports.",
+  };
+}
+
+export async function writeInjuryMonitorSnapshot(
+  outFile: string = OUTPUT_FILE,
+  failFile: string = FAILURE_FILE,
+): Promise<InjuryMonitorSnapshot> {
+  try {
+    const snapshot = await buildInjuryMonitorSnapshot();
+    await fs.mkdir(path.dirname(outFile), { recursive: true });
+    await fs.writeFile(outFile, `${JSON.stringify(snapshot, null, 2)}\n`, "utf8");
+    await fs.rm(failFile, { force: true });
+    console.log(`Wrote injury snapshot to ${outFile} with ${snapshot.items.length} entries.`);
+    return snapshot;
+  } catch (error) {
+    const payload = {
+      error: error instanceof Error ? error.message : String(error),
+      at: new Date().toISOString(),
+    };
+    await fs.mkdir(path.dirname(failFile), { recursive: true });
+    await fs.writeFile(failFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    throw error;
+  }
+}
+
+async function main() {
+  try {
+    await writeInjuryMonitorSnapshot();
+  } catch (error) {
+    console.error("Failed to build injury monitor snapshot:", error);
+    process.exitCode = 1;
+  }
+}
+
+const isMain = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMain) {
+  main();
+}

--- a/scripts/tests/test_player_injuries.spec.ts
+++ b/scripts/tests/test_player_injuries.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyInjuryStatus, normalizeInjuryEntry } from "../fetch_injuries.js";
+import type { BdlPlayerInjury } from "../fetch/bdl_player_injuries.js";
+
+describe("classifyInjuryStatus", () => {
+  it("flags season-ending language as season level", () => {
+    const result = classifyInjuryStatus("Out", "Season-ending surgery announced.");
+    expect(result.level).toBe("season");
+    expect(result.priority).toBe(0);
+  });
+
+  it("treats out statuses as caution", () => {
+    const result = classifyInjuryStatus("Out", "Sprained ankle");
+    expect(result.level).toBe("caution");
+  });
+
+  it("treats questionable statuses as monitor", () => {
+    const result = classifyInjuryStatus("Questionable", "Game-time decision");
+    expect(result.level).toBe("monitor");
+  });
+
+  it("marks probable statuses as ready", () => {
+    const result = classifyInjuryStatus("Probable", "Expected to play");
+    expect(result.level).toBe("ready");
+  });
+});
+
+describe("normalizeInjuryEntry", () => {
+  it("maps player name and team metadata", () => {
+    const injury: BdlPlayerInjury = {
+      player: {
+        id: 56677838,
+        first_name: "Kobe",
+        last_name: "Bufkin",
+        team_id: 1,
+      },
+      status: "Out",
+      return_date: "Nov 17",
+      description: "Nov 16: Bufkin (shoulder) is listed as doubtful for Sunday's game against the Trail Blazers.",
+      updated_at: "2024-11-16T18:30:00Z",
+    };
+
+    const normalized = normalizeInjuryEntry(injury, 0);
+    expect(normalized).not.toBeNull();
+    expect(normalized?.playerName).toBe("Kobe Bufkin");
+    expect(normalized?.teamTricode).toBe("ATL");
+    expect(normalized?.teamName).toBe("Atlanta Hawks");
+    expect(normalized?.reportLabel).toBe("Nov 16");
+    expect(normalized?.statusLevel).toBe("caution");
+  });
+
+  it("returns null when player information is incomplete", () => {
+    const injury: BdlPlayerInjury = {
+      player: {
+        first_name: "",
+        last_name: "",
+      },
+      status: "Out",
+    };
+
+    const normalized = normalizeInjuryEntry(injury, 0);
+    expect(normalized).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Ball Don't Lie team mapping helpers and injury fetch utilities
- generate a player injury snapshot JSON from the BDL API and limit to the top 10 entries
- update the homepage health monitor to load the snapshot and add coverage for the injury logic

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dbff5a9fa083279a4fc5f7d1647d99