### PR TITLE
Refactor GOAT scoring to use measurable components

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -104,7 +104,7 @@
               <div class="viz-canvas">
                 <canvas data-chart="goat-component-radar" aria-label="Component radar comparison"></canvas>
               </div>
-              <figcaption class="viz-card__caption">Radar overlays for the top trio across the five GOAT pillars.</figcaption>
+              <figcaption class="viz-card__caption">Radar overlays for the top trio across the four GOAT pillars.</figcaption>
             </figure>
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Impact vs longevity</header>
@@ -114,11 +114,11 @@
               <figcaption class="viz-card__caption">Scatter comparing prime impact scores against longevity credits.</figcaption>
             </figure>
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Stage vs culture resonance</header>
+              <header class="viz-card__title">Stage vs versatility synergy</header>
               <div class="viz-canvas">
-                <canvas data-chart="goat-stage-culture" aria-label="Stage dominance and cultural capital bubble chart"></canvas>
+                <canvas data-chart="goat-stage-versatility" aria-label="Stage dominance and versatility synergy bubble chart"></canvas>
               </div>
-              <figcaption class="viz-card__caption">Bubble size tracks GOAT value while plotting stage dominance and cultural reach.</figcaption>
+              <figcaption class="viz-card__caption">Bubble size tracks GOAT value while plotting stage dominance and versatility range.</figcaption>
             </figure>
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Twelve-month motion</header>

