### PR TITLE
Restore players page layout and scouting visuals

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -33,126 +33,129 @@
       </header>
 
       <main id="players-app" class="players-lab">
-        <section class="player-atlas" data-player-profiles>
-          <div class="player-atlas__header">
-            <div class="player-atlas__title">
-              <h1>Active Player Atlas</h1>
-              <p>
-                Use the live roster feed to surface every active player heading into the 2025-26 season.
-                Search directly or browse each franchise to pull a live card.
+        <section class="players-lab__section player-atlas" data-player-profiles>
+          <header class="players-lab__section-header">
+            <h2>Player scouting atlas</h2>
+            <p class="players-lab__lede">
+              Search the active 2025-26 roster pool to surface bespoke scouting percentiles for every player. Choose a
+              player to instantly render his GOAT index snapshot, vitals, and twelve curated visual reads.
+            </p>
+          </header>
+          <div class="player-atlas__layout">
+            <div class="player-atlas__search">
+              <label class="player-atlas__label" for="player-atlas-search">Find a player</label>
+              <div class="player-atlas__searchbox">
+                <div class="player-atlas__field">
+                  <input
+                    id="player-atlas-search"
+                    class="player-atlas__input"
+                    type="search"
+                    name="player-search"
+                    placeholder="Search by name, nickname, or era (e.g. &quot;Wemby&quot;, &quot;90s&quot;)"
+                    autocomplete="off"
+                    spellcheck="false"
+                    data-player-search
+                    aria-controls="player-atlas-results"
+                    aria-expanded="false"
+                  />
+                  <button type="button" class="player-atlas__clear" data-player-clear hidden>Clear</button>
+                </div>
+                <ul
+                  id="player-atlas-results"
+                  class="player-atlas__results"
+                  role="listbox"
+                  data-player-results
+                  hidden
+                ></ul>
+              </div>
+              <p class="player-atlas__hint" data-player-hint>Start typing to explore the atlas.</p>
+              <p class="player-atlas__empty" data-player-empty hidden>
+                No players found. Try a different era, nickname, or franchise.
+              </p>
+              <p class="player-atlas__error" data-player-error hidden>
+                We couldn't load the atlas right now. Refresh to try again.
               </p>
             </div>
-          </div>
-          <div class="player-atlas__layout">
-            <div class="player-atlas__panel">
-              <div class="player-atlas__search">
-                <label class="player-atlas__label" for="player-atlas-search">Search active players</label>
-                <div class="player-atlas__searchbox">
-                  <div class="player-atlas__field">
-                    <input
-                      id="player-atlas-search"
-                      class="player-atlas__input"
-                      type="search"
-                      name="player-search"
-                      placeholder="Search by name or jersey (e.g. &quot;Curry&quot;, &quot;#0&quot;)"
-                      autocomplete="off"
-                      spellcheck="false"
-                      data-player-search
-                      aria-controls="player-atlas-results"
-                      aria-expanded="false"
-                    />
-                    <button type="button" class="player-atlas__clear" data-player-clear hidden>Clear</button>
-                  </div>
-                  <ul
-                    id="player-atlas-results"
-                    class="player-atlas__results"
-                    role="listbox"
-                    data-player-results
-                    hidden
-                  ></ul>
-                </div>
-                <p class="player-atlas__hint" data-player-hint>Start typing to explore the atlas.</p>
-                <p class="player-atlas__empty" data-player-empty hidden>
-                  No active players match that search. Try a different name or jersey number.
-                </p>
-                <p class="player-atlas__error" data-player-error hidden>
-                  We couldn't load the roster feed right now. Refresh to try again.
-                </p>
-              </div>
-              <aside class="player-atlas__teams" data-player-teams hidden>
-                <h2 class="player-atlas__teams-title">Active franchises</h2>
-                <p class="player-atlas__teams-copy">
-                  Expand a franchise to browse its roster snapshot and jump straight to a player's live card.
-                </p>
-                <div class="player-atlas__teams-tree" data-player-team-tree></div>
-              </aside>
+            <div class="player-atlas__teams" data-player-teams hidden>
+              <h3 class="player-atlas__teams-title">Browse by franchise</h3>
+              <p class="player-atlas__teams-copy">
+                Expand a team to scan its 2025-26 roster and jump straight to a player's scouting card.
+              </p>
+              <div class="player-atlas__teams-tree" data-player-team-tree></div>
             </div>
             <article class="player-card" data-player-profile hidden aria-live="polite">
               <header class="player-card__header">
