### PR TITLE
chore: align pnpm version configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.12.1
           run_install: false
 
       - name: Tooling sanity

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.12.1
           run_install: false
 
       - name: Tooling sanity

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.1.0",
-  "packageManager": "pnpm@9.1.0",
+  "packageManager": "pnpm@9.12.1",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
- update the packageManager field to pin pnpm 9.12.1
- let GitHub Actions workflows use the version from package.json by removing the explicit pin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc689093588327b7e318bb53cc4c4a