### PR TITLE
Fix Ball Don't Lie credential fetch for nested deployments

### DIFF
--- a/public/scripts/bdl-credentials.js
+++ b/public/scripts/bdl-credentials.js
@@ -1,5 +1,21 @@
 (function () {
-  const DEFAULT_KEY_LOCATIONS = ['/bdl-key.json', '/data/bdl-key.json'];
+  const DEFAULT_KEY_LOCATIONS = (() => {
+    const FALLBACK = ['/bdl-key.json', '/data/bdl-key.json'];
+    if (typeof window === 'undefined' || typeof window.location?.href !== 'string') {
+      return FALLBACK;
+    }
+
+    try {
+      const base = new URL('.', window.location.href);
+      const scoped = ['bdl-key.json', 'data/bdl-key.json'].map((relativePath) =>
+        new URL(relativePath, base).toString(),
+      );
+      return [...scoped, ...FALLBACK];
+    } catch (error) {
+      console.warn('Unable to resolve Ball Don\'t Lie credential base path', error);
+      return FALLBACK;
+    }
+  })();
 
   function normalizeKey(raw) {
     if (raw === null || raw === undefined) {


### PR DESCRIPTION
## Summary
- update the credential bootstrap to resolve API key stubs relative to the current location so nested deployments can load them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc339b7f908327abb1b0773440aca8