### PR TITLE
Remove Dwight Howard from active roster index

### DIFF
--- a/public/data/players_index.json
+++ b/public/data/players_index.json
@@ -1,7 +1,7 @@
 {
   "fetched_at": "2025-09-29T13:47:09.758Z",
   "source": "rosters.json",
-  "count": 505,
+  "count": 504,
   "players": [
     {
       "id": 203992,
@@ -3444,15 +3444,6 @@
     {
       "id": 201588,
       "name": "George Hill",
-      "team_abbr": "PHI",
-      "position": null,
-      "jersey": null,
-      "height": null,
-      "weight": null
-    },
-    {
-      "id": 2730,
-      "name": "Dwight Howard",
       "team_abbr": "PHI",
       "position": null,
       "jersey": null,


### PR DESCRIPTION
## Summary
- remove the inactive Dwight Howard entry from the players index so the milestone chase uses current players

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc23a551c48327bf1582facb2ae033