### PR TITLE
Improve player atlas search experience and franchise tree layout

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -42,49 +42,51 @@
                 Search directly or browse each franchise to pull a live card.
               </p>
             </div>
-            <div class="player-atlas__search">
-              <label class="player-atlas__label" for="player-atlas-search">Search active players</label>
-              <div class="player-atlas__searchbox">
-                <div class="player-atlas__field">
-                  <input
-                    id="player-atlas-search"
-                    class="player-atlas__input"
-                    type="search"
-                    name="player-search"
-                    placeholder="Search by name or jersey (e.g. &quot;Curry&quot;, &quot;#0&quot;)"
-                    autocomplete="off"
-                    spellcheck="false"
-                    data-player-search
-                    aria-controls="player-atlas-results"
-                    aria-expanded="false"
-                  />
-                  <button type="button" class="player-atlas__clear" data-player-clear hidden>Clear</button>
-                </div>
-                <ul
-                  id="player-atlas-results"
-                  class="player-atlas__results"
-                  role="listbox"
-                  data-player-results
-                  hidden
-                ></ul>
-              </div>
-              <p class="player-atlas__hint" data-player-hint>Start typing to explore the atlas.</p>
-              <p class="player-atlas__empty" data-player-empty hidden>
-                No active players match that search. Try a different name or jersey number.
-              </p>
-              <p class="player-atlas__error" data-player-error hidden>
-                We couldn't load the roster feed right now. Refresh to try again.
-              </p>
-            </div>
           </div>
           <div class="player-atlas__layout">
-            <aside class="player-atlas__teams" data-player-teams hidden>
-              <h2 class="player-atlas__teams-title">Active franchises</h2>
-              <p class="player-atlas__teams-copy">
-                Expand a franchise to browse its roster snapshot and jump straight to a player's live card.
-              </p>
-              <div class="player-atlas__teams-tree" data-player-team-tree></div>
-            </aside>
+            <div class="player-atlas__panel">
+              <div class="player-atlas__search">
+                <label class="player-atlas__label" for="player-atlas-search">Search active players</label>
+                <div class="player-atlas__searchbox">
+                  <div class="player-atlas__field">
+                    <input
+                      id="player-atlas-search"
+                      class="player-atlas__input"
+                      type="search"
+                      name="player-search"
+                      placeholder="Search by name or jersey (e.g. &quot;Curry&quot;, &quot;#0&quot;)"
+                      autocomplete="off"
+                      spellcheck="false"
+                      data-player-search
+                      aria-controls="player-atlas-results"
+                      aria-expanded="false"
+                    />
+                    <button type="button" class="player-atlas__clear" data-player-clear hidden>Clear</button>
+                  </div>
+                  <ul
+                    id="player-atlas-results"
+                    class="player-atlas__results"
+                    role="listbox"
+                    data-player-results
+                    hidden
+                  ></ul>
+                </div>
+                <p class="player-atlas__hint" data-player-hint>Start typing to explore the atlas.</p>
+                <p class="player-atlas__empty" data-player-empty hidden>
+                  No active players match that search. Try a different name or jersey number.
+                </p>
+                <p class="player-atlas__error" data-player-error hidden>
+                  We couldn't load the roster feed right now. Refresh to try again.
+                </p>
+              </div>
+              <aside class="player-atlas__teams" data-player-teams hidden>
+                <h2 class="player-atlas__teams-title">Active franchises</h2>
+                <p class="player-atlas__teams-copy">
+                  Expand a franchise to browse its roster snapshot and jump straight to a player's live card.
+                </p>
+                <div class="player-atlas__teams-tree" data-player-team-tree></div>
+              </aside>
+            </div>
             <article class="player-card" data-player-profile hidden aria-live="polite">
               <header class="player-card__header">
                 <h2 class="player-card__name" data-player-name></h2>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -4607,9 +4607,15 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__layout {
   display: grid;
-  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
   gap: clamp(1.6rem, 3.2vw, 2.4rem);
   align-items: start;
+}
+.player-atlas__panel {
+  display: grid;
+  gap: clamp(1rem, 2.4vw, 1.45rem);
+  align-content: start;
+  max-width: min(420px, 100%);
 }
 .player-atlas__search {
   position: relative;
@@ -4622,7 +4628,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
     linear-gradient(150deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1)),
     color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.9) 30%);
   box-shadow: var(--shadow-soft);
