### PR TITLE
Refactor players atlas to consume live BallDontLie data

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -33,17 +33,17 @@
       </header>
 
       <main id="players-app" class="players-lab">
-        <section class="players-lab__section player-atlas" data-player-profiles>
-          <header class="players-lab__section-header">
-            <h2>Player scouting atlas</h2>
-            <p class="players-lab__lede">
-              Search the active 2025-26 roster pool to surface bespoke scouting percentiles for every player. Choose a
-              player to instantly render his GOAT index snapshot, vitals, and twelve curated visual reads.
-            </p>
-          </header>
-          <div class="player-atlas__layout">
+        <section class="player-atlas" data-player-profiles>
+          <div class="player-atlas__header">
+            <div class="player-atlas__title">
+              <h1>Active Player Atlas</h1>
+              <p>
+                Use the BallDontLie-powered roster feed to surface every active player heading into the 2025-26 season.
+                Search directly or browse each franchise to pull a live card.
+              </p>
+            </div>
             <div class="player-atlas__search">
-              <label class="player-atlas__label" for="player-atlas-search">Find a player</label>
+              <label class="player-atlas__label" for="player-atlas-search">Search active players</label>
               <div class="player-atlas__searchbox">
                 <div class="player-atlas__field">
                   <input
@@ -51,7 +51,7 @@
                     class="player-atlas__input"
                     type="search"
                     name="player-search"
-                    placeholder="Search by name, nickname, or era (e.g. &quot;Wemby&quot;, &quot;90s&quot;)"
+                    placeholder="Search by name or jersey (e.g. &quot;Curry&quot;, &quot;#0&quot;)"
                     autocomplete="off"
                     spellcheck="false"
                     data-player-search
@@ -70,94 +70,92 @@
               </div>
               <p class="player-atlas__hint" data-player-hint>Start typing to explore the atlas.</p>
               <p class="player-atlas__empty" data-player-empty hidden>
-                No players found. Try a different era, nickname, or franchise.
+                No active players match that search. Try a different name or jersey number.
               </p>
               <p class="player-atlas__error" data-player-error hidden>
-                We couldn't load the atlas right now. Refresh to try again.
+                We couldn't load the BallDontLie roster feed right now. Refresh to try again.
               </p>
             </div>
-            <div class="player-atlas__teams" data-player-teams hidden>
-              <h3 class="player-atlas__teams-title">Browse by franchise</h3>
+          </div>
+          <div class="player-atlas__layout">
+            <aside class="player-atlas__teams" data-player-teams hidden>
+              <h2 class="player-atlas__teams-title">Active franchises</h2>
               <p class="player-atlas__teams-copy">
-                Expand a team to scan its 2025-26 roster and jump straight to a player's scouting card.
+                Expand a franchise to browse its BallDontLie roster and jump straight to a player's live card.
               </p>
               <div class="player-atlas__teams-tree" data-player-team-tree></div>
-            </div>
+            </aside>
             <article class="player-card" data-player-profile hidden aria-live="polite">
               <header class="player-card__header">
-                <div class="player-card__identity">
-                  <h3 class="player-card__name" data-player-name></h3>
-                  <p class="player-card__meta" data-player-meta></p>
-                </div>
-                <div class="player-card__goat">
-                  <span class="player-card__goat-label">GOAT scores</span>
-                  <div class="player-card__goat-grid">
-                    <div class="player-card__goat-entry">
-                      <span
-                        class="player-card__goat-value"
-                        data-player-goat-recent
-                        aria-label="GOAT score over the last three seasons"
-                      >
-                        <span class="player-card__goat-number" data-player-goat-recent-score>—</span>
-                        <span class="player-card__goat-rank" data-player-goat-recent-rank>No. —</span>
-                      </span>
-                      <span class="player-card__goat-context">Last 3 seasons (2022-23 to 2024-25)</span>
-                    </div>
-                    <div class="player-card__goat-entry">
-                      <span
-                        class="player-card__goat-value"
-                        data-player-goat-historic
-                        aria-label="Career GOAT score"
-                      >
-                        <span class="player-card__goat-number" data-player-goat-historic-score>—</span>
-                        <span class="player-card__goat-rank" data-player-goat-historic-rank>No. —</span>
-                      </span>
-                      <span class="player-card__goat-context">All-time GOAT resume</span>
-                    </div>
-                  </div>
-                </div>
+                <h2 class="player-card__name" data-player-name></h2>
+                <p class="player-card__meta" data-player-meta></p>
               </header>