--- a/public/scripts/goat.js
+++ b/public/scripts/goat.js
@@ -789,7 +789,7 @@ async function init() {
         },
       },
       {
-        element: document.querySelector('[data-chart="goat-stage-culture"]'),
+        element: document.querySelector('[data-chart="goat-stage-versatility"]'),
         source: goatDataSource,
         async createConfig(source) {
           const playersSource = Array.isArray(source?.players) ? source.players : [];
@@ -798,7 +798,7 @@ async function init() {
             .filter((player) => player.goatComponents)
             .map((player) => ({
               x: player.goatComponents.stage ?? 0,
-              y: player.goatComponents.culture ?? 0,
+              y: player.goatComponents.versatility ?? 0,
               r: Math.max(6, (player.goatScore ?? 0) * 0.25),
               name: player.name,
               status: player.status ?? 'Unknown',
@@ -808,7 +808,7 @@ async function init() {
             data: {
               datasets: [
                 {
-                  label: 'Stage vs culture',
+                  label: 'Stage vs versatility',
                   data: dataset,
                   backgroundColor: 'rgba(239, 61, 91, 0.32)',
                   borderColor: palette.coral,
@@ -824,7 +824,7 @@ async function init() {
                   callbacks: {
                     label(context) {
                       const raw = context.raw;
-                      return `${raw.name}: Stage ${helpers.formatNumber(raw.x, 1)}, Culture ${helpers.formatNumber(
+                      return `${raw.name}: Stage ${helpers.formatNumber(raw.x, 1)}, Versatility ${helpers.formatNumber(
                         raw.y,
                         1,
                       )}`;
@@ -838,7 +838,7 @@ async function init() {
                   grid: { color: 'rgba(11, 37, 69, 0.08)' },
                 },
                 y: {
-                  title: { display: true, text: 'Cultural capital' },
+                  title: { display: true, text: 'Versatility credit' },
                   grid: { color: 'rgba(11, 37, 69, 0.08)' },
                 },
               },

--- a/public/scripts/history.js
+++ b/public/scripts/history.js
@@ -458,12 +458,6 @@ function renderVisuals(goatEntry, references) {
       percentile: computePercentile(goatEntry.goatComponents?.versatility ?? null, references.versatility),
     },
     {
-      label: 'Culture',
-      value: goatEntry.goatComponents?.culture,
-      display: decimalFormatter.format(goatEntry.goatComponents?.culture ?? 0),
-      percentile: computePercentile(goatEntry.goatComponents?.culture ?? null, references.culture),
-    },
-    {
       label: 'Career win %',
       value: goatEntry.winPct,
       display: goatEntry.winPct != null ? percentFormatter.format(goatEntry.winPct) : '—',
@@ -563,7 +557,6 @@ function buildGoatReferences(goatPlayers) {
     stage: [],
     longevity: [],
     versatility: [],
-    culture: [],
     winPct: [],
     playoffWinPct: [],
     careerLength: [],
@@ -577,7 +570,6 @@ function buildGoatReferences(goatPlayers) {
     if (Number.isFinite(player.goatComponents?.stage)) refs.stage.push(player.goatComponents.stage);
     if (Number.isFinite(player.goatComponents?.longevity)) refs.longevity.push(player.goatComponents.longevity);
     if (Number.isFinite(player.goatComponents?.versatility)) refs.versatility.push(player.goatComponents.versatility);
-    if (Number.isFinite(player.goatComponents?.culture)) refs.culture.push(player.goatComponents.culture);
     if (Number.isFinite(player.winPct)) refs.winPct.push(player.winPct);
     if (Number.isFinite(player.playoffWinPct)) refs.playoffWinPct.push(player.playoffWinPct);
     if (player.careerSpan) {

--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -56,15 +56,15 @@ const atlasMetricBlueprint = {
   'rim-pressure': {
     extract(context) {
       const impact = context.components?.impact;
-      const culture = context.components?.culture;
-      if (Number.isFinite(impact) && Number.isFinite(culture)) {
-        return impact * 0.75 + culture * 0.25;
+      const versatility = context.components?.versatility;
+      if (Number.isFinite(impact) && Number.isFinite(versatility)) {
+        return impact * 0.7 + versatility * 0.3;
       }
       if (Number.isFinite(impact)) {
         return impact;
       }
-      if (Number.isFinite(culture)) {
-        return culture;
+      if (Number.isFinite(versatility)) {
+        return versatility;
       }
       return null;
     },
@@ -72,17 +72,17 @@ const atlasMetricBlueprint = {
       const impact = Number.isFinite(context.components?.impact)
         ? helpers.formatNumber(context.components.impact, 1)
         : null;
-      const culture = Number.isFinite(context.components?.culture)
-        ? helpers.formatNumber(context.components.culture, 1)
+      const versatility = Number.isFinite(context.components?.versatility)
+        ? helpers.formatNumber(context.components.versatility, 1)
         : null;
-      if (impact && culture) {
-        return `Blend of impact (${impact}) and culture (${culture}) GOAT points fuels rim pressure.`;
+      if (impact && versatility) {
+        return `Blend of impact (${impact}) and versatility (${versatility}) GOAT points fuels rim pressure.`;
       }
       if (impact) {
         return `Impact pillar at ${impact} GOAT points drives rim pressure.`;
       }
-      if (culture) {
-        return `Culture pillar at ${culture} GOAT points steadies rim pressure.`;
+      if (versatility) {
+        return `Versatility pillar at ${versatility} GOAT points steadies rim pressure.`;
       }
       return 'Rim pressure percentile unavailable.';
     },
@@ -123,13 +123,34 @@ const atlasMetricBlueprint = {
   },
   'defensive-playmaking': {
     extract(context) {
-      const value = context.components?.culture;
-      return Number.isFinite(value) ? value : null;
+      const impact = context.components?.impact;
+      const versatility = context.components?.versatility;
+      if (Number.isFinite(impact) && Number.isFinite(versatility)) {
+        return versatility * 0.6 + impact * 0.4;
+      }
+      if (Number.isFinite(versatility)) {
+        return versatility;
+      }
+      if (Number.isFinite(impact)) {
+        return impact;
+      }
+      return null;
     },
     describe(context) {
-      const value = context.components?.culture;
-      if (Number.isFinite(value)) {
-        return `Culture pillar contributes ${helpers.formatNumber(value, 1)} GOAT points of defensive playmaking.`;
+      const impact = Number.isFinite(context.components?.impact)
+        ? helpers.formatNumber(context.components.impact, 1)
+        : null;
+      const versatility = Number.isFinite(context.components?.versatility)
+        ? helpers.formatNumber(context.components.versatility, 1)
+        : null;
+      if (impact && versatility) {
+        return `Versatility (${versatility}) and impact (${impact}) GOAT points shape defensive playmaking.`;
+      }
+      if (versatility) {
+        return `Versatility pillar contributes ${versatility} GOAT points of defensive playmaking.`;
+      }
+      if (impact) {
+        return `Impact pillar contributes ${impact} GOAT points of defensive playmaking.`;
       }
       return 'Defensive playmaking percentile unavailable.';
     },
@@ -166,8 +187,8 @@ const atlasMetricBlueprint = {
       if (Number.isFinite(context.components?.versatility)) {
         parts.push(context.components.versatility * 0.45);
       }
-      if (Number.isFinite(context.components?.culture)) {
-        parts.push(context.components.culture * 0.35);
+      if (Number.isFinite(context.components?.longevity)) {
+        parts.push(context.components.longevity * 0.3);
       }
       if (Number.isFinite(context.winPct)) {
         parts.push(context.winPct * 40);
@@ -182,11 +203,23 @@ const atlasMetricBlueprint = {
       const versatility = Number.isFinite(context.components?.versatility)
         ? helpers.formatNumber(context.components.versatility, 1)
         : null;
-      if (winPct && versatility) {
-        return `Versatility (${versatility}) GOAT points plus a ${winPct}% win rate steer tempo.`;
+      const longevity = Number.isFinite(context.components?.longevity)
+        ? helpers.formatNumber(context.components.longevity, 1)
+        : null;
+      if (winPct && versatility && longevity) {
+        return `Versatility (${versatility}) and longevity (${longevity}) GOAT points plus a ${winPct}% win rate steer tempo.`;
+      }
+      if (versatility && winPct) {
+        return `Versatility pillar at ${versatility} GOAT points and a ${winPct}% win rate steer tempo.`;
+      }
+      if (longevity && winPct) {
+        return `Longevity pillar at ${longevity} GOAT points with a ${winPct}% win rate steadies tempo.`;
       }
       if (versatility) {
         return `Versatility pillar at ${versatility} GOAT points anchors pace control.`;
+      }
+      if (longevity) {
+        return `Longevity pillar at ${longevity} GOAT points anchors pace control.`;
       }
       if (winPct) {
         return `Career win rate of ${winPct}% keeps possessions in command.`;
@@ -1197,7 +1230,7 @@ function buildAtlasMetrics(catalog, goatSource) {
     const nameKey = normalizeName(player.name);
     const componentSource = player.goatComponents || {};
     const components = {};
-    ['impact', 'stage', 'longevity', 'versatility', 'culture'].forEach((key) => {
+    ['impact', 'stage', 'longevity', 'versatility'].forEach((key) => {
       const value = toNumber(componentSource[key]);
       if (value !== null) {
         components[key] = value;


### PR DESCRIPTION
## Summary
- replace recent GOAT aggregation with weighted production, impact, efficiency, and availability components derived from Ball Don't Lie logs
- rebuild the historical GOAT scorer without the cultural pillar and rebalance weights across the remaining data-backed pillars
- update the GOAT dashboards to present the four-component system in charts, captions, and derived player metrics

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dc142e056883279546fc532e9f677d