### PR TITLE
Refactor games page to use Ball Don't Lie API data

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="bdl-api-key" content="" />
     <link rel="icon" type="image/png" href="nba-logo-vector-01.png" />
     <link rel="stylesheet" href="styles/hub.css" />
     <title>Games Observatory | NBA Intelligence Hub</title>
@@ -27,218 +28,160 @@
             <a href="about.html">About</a>
           </nav>
         </div>
-        <div class="hero">
-          <span class="eyebrow">Games Observatory</span>
+        <div class="hero hero--lab">
+          <div class="hero__intro">
+            <span class="eyebrow">Games Observatory</span>
+            <h1>Ball Don't Lie scoreboard lab</h1>
+            <p class="hero__lead">
+              Tracking the 2025-26 buildup through the Ball Don't Lie games API while keeping the 2024-25 finish as our reference
+              point.
+            </p>
+            <div class="games-toolbar">
+              <label for="game-date">Game date</label>
+              <input id="game-date" type="date" name="game-date" data-game-date />
+              <button type="button" class="games-toolbar__refresh" data-manual-refresh>
+                Refresh now
+              </button>
+            </div>
+          </div>
+          <dl class="hero-metrics hero-metrics--lab">
+            <div class="hero-metrics__item">
+              <dt>Games tracked</dt>
+              <dd>
+                <span data-metric="games-total">—</span>
+                <small>for <span data-selected-date>—</span></small>
+              </dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Live right now</dt>
+              <dd>
+                <span data-metric="live-count">—</span>
+                <small>auto-pinging every 2½ minutes</small>
+              </dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Finals logged</dt>
+              <dd>
+                <span data-metric="final-count">—</span>
+                <small>completed on the slate</small>
+              </dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Average final margin</dt>
+              <dd>
+                <span data-metric="avg-margin">—</span>
+                <small data-metric="avg-detail">Awaiting results</small>
+              </dd>
+            </div>
+            <div class="hero-metrics__item">
+              <dt>Highest scoring output</dt>
+              <dd>
+                <span data-metric="top-total">—</span>
+                <small data-metric="top-detail">No scores yet</small>
+              </dd>
+            </div>
+          </dl>
         </div>
       </header>
 
       <main class="lab-content">
         <section class="lab-grid">
-          <article class="lab-module lab-module--wide" data-chart-wrapper>
+          <article class="lab-module lab-module--wide scoreboard-module">
             <header class="lab-module__header">
-              <h2>Momentum rewrites after halftime</h2>
+              <h2>Scoreboard pulse</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">First-half vs. second-half margins</span>
-                <span class="lab-chip lab-chip--accent" data-metric="headline-swing">—</span>
+                <span class="lab-chip">Powered by Ball Don't Lie</span>
+                <span class="lab-chip lab-chip--accent" data-metric="scoreboard-summary">—</span>
               </div>
             </header>
-            <div class="viz-canvas">
-              <canvas id="momentum-slope" data-chart-ratio="0.55" aria-describedby="momentum-caption"></canvas>
-            </div>
-            <p id="momentum-caption" class="lab-module__caption">
-              Dual lines trace how contenders flip the scoreboard after the break while tooltips
-              surface each club's signature scoring avalanche.
+            <div class="scoreboard-grid" data-scoreboard aria-live="polite"></div>
+            <p class="lab-module__caption">
+              Data syncs directly from the Ball Don't Lie games endpoint. Auto-refreshes every 2½ minutes when today's slate is
+              active.
+              <span class="games-caption-meta">Last update: <span data-refresh>—</span></span>
+              <span class="games-caption-meta" data-fetch-state></span>
             </p>
           </article>
 
           <article class="lab-module" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Itinerary tax on net rating</h2>
+              <h2>Status mix</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Segment miles vs. efficiency</span>
-                <span class="lab-chip">Bubble size encodes games</span>
+                <span class="lab-chip">Upcoming vs. live vs. finals</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="travel-tax" data-chart-ratio="0.8" aria-describedby="travel-caption"></canvas>
+              <canvas id="status-breakdown" data-chart-ratio="0.76" aria-describedby="status-caption"></canvas>
             </div>