-              <div class="player-card__body">
-                <p class="player-card__bio" data-player-bio></p>
-                <dl class="player-card__facts">
-                  <div class="player-card__fact">
-                    <dt>Archetype</dt>
-                    <dd data-player-archetype>—</dd>
-                  </div>
-                  <div class="player-card__fact">
-                    <dt>Vitals</dt>
-                    <dd data-player-vitals>—</dd>
-                  </div>
-                  <div class="player-card__fact">
-                    <dt>Origin</dt>
-                    <dd data-player-origin>—</dd>
-                  </div>
-                  <div class="player-card__fact">
-                    <dt>Draft</dt>
-                    <dd data-player-draft>—</dd>
-                  </div>
-                </dl>
-              </div>
-              <section
-                class="player-card__visuals-section"
-                aria-labelledby="player-card-visuals-title"
-              >
-                <header class="player-card__visuals-header">
-                  <h4 id="player-card-visuals-title">Percentile visual reads</h4>
-                  <p>
-                    Twelve scouting gauges anchor the 2025-26 outlook on each player's 2024-25
-                    production — a quick scan of creation, feel, and defensive range.
-                  </p>
+              <dl class="player-card__facts">
+                <div class="player-card__fact">
+                  <dt>Team</dt>
+                  <dd data-player-team>—</dd>
+                </div>
+                <div class="player-card__fact">
+                  <dt>Position</dt>
+                  <dd data-player-position>—</dd>
+                </div>
+                <div class="player-card__fact">
+                  <dt>Jersey</dt>
+                  <dd data-player-jersey>—</dd>
+                </div>
+                <div class="player-card__fact">
+                  <dt>Height</dt>
+                  <dd data-player-height>—</dd>
+                </div>
+                <div class="player-card__fact">
+                  <dt>Weight</dt>
+                  <dd data-player-weight>—</dd>
+                </div>
+              </dl>
+              <section class="player-card__stats" aria-labelledby="player-card-stats-title">
+                <header class="player-card__stats-header">
+                  <h3 id="player-card-stats-title">
+                    Season averages
+                    <span class="player-card__stats-season" data-player-stats-season></span>
+                  </h3>
+                  <p class="player-card__stats-meta" data-player-stats-meta></p>
                 </header>
-                <div
-                  class="player-card__visuals"
-                  data-player-metrics
-                  aria-label="Percentile visualizations"
-                ></div>
-                <p class="player-card__visuals-empty" data-player-metrics-empty hidden>
-                  Percentile visuals are coming soon for this player.
+                <div class="player-card__stats-grid" data-player-stats>
+                  <div class="player-card__stat">
+                    <span class="player-card__stat-value" data-player-stat-games>—</span>
+                    <span class="player-card__stat-label">G</span>
+                  </div>
+                  <div class="player-card__stat">
+                    <span class="player-card__stat-value" data-player-stat-points>—</span>
+                    <span class="player-card__stat-label">PTS</span>
+                  </div>
+                  <div class="player-card__stat">
+                    <span class="player-card__stat-value" data-player-stat-rebounds>—</span>
+                    <span class="player-card__stat-label">REB</span>
+                  </div>
+                  <div class="player-card__stat">
+                    <span class="player-card__stat-value" data-player-stat-assists>—</span>
+                    <span class="player-card__stat-label">AST</span>
+                  </div>
+                  <div class="player-card__stat">
+                    <span class="player-card__stat-value" data-player-stat-steals>—</span>
+                    <span class="player-card__stat-label">STL</span>
+                  </div>
+                  <div class="player-card__stat">
+                    <span class="player-card__stat-value" data-player-stat-blocks>—</span>
+                    <span class="player-card__stat-label">BLK</span>
+                  </div>
+                </div>
+                <p class="player-card__stats-empty" data-player-stats-empty hidden>
+                  No BallDontLie season averages are available for this player yet.
+                </p>
+                <p class="player-card__stats-error" data-player-stats-error hidden>
+                  We couldn't load BallDontLie season averages right now. Try again later.
                 </p>
               </section>
+              <footer class="player-card__footer">
+                <p data-player-updated></p>
+              </footer>
             </article>
           </div>
         </section>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -4069,26 +4069,51 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .team-marker__label { display: none; }
 }
 .players-lab { display: grid; gap: clamp(2.4rem, 5vw, 3.8rem); margin-bottom: 4rem; }
