### PR TITLE
Fix games page default date and calendar bounds

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -34,7 +34,7 @@
             <h1>Scoreboard lab</h1>
             <p class="hero__lead">
               Tracking the 2025-26 buildup through our live games feed while keeping the 2024-25 finish as our reference
-              point—the default slate spotlights the June 22, 2025 finale so every chart stays populated until the new campaign
+              point—the default slate spotlights the June 22, 2024 finale so every chart stays populated until the new campaign
               tips off.
             </p>
             <div class="games-toolbar">


### PR DESCRIPTION
## Summary
- point the games landing copy at the correct 2024 Finals date
- clamp the default games date to the most recent completed slate
- restrict the calendar control to archive coverage and today to avoid impossible future fetches

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc124f251c8327b7feee6ec2f64aeb