### PR TITLE
ci: ensure pnpm is installed in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Install Node deps
+        run: pnpm i --frozen-lockfile
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- add Node 20 and pnpm setup to the CI workflow
- install pnpm dependencies so the tool is available in the lint-and-test job

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68dc7351acac8327a5d59fbeaa64c166