### PR TITLE
Enable date range selection on games observatory

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -38,8 +38,24 @@
               tips off.
             </p>
             <div class="games-toolbar">
-              <label for="game-date">Game date</label>
-              <input id="game-date" type="date" name="game-date" data-game-date />
+              <label for="game-date-start">Game dates</label>
+              <div class="games-toolbar__range">
+                <input
+                  id="game-date-start"
+                  type="date"
+                  name="game-date-start"
+                  data-game-date-start
+                  aria-label="Start date"
+                />
+                <span class="games-toolbar__separator" aria-hidden="true">to</span>
+                <input
+                  id="game-date-end"
+                  type="date"
+                  name="game-date-end"
+                  data-game-date-end
+                  aria-label="End date"
+                />
+              </div>
               <button type="button" class="games-toolbar__refresh" data-manual-refresh>
                 Refresh now
               </button>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5961,6 +5961,18 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   color: rgba(17, 86, 214, 0.85);
 }
 
+.games-toolbar__range {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.games-toolbar__separator {
+  font-size: 0.85rem;
+  color: color-mix(in srgb, var(--text-muted, #6b7a90) 80%, transparent);
+}
+
 .games-toolbar input[type='date'] {
   appearance: none;
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);


### PR DESCRIPTION
## Summary
- add dual date inputs on the games page so visitors can review a span of slates at once
- update the live data loader, metrics, and auto-refresh logic to honor the selected date range
- style the toolbar to accommodate the new range picker presentation

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc3009f504832791bf191c8fc58ed1