-  max-width: min(520px, 100%);
+  max-width: 100%;
 }
 .player-atlas__label {
   font-size: 0.8rem;
@@ -4722,28 +4728,35 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-atlas__error { color: color-mix(in srgb, var(--red) 65%, var(--navy) 35%); }
 .player-atlas__teams {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.65rem;
   align-content: start;
+  padding: clamp(0.9rem, 2vw, 1.1rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  background:
+    linear-gradient(160deg, rgba(17, 86, 214, 0.06), rgba(244, 181, 63, 0.04)),
+    color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.88) 30%);
+  box-shadow: var(--shadow-soft);
 }
 .player-atlas__teams[hidden] { display: none; }
 .player-atlas__teams-title {
   margin: 0;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 700;
   color: var(--navy);
 }
 .player-atlas__teams-copy {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-atlas__teams-tree {
   display: flex;
   flex-direction: column;
-  gap: 0.55rem;
-  max-height: clamp(16rem, 48vh, 22rem);
+  gap: 0.4rem;
+  max-height: clamp(12rem, 42vh, 18rem);
   overflow-y: auto;
-  padding-right: 0.25rem;
+  padding-right: 0.2rem;
 }
 
 .player-atlas__teams-tree > * {
@@ -4752,9 +4765,8 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-atlas__teams-tree:focus-visible { outline: none; }
 .player-atlas__team {
   border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  background: color-mix(in srgb, rgba(255, 255, 255, 0.95) 70%, rgba(242, 246, 255, 0.88) 30%);
-  box-shadow: var(--shadow-soft);
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  background: color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(242, 246, 255, 0.88) 30%);
   overflow: hidden;
 }
 .player-atlas__team-summary {
@@ -4762,8 +4774,8 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 0.9rem;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
   cursor: pointer;
   font-weight: 600;
   color: var(--navy);
@@ -4772,16 +4784,16 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-atlas__team-summary::marker {
   display: none;
 }
-.player-atlas__team-name { font-size: 0.92rem; }
+.player-atlas__team-name { font-size: 0.88rem; }
 .player-atlas__team-count {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 2ch;
-  padding: 0.1rem 0.5rem;
+  padding: 0.08rem 0.45rem;
   border-radius: 999px;
-  background: color-mix(in srgb, rgba(17, 86, 214, 0.16) 60%, rgba(244, 181, 63, 0.2) 40%);
-  font-size: 0.75rem;
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.18) 60%, rgba(244, 181, 63, 0.18) 40%);
+  font-size: 0.7rem;
   font-weight: 700;
   color: color-mix(in srgb, var(--royal) 68%, var(--navy) 32%);
 }
@@ -4790,9 +4802,10 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__team-roster {
   margin: 0;
-  padding: 0 0 0.75rem;
+  padding: 0 0.35rem 0.45rem;
   list-style: none;
   display: grid;
+  gap: 0.15rem;
 }
 .player-atlas__team-entry { margin: 0; }
 .player-atlas__team-player {
@@ -4800,29 +4813,29 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   border: 0;
   background: transparent;
   text-align: left;
-  padding: 0.65rem 1rem 0.6rem;
+  padding: 0.48rem 0.65rem 0.45rem;
   display: grid;
-  gap: 0.2rem;
+  gap: 0.18rem;
   font: inherit;
   color: var(--navy);
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease;
+  border-radius: var(--radius-sm);
 }
 .player-atlas__team-player:hover,
 .player-atlas__team-player:focus-visible,
 .player-atlas__team-player.is-active {
-  background: linear-gradient(135deg, rgba(17, 86, 214, 0.16), rgba(244, 181, 63, 0.14));
+  background: linear-gradient(135deg, rgba(17, 86, 214, 0.18), rgba(244, 181, 63, 0.16));
   color: var(--navy);
 }
 .player-atlas__team-player:focus-visible { outline: none; }
-.player-atlas__team-player-name { font-weight: 600; font-size: 0.9rem; }
+.player-atlas__team-player-name { font-weight: 600; font-size: 0.86rem; }
 .player-atlas__team-player-meta {
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-card {
   grid-column: 2;
-  grid-row: 1 / span 2;
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
@@ -4832,6 +4845,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   display: grid;
   gap: clamp(1rem, 2.6vw, 1.6rem);
   padding: clamp(1.25rem, 2.8vw, 2rem);
+  align-self: stretch;
 }
 .player-card[hidden] { display: none; }
 .player-card__header {
@@ -5196,6 +5210,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 @media (max-width: 1080px) {
   .player-atlas__layout { grid-template-columns: minmax(0, 1fr); }
   .player-atlas__layout > * { grid-column: 1; }
+  .player-atlas__panel { max-width: none; }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- refactor the player atlas markup to stack the search panel and compact franchise tree alongside the player card
- update styles to shrink the roster tree footprint and keep the new panel layout responsive
- add a dedicated search engine with richer tokens so search and team browsing share the same player card without performance coupling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc11a4618c83278ff78b8132c644ec