### PR TITLE
Fix BDL credential lookup paths

### DIFF
--- a/public/scripts/bdl-credentials.js
+++ b/public/scripts/bdl-credentials.js
@@ -44,7 +44,7 @@
     }
   }
 
-  const KEY_LOCATIONS = ['bdl-key.json', 'data/bdl-key.json'];
+  const KEY_LOCATIONS = ['/bdl-key.json', '/data/bdl-key.json'];
 
   (async () => {
     for (const path of KEY_LOCATIONS) {


### PR DESCRIPTION
## Summary
- ensure the client fetches Ball Don't Lie credentials from absolute paths so static pages resolve the stub

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc25edf8a88327ad3ec9ae92632fba