### PR TITLE
Handle missing Ball Don't Lie credentials on games page

### DIFF
--- a/public/data/bdl-key.json
+++ b/public/data/bdl-key.json
@@ -1,0 +1,4 @@
+{
+  "key": "",
+  "note": "Populate this file with your Ball Don't Lie API key or inject a meta[name=bdl-api-key] tag at runtime."
+}

--- a/public/scripts/bdl-credentials.js
+++ b/public/scripts/bdl-credentials.js
@@ -44,13 +44,21 @@
     }
   }
 
-  const KEY_LOCATIONS = ['bdl-key.json', 'data/bdl-key.json'];
+  const KEY_LOCATIONS = ['data/bdl-key.json', 'bdl-key.json'];
 
   (async () => {
     for (const path of KEY_LOCATIONS) {
       try {
         const response = await fetch(path, { cache: 'no-store' });
         if (!response.ok) {
+          if (response.status === 404) {
+            continue;
+          }
+          console.warn(
+            "Unexpected response while loading Ball Don't Lie credential stub from",
+            path,
+            response.status,
+          );
           continue;
         }
         const payload = await response.json().catch(() => null);
@@ -58,6 +66,9 @@
         if (applyKey(key)) {
           return;
         }
+        // If we reached a real stub file but it did not provide a key, stop here to
+        // avoid cascading fetch attempts that create additional console noise.
+        return;
       } catch (error) {
         console.warn('Unable to load Ball Don\'t Lie credential stub from', path, error);
       }


### PR DESCRIPTION
## Summary
- prevent the games page from calling the Ball Don't Lie API when no credential is configured and surface a clear error message instead
- adjust the credential bootstrap script to stop after the first successful stub and warn on unexpected responses
- add a placeholder bdl-key.json stub so local runs avoid 404 noise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc25c0364c832794118113f168e169