-            <p id="travel-caption" class="lab-module__caption">
-              Each bubble plots a road gauntlet, balancing mileage, recovery windows, and the
-              swing it puts on scoring margin.
+            <p id="status-caption" class="lab-module__caption">
+              Doughnut slices show how the slate splits between unplayed, in-progress, and completed games.
             </p>
           </article>
 
           <article class="lab-module" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Arena pulse index</h2>
+              <h2>Tipoff cadence</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Decibel surges vs. comeback closes</span>
+                <span class="lab-chip">Games by local hour</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="crowd-pulse" data-chart-ratio="0.75" aria-describedby="crowd-caption"></canvas>
+              <canvas id="tipoff-curve" data-chart-ratio="0.62" aria-describedby="tipoff-caption"></canvas>
             </div>
-            <p id="crowd-caption" class="lab-module__caption">
-              Bars amplify the loudest momentum spikes while the overlay line tracks how often
-              that noise powers a comeback finish.
+            <p id="tipoff-caption" class="lab-module__caption">
+              Line chart counts how many contests start in each local hour, highlighting the rhythm of the schedule.
             </p>
           </article>
 
           <article class="lab-module lab-module--wide" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Clutch time volatility index</h2>
+              <h2>Margin spread</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Clutch margin vs. win rate</span>
-                <span class="lab-chip">Possession load annotated</span>
+                <span class="lab-chip">Absolute margin buckets</span>
+                <span class="lab-chip lab-chip--accent" data-metric="margin-annotation">—</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="clutch-volatility" data-chart-ratio="0.52" aria-describedby="clutch-caption"></canvas>
+              <canvas id="margin-spread" data-chart-ratio="0.5" aria-describedby="margin-caption"></canvas>
             </div>
-            <p id="clutch-caption" class="lab-module__caption">
-              Combined bars and lines surface which contenders stabilize close games and how their
-              overtime track record shades that composure.
+            <p id="margin-caption" class="lab-module__caption">
+              Bars tally how frequently finals and live games land in each margin band so you can spot tight finishes at a glance.
             </p>
           </article>
 
           <article class="lab-module" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Pace vs. chaos signature</h2>
+              <h2>Single-game scoring leaders</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Game pace vs. lead changes</span>
-                <span class="lab-chip">Bubble area encodes run index</span>
+                <span class="lab-chip">Team points</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="pace-chaos" data-chart-ratio="0.78" aria-describedby="pace-caption"></canvas>
+              <canvas id="scoring-leaders" data-chart-ratio="0.72" aria-describedby="leaders-caption"></canvas>
             </div>
-            <p id="pace-caption" class="lab-module__caption">
-              Scatter bubbles partition four archetypes of nightly drama, balancing tempo against
-              the sheer number of scoreboard flips.
+            <p id="leaders-caption" class="lab-module__caption">
+              Horizontal bars spotlight the loudest offensive performances logged on the selected slate.
             </p>
           </article>
 
           <article class="lab-module" data-chart-wrapper>
             <header class="lab-module__header">
-              <h2>Lead change density</h2>
+              <h2>Score balance</h2>
               <div class="lab-module__meta">
-                <span class="lab-chip">Game count by swing band</span>
-                <span class="lab-chip">Line traces average margin</span>
+                <span class="lab-chip">Visitor points vs. home points</span>
               </div>
             </header>
             <div class="viz-canvas">
-              <canvas id="lead-density" data-chart-ratio="0.6" aria-describedby="lead-caption"></canvas>
+              <canvas id="score-balance" data-chart-ratio="0.78" aria-describedby="balance-caption"></canvas>
             </div>
