### PR TITLE
Automate milestone chase cards and remove shot lab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -150,17 +150,6 @@
             <p class="tempo-gauge__footnote" data-pace-footnote></p>
           </section>
 
-          <section class="sidebar-card sidebar-card--spacing">
-            <header class="sidebar-card__header">
-              <span class="chip chip--accent">Shot map lab</span>
-              <h3>Spacing experiments to watch</h3>
-              <p>Where new shooting geometry could bend defensive coverage in 2025-26.</p>
-            </header>
-            <div class="spacing-lab" data-spacing-lab>
-              <p class="spacing-lab__placeholder">Spacing models syncing…</p>
-            </div>
-          </section>
-
           <section class="sidebar-card sidebar-card--rest">
             <header class="sidebar-card__header">
               <span class="chip chip--accent">Travel analytics</span>
@@ -182,40 +171,8 @@
               <h3>Milestones on deck</h3>
               <p>Keep these thresholds on your radar—the chase frames weekly coverage and fuels the season-long narrative.</p>
             </header>
-            <div class="milestone-chase__grid milestone-chase__grid--stacked">
-              <article class="milestone-card">
-                <header>
-                  <span class="milestone-card__tag">Scoring climb</span>
-                  <h3>LeBron: 55K pace car</h3>
-                </header>
-                <p>Now past 50,000 career points, James needs 4,872 more to summit the 55K plateau—keep an eye on his 27.5 ppg track.</p>
-                <ul>
-                  <li>Key stretch: coastal swing with five marquee national games in February</li>
-                  <li>Projected milestone game: vs. Knicks (Apr 6)</li>
-                </ul>
-              </article>
-              <article class="milestone-card">
-                <header>
-                  <span class="milestone-card__tag">Defensive pillar</span>
-                  <h3>Rudy Gobert</h3>
-                </header>
-                <p>Fresh off his fourth DPOY, Gobert is hunting an unprecedented fifth trophy while anchoring another top-flight Wolves defense.</p>
-                <ul>
-                  <li>Minnesota pacing for best opponent rim field-goal rate in franchise history</li>
-                  <li>Needs 186 blocks to hit the 2,500 milestone club</li>
-                </ul>
-              </article>
-              <article class="milestone-card">
-                <header>
-                  <span class="milestone-card__tag">Sharpshooter ledger</span>
-                  <h3>Stephen Curry</h3>
-                </header>
-                <p>The league's three-point king sits at 3,929 career triples and is tracking toward the 4,000 benchmark before All-Star Weekend.</p>
-                <ul>
-                  <li>Needs just 71 threes—on pace to clear it in 26 games at his current clip</li>
-                  <li>Chase spotlight: Warriors at Lakers on national TV Jan 18</li>
-                </ul>
-              </article>
+            <div class="milestone-chase__grid milestone-chase__grid--stacked" data-milestone-chase>
+              <p class="milestone-chase__placeholder">Milestone tracking is syncing with the latest BallDontLie data…</p>
             </div>
           </section>
         </aside>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -141,8 +141,7 @@ a:hover, a:focus { color: var(--sky); }
   font-size: 0.95rem;
 }
 
-.injury-grid,
-.spacing-lab {
+.injury-grid {
   display: grid;
   gap: 0.75rem;
 }
@@ -162,8 +161,7 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .injury-grid__placeholder,
-.tempo-gauge__placeholder,
-.spacing-lab__placeholder {
+.tempo-gauge__placeholder {
   margin: 0;
   padding: 0.75rem 0.9rem;
   border-radius: var(--radius-md);
@@ -406,97 +404,6 @@ a:hover, a:focus { color: var(--sky); }
 
 .tempo-gauge__note {
   color: color-mix(in srgb, var(--text-subtle) 80%, var(--text-strong) 20%);
-}
-
-.spacing-card {
-  border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--gold) 24%, transparent);
-  background: color-mix(in srgb, var(--surface) 78%, rgba(239, 61, 91, 0.08) 22%);
-  padding: 0.85rem 1rem;
-  display: grid;
-  gap: 0.6rem;
-}
-
-.spacing-card__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-}
-
-.spacing-card__identity {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.spacing-card__team {
-  margin: 0;
-  font-weight: 600;
-}
-
-.spacing-card__tag {
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.35rem 0.65rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--red) 30%, transparent);
-  color: var(--red);
-  white-space: nowrap;
-}
-
-.spacing-card__metrics {
-  margin: 0;
-  display: grid;
-  gap: 0.4rem;
-}
-
-.spacing-card__metric {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.spacing-card__metric dt {
-  margin: 0;
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: color-mix(in srgb, var(--text-subtle) 75%, var(--text-strong) 25%);
-}
-
-.spacing-card__metric dd {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  font-size: 0.9rem;
-  color: var(--text-strong);
-}
-
-.spacing-card__bar {
-  flex: 1 1 auto;
-  height: 6px;
-  border-radius: 999px;
-  background: color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(244, 181, 63, 0.4) 30%);
-  overflow: hidden;
-  position: relative;
-}
-
-.spacing-card__bar::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  width: var(--fill, 0%);
-  background: linear-gradient(90deg, var(--gold), var(--red));
-}
-
-.spacing-card__note {
-  margin: 0;
-  font-size: 0.84rem;
-  color: color-mix(in srgb, var(--text-subtle) 78%, var(--text-strong) 22%);
 }
 
 .milestone-chase__grid--stacked {
@@ -5605,6 +5512,16 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   gap: 1.2rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   margin-top: 1.5rem;
+}
+
+.milestone-chase__placeholder {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--royal) 35%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.06) 60%, rgba(255, 255, 255, 0.9) 40%);
+  color: var(--text-subtle);
+  font-size: 0.9rem;
 }
 
 .milestone-card {

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -141,8 +141,7 @@ a:hover, a:focus { color: var(--sky); }
   font-size: 0.95rem;
 }
 