-.player-atlas { display: grid; gap: clamp(1.6rem, 3.4vw, 2.3rem); }
+.player-atlas {
+  display: grid;
+  gap: clamp(1.8rem, 4vw, 2.8rem);
+  padding: clamp(1.5rem, 3.6vw, 2.4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background:
+    linear-gradient(160deg, rgba(17, 86, 214, 0.1), rgba(244, 181, 63, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: var(--shadow-soft);
+}
+.player-atlas__header {
+  display: grid;
+  gap: clamp(1rem, 2.4vw, 1.5rem);
+}
+.player-atlas__title { display: grid; gap: 0.55rem; }
+.player-atlas__title h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 3.8vw, 2.6rem);
+  color: var(--navy);
+}
+.player-atlas__title p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+}
 .player-atlas__layout {
   display: grid;
   grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
-  gap: clamp(1.4rem, 3vw, 2.2rem);
+  gap: clamp(1.6rem, 3.2vw, 2.4rem);
   align-items: start;
 }
 .player-atlas__search {
-  grid-column: 1;
-  grid-row: 1;
   position: relative;
   display: grid;
   gap: 0.65rem;
+  padding: clamp(1.05rem, 2.6vw, 1.5rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   background:
     linear-gradient(150deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
-    color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(242, 246, 255, 0.85) 30%);
-  padding: clamp(1.1rem, 2.6vw, 1.55rem);
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
   box-shadow: var(--shadow-soft);
+  max-width: min(520px, 100%);
 }
 .player-atlas__label {
   font-size: 0.8rem;
@@ -4187,13 +4212,9 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__error { color: color-mix(in srgb, var(--red) 65%, var(--navy) 35%); }
 .player-atlas__teams {
-  grid-column: 1;
-  grid-row: 2;
   display: grid;
-  gap: 0.65rem;
-  margin-top: -0.35rem;
-  padding-top: 0.9rem;
-  border-top: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  gap: 0.75rem;
+  align-content: start;
 }
 .player-atlas__teams[hidden] { display: none; }
 .player-atlas__teams-title {
@@ -4412,6 +4433,75 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   font-size: 0.95rem;
   color: color-mix(in srgb, var(--text-subtle) 82%, var(--navy) 18%);
 }
+.player-card__stats {
+  display: grid;
+  gap: clamp(0.85rem, 2.2vw, 1.2rem);
+  padding: clamp(1rem, 2.6vw, 1.4rem);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.08), rgba(17, 181, 198, 0.06)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: var(--shadow-soft);
+}
+.player-card__stats-header { display: grid; gap: 0.4rem; }
+.player-card__stats-header h3 {
+  margin: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  font-size: clamp(1.15rem, 2.4vw, 1.45rem);
+  color: color-mix(in srgb, var(--navy) 85%, var(--royal) 15%);
+}
+.player-card__stats-season {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--text-subtle) 68%, var(--navy) 32%);
+}
+.player-card__stats-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+}
+.player-card__stats-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+.player-card__stat {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(160deg, rgba(17, 86, 214, 0.12), rgba(17, 181, 198, 0.12));
+  text-align: center;
+}
+.player-card__stat-value {
+  font-size: clamp(1.35rem, 3.2vw, 1.8rem);
+  font-weight: 700;
+  color: color-mix(in srgb, var(--royal) 70%, var(--navy) 30%);
+}
+.player-card__stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--text-subtle) 70%, var(--navy) 30%);
+}
+.player-card__stats-empty,
+.player-card__stats-error {
+  margin: 0;
+  font-size: 0.88rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
+.player-card__stats-error { color: color-mix(in srgb, var(--red) 65%, var(--navy) 35%); }
+.player-card__footer { margin-top: 0.5rem; }
+.player-card__footer p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
 .player-card__visuals {
   display: grid;
   gap: clamp(0.85rem, 2.2vw, 1.2rem);
@@ -4596,22 +4686,12 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 @media (max-width: 1080px) {
   .player-atlas__layout { grid-template-columns: minmax(0, 1fr); }
-  .player-atlas__search,
-  .player-atlas__teams,
-  .player-card {
-    grid-column: 1;
-    grid-row: auto;
-  }
-  .player-atlas__teams {
-    border-top-color: color-mix(in srgb, var(--border) 52%, transparent);
-  }
+  .player-atlas__layout > * { grid-column: 1; }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .player-card__header { flex-direction: column; align-items: flex-start; }
-  .player-card__goat { justify-items: stretch; }
-  .player-card__goat-entry { justify-items: start; }
-  .player-card__goat-context { text-align: left; }
+  .player-card__stats-grid { grid-template-columns: minmax(0, 1fr); }
 }
 .franchise-footprint {
   display: grid;

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -4241,26 +4241,51 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .team-marker__label { display: none; }
 }
 .players-lab { display: grid; gap: clamp(2.4rem, 5vw, 3.8rem); margin-bottom: 4rem; }
-.player-atlas { display: grid; gap: clamp(1.6rem, 3.4vw, 2.3rem); }
+.player-atlas {
+  display: grid;
+  gap: clamp(1.8rem, 4vw, 2.8rem);
+  padding: clamp(1.5rem, 3.6vw, 2.4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background:
+    linear-gradient(160deg, rgba(17, 86, 214, 0.1), rgba(244, 181, 63, 0.08)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.9) 30%);
+  box-shadow: var(--shadow-soft);
+}
+.player-atlas__header {
+  display: grid;
+  gap: clamp(1rem, 2.4vw, 1.5rem);
+}
+.player-atlas__title { display: grid; gap: 0.55rem; }
+.player-atlas__title h1 {
+  margin: 0;
+  font-size: clamp(1.9rem, 3.8vw, 2.6rem);
+  color: var(--navy);
+}
+.player-atlas__title p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+}
 .player-atlas__layout {
   display: grid;
   grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
-  gap: clamp(1.4rem, 3vw, 2.2rem);
+  gap: clamp(1.6rem, 3.2vw, 2.4rem);
   align-items: start;
 }
 .player-atlas__search {
-  grid-column: 1;
-  grid-row: 1;
   position: relative;
   display: grid;
   gap: 0.65rem;
+  padding: clamp(1.05rem, 2.6vw, 1.5rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   background:
     linear-gradient(150deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
-    color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(242, 246, 255, 0.85) 30%);
-  padding: clamp(1.1rem, 2.6vw, 1.55rem);
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
   box-shadow: var(--shadow-soft);
+  max-width: min(520px, 100%);
 }
 .player-atlas__label {
   font-size: 0.8rem;
@@ -4359,13 +4384,9 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__error { color: color-mix(in srgb, var(--red) 65%, var(--navy) 35%); }
 .player-atlas__teams {
-  grid-column: 1;
-  grid-row: 2;
   display: grid;
-  gap: 0.65rem;
-  margin-top: -0.35rem;
-  padding-top: 0.9rem;
-  border-top: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  gap: 0.75rem;
+  align-content: start;
 }
 .player-atlas__teams[hidden] { display: none; }
 .player-atlas__teams-title {
@@ -4584,6 +4605,75 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   font-size: 0.95rem;
   color: color-mix(in srgb, var(--text-subtle) 82%, var(--navy) 18%);
 }
+.player-card__stats {
+  display: grid;
+  gap: clamp(0.85rem, 2.2vw, 1.2rem);
+  padding: clamp(1rem, 2.6vw, 1.4rem);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  background:
+    linear-gradient(150deg, rgba(17, 86, 214, 0.08), rgba(17, 181, 198, 0.06)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.92) 30%);
+  box-shadow: var(--shadow-soft);
+}
+.player-card__stats-header { display: grid; gap: 0.4rem; }
+.player-card__stats-header h3 {
+  margin: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  font-size: clamp(1.15rem, 2.4vw, 1.45rem);
+  color: color-mix(in srgb, var(--navy) 85%, var(--royal) 15%);
+}
+.player-card__stats-season {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--text-subtle) 68%, var(--navy) 32%);
+}
+.player-card__stats-meta {
+  margin: 0;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-subtle) 80%, var(--navy) 20%);
+}
+.player-card__stats-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+.player-card__stat {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(160deg, rgba(17, 86, 214, 0.12), rgba(17, 181, 198, 0.12));
+  text-align: center;
+}
+.player-card__stat-value {
+  font-size: clamp(1.35rem, 3.2vw, 1.8rem);
+  font-weight: 700;
+  color: color-mix(in srgb, var(--royal) 70%, var(--navy) 30%);
+}
+.player-card__stat-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--text-subtle) 70%, var(--navy) 30%);
+}
+.player-card__stats-empty,
+.player-card__stats-error {
+  margin: 0;
+  font-size: 0.88rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
+.player-card__stats-error { color: color-mix(in srgb, var(--red) 65%, var(--navy) 35%); }
+.player-card__footer { margin-top: 0.5rem; }
+.player-card__footer p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
 .player-card__visuals {
   display: grid;
   gap: clamp(0.85rem, 2.2vw, 1.2rem);
@@ -4768,22 +4858,12 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 @media (max-width: 1080px) {
   .player-atlas__layout { grid-template-columns: minmax(0, 1fr); }
-  .player-atlas__search,
-  .player-atlas__teams,
-  .player-card {
-    grid-column: 1;
-    grid-row: auto;
-  }
-  .player-atlas__teams {
-    border-top-color: color-mix(in srgb, var(--border) 52%, transparent);
-  }
+  .player-atlas__layout > * { grid-column: 1; }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
   .player-card__header { flex-direction: column; align-items: flex-start; }
-  .player-card__goat { justify-items: stretch; }
-  .player-card__goat-entry { justify-items: start; }
-  .player-card__goat-context { text-align: left; }
+  .player-card__stats-grid { grid-template-columns: minmax(0, 1fr); }
 }
 .franchise-footprint {
   display: grid;


### PR DESCRIPTION
## Summary
- rebuild the Players hero with an Active Player Atlas search experience backed by BallDontLie roster data
- rework the front-end logic to serve live BallDontLie metadata and season averages while removing static GOAT content
- refresh shared styles to support the new atlas layout and responsive player card presentation

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dbfe0832008327bc49204d649eb50c