### PR TITLE
Default games view to 2024-25 finale data

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -34,7 +34,8 @@
             <h1>Ball Don't Lie scoreboard lab</h1>
             <p class="hero__lead">
               Tracking the 2025-26 buildup through the Ball Don't Lie games API while keeping the 2024-25 finish as our reference
-              point.
+              point—the default slate spotlights the June 22, 2025 finale so every chart stays populated until the new campaign
+              tips off.
             </p>
             <div class="games-toolbar">
               <label for="game-date">Game date</label>

--- a/public/scripts/games.js
+++ b/public/scripts/games.js
@@ -3,6 +3,8 @@ import { registerCharts, destroyCharts, helpers } from './hub-charts.js';
 const API_BASE = 'https://api.balldontlie.io/v1';
 const PAGE_SIZE = 100;
 const REFRESH_INTERVAL_MS = 150000;
+const NEXT_SEASON_TIPOFF_DATE = '2025-10-04';
+const LAST_COMPLETED_SEASON_FINALE = '2025-06-22';
 
 const stageRank = { live: 0, upcoming: 1, final: 2 };
 
@@ -25,7 +27,15 @@ const metricTargets = {
   fetchState: document.querySelector('[data-fetch-state]'),
 };
 
-let activeDate = getTodayIso();
+function determineInitialDate() {
+  const today = getTodayIso();
+  if (today >= NEXT_SEASON_TIPOFF_DATE) {
+    return today;
+  }
+  return LAST_COMPLETED_SEASON_FINALE;
+}
+
+let activeDate = determineInitialDate();
 let latestGames = [];
 let lastUpdated = null;
 let refreshTimer = null;


### PR DESCRIPTION
## Summary
- default the games observatory to a June 22, 2025 slate from the completed 2024-25 campaign so charts load with real data
- update the page intro copy to explain the 2024-25 fallback until the 2025-26 season tips off

## Testing
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68dc0690e1948327b2617a1e423feb7f