-.injury-grid,
-.spacing-lab {
+.injury-grid {
   display: grid;
   gap: 0.75rem;
 }
@@ -162,8 +161,7 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .injury-grid__placeholder,
-.tempo-gauge__placeholder,
-.spacing-lab__placeholder {
+.tempo-gauge__placeholder {
   margin: 0;
   padding: 0.75rem 0.9rem;
   border-radius: var(--radius-md);
@@ -406,97 +404,6 @@ a:hover, a:focus { color: var(--sky); }
 
 .tempo-gauge__note {
   color: color-mix(in srgb, var(--text-subtle) 80%, var(--text-strong) 20%);
-}
-
-.spacing-card {
-  border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--gold) 24%, transparent);
-  background: color-mix(in srgb, var(--surface) 78%, rgba(239, 61, 91, 0.08) 22%);
-  padding: 0.85rem 1rem;
-  display: grid;
-  gap: 0.6rem;
-}
-
-.spacing-card__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.6rem;
-}
-
-.spacing-card__identity {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  min-width: 0;
-}
-
-.spacing-card__team {
-  margin: 0;
-  font-weight: 600;
-}
-
-.spacing-card__tag {
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: 0.35rem 0.65rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--red) 30%, transparent);
-  color: var(--red);
-  white-space: nowrap;
-}
-
-.spacing-card__metrics {
-  margin: 0;
-  display: grid;
-  gap: 0.4rem;
-}
-
-.spacing-card__metric {
-  display: grid;
-  gap: 0.25rem;
-}
-
-.spacing-card__metric dt {
-  margin: 0;
-  font-size: 0.78rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: color-mix(in srgb, var(--text-subtle) 75%, var(--text-strong) 25%);
-}
-
-.spacing-card__metric dd {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  font-size: 0.9rem;
-  color: var(--text-strong);
-}
-
-.spacing-card__bar {
-  flex: 1 1 auto;
-  height: 6px;
-  border-radius: 999px;
-  background: color-mix(in srgb, rgba(255, 255, 255, 0.9) 70%, rgba(244, 181, 63, 0.4) 30%);
-  overflow: hidden;
-  position: relative;
-}
-
-.spacing-card__bar::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  width: var(--fill, 0%);
-  background: linear-gradient(90deg, var(--gold), var(--red));
-}
-
-.spacing-card__note {
-  margin: 0;
-  font-size: 0.84rem;
-  color: color-mix(in srgb, var(--text-subtle) 78%, var(--text-strong) 22%);
 }
 
 .milestone-chase__grid--stacked {
@@ -5253,6 +5160,16 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   gap: 1.2rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   margin-top: 1.5rem;
+}
+
+.milestone-chase__placeholder {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed color-mix(in srgb, var(--royal) 35%, transparent);
+  background: color-mix(in srgb, rgba(17, 86, 214, 0.06) 60%, rgba(255, 255, 255, 0.9) 40%);
+  color: var(--text-subtle);
+  font-size: 0.9rem;
 }
 
 .milestone-card {


### PR DESCRIPTION
## Summary
- replace the static Chase File sidebar cards with dynamic content generated from the BallDontLie career leader and roster data
- remove the unused Shot Map lab module and clean up its related styles in both the public and site stylesheets
- add placeholder styling for the automated milestone deck to keep the sidebar layout consistent

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc18e7cf288327908da99250ea5526