### PR TITLE
Route data builds through BDL proxy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Build site data
         run: pnpm build:data
+        env:
+          BDL_PROXY_BASE: https://bdlproxy.hicksrch.workers.dev/bdl
 
       - name: Configure Pages
         uses: actions/configure-pages@v5

--- a/scripts/dev/verify_bdl.ts
+++ b/scripts/dev/verify_bdl.ts
@@ -39,8 +39,23 @@ function inCi(): boolean {
   return parseBoolean(process.env.CI);
 }
 
+const DEFAULT_PROXY_BASE = "https://bdlproxy.hicksrch.workers.dev/bdl/";
+const BDL_UPSTREAM_HOST_PATTERN = /\bballdontlie\.io$/i;
+
+function requiresBdlKey(): boolean {
+  const rawBase = process.env.BDL_PROXY_BASE?.trim() || DEFAULT_PROXY_BASE;
+  try {
+    const hostname = new URL(rawBase).hostname;
+    return BDL_UPSTREAM_HOST_PATTERN.test(hostname);
+  } catch {
+    return true;
+  }
+}
+
 async function verify(): Promise<void> {
-  requireBallDontLieKey();
+  if (requiresBdlKey()) {
+    requireBallDontLieKey();
+  }
   const rosters = await fetchActiveRosters();
 
   const missing = TEAM_METADATA.filter((team) => !Array.isArray(rosters[team.tricode]));


### PR DESCRIPTION
## Summary
- update the Ball Don't Lie fetch helper to honor BDL_PROXY_BASE and only send upstream API keys when required
- adjust active roster ingestion and verification scripts to avoid attaching Authorization headers when routed through the proxy
- configure the Pages workflow to point build:data at the Cloudflare proxy base

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc697c51c483278eb7371838240a63