-            <p id="lead-caption" class="lab-module__caption">
-              Columns stack how often games enter particular lead-change ranges while the companion
-              line reveals the scoreboard cushion those nights settle on.
-            </p>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Rest differential outcomes</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Rest edge vs. win rate</span>
-                <span class="lab-chip">Dot plot shows scoring margin</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="rest-outcomes" data-chart-ratio="0.62" aria-describedby="rest-caption"></canvas>
-            </div>
-            <p id="rest-caption" class="lab-module__caption">
-              Grouped marks compare how extra downtime or back-to-backs reshape win probability and
-              the cushion teams enjoy or surrender.
-            </p>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Overtime heartbeat</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">OT length share</span>
-                <span class="lab-chip">Tooltip tracks win rate</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="overtime-heartbeat" data-chart-ratio="0.66" aria-describedby="overtime-caption"></canvas>
-            </div>
-            <p id="overtime-caption" class="lab-module__caption">
-              A concentric doughnut shows how rare marathon endings really are while surfacing which
-              sessions flip into coin-flip territory.
-            </p>
-          </article>
-
-          <article class="lab-module lab-module--wide" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Shot profile tides</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Shot mix by game state</span>
-                <span class="lab-chip">Stacked to 100%</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="shot-profile" data-chart-ratio="0.5" aria-describedby="shot-caption"></canvas>
-            </div>
-            <p id="shot-caption" class="lab-module__caption">
-              Horizontal stacks reveal how teams shift rim attacks, mid-range probes, and threes as
-              possessions toggle between control, chaos, and desperation.
-            </p>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Whistle cadence</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Fouls and free throws per frame</span>
-                <span class="lab-chip">Overlay line tracks bonus trips</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="whistle-cadence" data-chart-ratio="0.58" aria-describedby="whistle-caption"></canvas>
-            </div>
-            <p id="whistle-caption" class="lab-module__caption">
-              Dual series underline how whistles intensify late while the tooltip surfaces the free
-              throws those calls unlock.
-            </p>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Broadcast window energy</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Audience vs. run frequency</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="broadcast-energy" data-chart-ratio="0.64" aria-describedby="broadcast-caption"></canvas>
-            </div>
-            <p id="broadcast-caption" class="lab-module__caption">
-              Bars benchmark average viewership across tip slots while the overlay line shows how
-              often those windows deliver sustained scoring swings.
-            </p>
-          </article>
-
-          <article class="lab-module" data-chart-wrapper>
-            <header class="lab-module__header">
-              <h2>Altitude acclimation curve</h2>
-              <div class="lab-module__meta">
-                <span class="lab-chip">Elevation vs. net swing</span>
-                <span class="lab-chip">Bubble size signals recovery hours</span>
-              </div>
-            </header>
-            <div class="viz-canvas">
-              <canvas id="altitude-acclimation" data-chart-ratio="0.78" aria-describedby="altitude-caption"></canvas>
-            </div>
-            <p id="altitude-caption" class="lab-module__caption">
-              An elevation scatter dramatizes how thin air magnifies home edges, with bubble sizes
-              echoing the recovery build-up clubs budget for the trip.
+            <p id="balance-caption" class="lab-module__caption">
+              Scatter plot pairs each game’s current score, revealing which matchups stay balanced and which tilt toward one side.
             </p>
           </article>
         </section>
       </main>
 
-      <footer class="page-footer">Powered by box scores, travel logs, and acoustic telemetry nobody else is cross-mapping yet.</footer>
+      <footer class="page-footer">Powered by the Ball Don't Lie games feed with a 2024-25 context lens.</footer>
     </div>
 
     <script src="vendor/chart.umd.js" defer></script>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5326,3 +5326,244 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .roster-player { padding: 0.65rem 0.75rem; }
 }
 
