### PR TITLE
Handle optional Ball Don't Lie credentials on players page

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="bdl-api-key" content="" />
     <link rel="icon" type="image/png" href="nba-logo-vector-01.png" />
     <link rel="stylesheet" href="styles/hub.css" />
     <title>Players | NBA Intelligence Hub</title>
@@ -326,7 +327,7 @@
       <footer class="page-footer">Player insights are the heartbeat of the hub — more soon.</footer>
     </div>
     <script src="vendor/chart.umd.js" defer></script>
-    <script src="scripts/bdl-credentials.js" defer></script>
+    <script src="scripts/bdl-credentials.js" defer data-disabled="true" data-warn-missing="false" data-auto-fetch="false"></script>
     <script type="module" src="scripts/players.js"></script>
 
 <!-- BUILD:PLAYERS -->


### PR DESCRIPTION
## Summary
- disable automatic Ball Don't Lie credential fetch on the players page
- support an explicit disabled mode in the credential bootstrap script
- update the players atlas to handle disabled credentials gracefully without API calls

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc34d07f408327914589c455ce25f7