-                <h2 class="player-card__name" data-player-name></h2>
-                <p class="player-card__meta" data-player-meta></p>
+                <div class="player-card__identity">
+                  <h3 class="player-card__name" data-player-name></h3>
+                  <p class="player-card__meta" data-player-meta></p>
+                </div>
+                <div class="player-card__goat">
+                  <span class="player-card__goat-label">GOAT scores</span>
+                  <div class="player-card__goat-grid">
+                    <div class="player-card__goat-entry">
+                      <span
+                        class="player-card__goat-value"
+                        data-player-goat-recent
+                        aria-label="GOAT score over the last three seasons"
+                      >
+                        <span class="player-card__goat-number" data-player-goat-recent-score>—</span>
+                        <span class="player-card__goat-rank" data-player-goat-recent-rank>No. —</span>
+                      </span>
+                      <span class="player-card__goat-context">Last 3 seasons (2022-23 to 2024-25)</span>
+                    </div>
+                    <div class="player-card__goat-entry">
+                      <span
+                        class="player-card__goat-value"
+                        data-player-goat-historic
+                        aria-label="Career GOAT score"
+                      >
+                        <span class="player-card__goat-number" data-player-goat-historic-score>—</span>
+                        <span class="player-card__goat-rank" data-player-goat-historic-rank>No. —</span>
+                      </span>
+                      <span class="player-card__goat-context">All-time GOAT resume</span>
+                    </div>
+                  </div>
+                </div>
               </header>
-              <dl class="player-card__facts">
-                <div class="player-card__fact">
-                  <dt>Team</dt>
-                  <dd data-player-team>—</dd>
-                </div>
-                <div class="player-card__fact">
-                  <dt>Position</dt>
-                  <dd data-player-position>—</dd>
-                </div>
-                <div class="player-card__fact">
-                  <dt>Jersey</dt>
-                  <dd data-player-jersey>—</dd>
-                </div>
-                <div class="player-card__fact">
-                  <dt>Height</dt>
-                  <dd data-player-height>—</dd>
-                </div>
-                <div class="player-card__fact">
-                  <dt>Weight</dt>
-                  <dd data-player-weight>—</dd>
-                </div>
-              </dl>
-              <section class="player-card__stats" aria-labelledby="player-card-stats-title">
-                <header class="player-card__stats-header">
-                  <h3 id="player-card-stats-title">
-                    Season averages
-                    <span class="player-card__stats-season" data-player-stats-season></span>
-                  </h3>
-                  <p class="player-card__stats-meta" data-player-stats-meta></p>
+              <div class="player-card__body">
+                <p class="player-card__bio" data-player-bio></p>
+                <dl class="player-card__facts">
+                  <div class="player-card__fact">
+                    <dt>Archetype</dt>
+                    <dd data-player-archetype>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Vitals</dt>
+                    <dd data-player-vitals>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Origin</dt>
+                    <dd data-player-origin>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Draft</dt>
+                    <dd data-player-draft>—</dd>
+                  </div>
+                </dl>
+              </div>
+              <section
+                class="player-card__visuals-section"
+                aria-labelledby="player-card-visuals-title"
+              >
+                <header class="player-card__visuals-header">
+                  <h4 id="player-card-visuals-title">Percentile visual reads</h4>
+                  <p>
+                    Twelve scouting gauges anchor the 2025-26 outlook on each player's 2024-25
+                    production — a quick scan of creation, feel, and defensive range.
+                  </p>
                 </header>
-                <div class="player-card__stats-grid" data-player-stats>
-                  <div class="player-card__stat">
-                    <span class="player-card__stat-value" data-player-stat-games>—</span>
-                    <span class="player-card__stat-label">G</span>
-                  </div>
-                  <div class="player-card__stat">
-                    <span class="player-card__stat-value" data-player-stat-points>—</span>
-                    <span class="player-card__stat-label">PTS</span>
-                  </div>
-                  <div class="player-card__stat">
-                    <span class="player-card__stat-value" data-player-stat-rebounds>—</span>
-                    <span class="player-card__stat-label">REB</span>
-                  </div>
-                  <div class="player-card__stat">
-                    <span class="player-card__stat-value" data-player-stat-assists>—</span>
-                    <span class="player-card__stat-label">AST</span>
-                  </div>
-                  <div class="player-card__stat">
-                    <span class="player-card__stat-value" data-player-stat-steals>—</span>
-                    <span class="player-card__stat-label">STL</span>
-                  </div>
-                  <div class="player-card__stat">
-                    <span class="player-card__stat-value" data-player-stat-blocks>—</span>
-                    <span class="player-card__stat-label">BLK</span>
-                  </div>
-                </div>
-                <p class="player-card__stats-empty" data-player-stats-empty hidden>
-                  No season averages are available for this player yet.
-                </p>
-                <p class="player-card__stats-error" data-player-stats-error hidden>
-                  We couldn't load season averages right now. Try again later.
+                <div
+                  class="player-card__visuals"
+                  data-player-metrics
+                  aria-label="Percentile visualizations"
+                ></div>
+                <p class="player-card__visuals-empty" data-player-metrics-empty hidden>
+                  Percentile visuals are coming soon for this player.
                 </p>
               </section>
               <footer class="player-card__footer">


### PR DESCRIPTION
## Summary
- Restore the players page markup so the atlas, GOAT summary, and visuals grid match the earlier design.
- Update the players atlas script to populate GOAT outputs, vitals, and biography fields while rendering percentile metric cards.
- Keep Ball Don't Lie roster data wired into the refreshed layout with safe fallbacks when stats widgets are unavailable.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68dc3181aa488327a98deeecb64295a7