+
+.games-toolbar {
+  margin-top: 1.2rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.games-toolbar label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(17, 86, 214, 0.85);
+}
+
+.games-toolbar input[type='date'] {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(135deg, rgba(17, 86, 214, 0.08), rgba(31, 123, 255, 0.04)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.92) 30%);
+  padding: 0.5rem 0.75rem;
+  font: inherit;
+  color: var(--text-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.games-toolbar input[type='date']:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--royal) 65%, transparent);
+  outline-offset: 2px;
+}
+
+.games-toolbar__refresh {
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.55rem 0.95rem;
+  font: inherit;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.9), rgba(239, 61, 91, 0.88));
+  box-shadow: 0 14px 26px rgba(17, 86, 214, 0.28);
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.games-toolbar__refresh:hover,
+.games-toolbar__refresh:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(17, 86, 214, 0.32);
+}
+
+.games-toolbar__refresh:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.scoreboard-grid {
+  display: grid;
+  gap: clamp(0.9rem, 2vw, 1.2rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.scoreboard-state {
+  margin: 0;
+  padding: clamp(0.85rem, 2vw, 1rem);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--royal) 16%, transparent);
+  background:
+    linear-gradient(130deg, rgba(17, 86, 214, 0.08), rgba(31, 123, 255, 0.05)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.95) 74%, rgba(242, 246, 255, 0.9) 26%);
+  color: var(--text-subtle);
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.scoreboard-card {
+  position: relative;
+  padding: 1rem 1.15rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-left: 4px solid color-mix(in srgb, var(--royal) 65%, transparent);
+  background:
+    linear-gradient(155deg, rgba(17, 86, 214, 0.08), rgba(244, 181, 63, 0.04)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.94) 72%, rgba(242, 246, 255, 0.9) 28%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.scoreboard-card--live {
+  border-left-color: rgba(239, 61, 91, 0.85);
+}
+
+.scoreboard-card--final {
+  border-left-color: rgba(11, 37, 69, 0.85);
+}
+
+.scoreboard-card__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.scoreboard-card__status {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-subtle) 88%, var(--navy) 12%);
+}
+
+.scoreboard-card--live .scoreboard-card__status {
+  color: rgba(239, 61, 91, 0.85);
+}
+
+.scoreboard-card--final .scoreboard-card__status {
+  color: color-mix(in srgb, var(--navy) 90%, var(--text-subtle) 10%);
+}
+
+.scoreboard-card__meta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+.scoreboard-card__rows {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.scoreboard-card__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.scoreboard-card__team {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.scoreboard-card__tricode {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--navy) 70%, transparent);
+}
+
+.scoreboard-card__name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--navy);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.scoreboard-card__score {
+  font-size: clamp(1.4rem, 3.3vw, 1.9rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--navy);
+}
+
+.scoreboard-card__score--lead {
+  color: var(--royal);
+}
+
+.scoreboard-card--live .scoreboard-card__score--lead {
+  color: rgba(239, 61, 91, 0.9);
+}
+
+.scoreboard-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-subtle);
+}
+
+.scoreboard-card__footer span::before {
+  content: '\2022';
+  margin-right: 0.35rem;
+  color: color-mix(in srgb, var(--royal) 70%, transparent);
+}
+
+.scoreboard-card__footer span:first-child::before {
+  content: '';
+  margin: 0;
+}
+
+.games-caption-meta {
+  display: inline-block;
+  margin-left: 0.75rem;
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-subtle) 88%, var(--navy) 12%);
+}
+
+.games-caption-meta:first-of-type {
+  margin-left: 0.5rem;
+}
+
+.games-caption-meta[data-fetch-state] {
+  min-width: 6.5ch;
+}
+
+.games-caption-meta[data-fetch-state].is-error {
+  color: rgba(239, 61, 91, 0.88);
+  font-weight: 600;
+}
+
+.games-caption-meta[data-fetch-state].is-success {
+  color: color-mix(in srgb, var(--royal) 70%, var(--text-subtle) 30%);
+}
+
+@media (max-width: 640px) {
+  .scoreboard-card {
+    padding: 0.85rem 0.9rem 1rem;
+  }
+
+  .scoreboard-card__rows {
+    gap: 0.45rem;
+  }
+
+  .scoreboard-card__team {
+    gap: 0.4rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the games landing page with a Ball Don't Lie-powered scoreboard hero, refreshed modules, and API key wiring
- rebuild the games JavaScript to fetch the latest slate, drive metrics, scoreboard rendering, and chart configurations directly from the API
- expand the shared styles with toolbar and scoreboard treatments to support the new layout

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68dc00198bb88327a08f7d8c3fe85d08