### PR TITLE
CI: unify pnpm via Corepack, fix all workflows, route data via proxy

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,16 @@
+name: setup-pnpm
+description: Setup Node and pnpm via Corepack
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: pnpm
+    - shell: bash
+      run: |
+        set -euo pipefail
+        corepack enable
+        corepack prepare pnpm@9.12.1 --activate
+    - shell: bash
+      run: pnpm -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,39 +13,21 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm i --frozen-lockfile
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      # IMPORTANT: don't pass a conflicting version; let it read packageManager from package.json
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Install Node deps
-        run: pnpm i --frozen-lockfile
-
-      # Build the data via your Cloudflare proxy; allow injuries to soft-fail
       - name: Build data
         run: pnpm build:data
         env:
           BDL_PROXY_BASE: https://bdlproxy.hicksrch.workers.dev/bdl
           ALLOW_INJURY_FAILURE: "true"
 
-      # Lightweight upstream health check; tolerant of a transient 5xx
       - name: Verify BDL
         run: pnpm verify:bdl
         env:
           BDL_PROXY_BASE: https://bdlproxy.hicksrch.workers.dev/bdl
           VERIFY_ALLOW_5XX: "true"
 
-      # Optional: your unit tests (vitest)
       - name: Tests
         run: pnpm test
-

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,35 +18,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm i --frozen-lockfile
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Install deps
-        run: pnpm i --frozen-lockfile
-
-      # Build your data via the Cloudflare proxy (no secrets in CI)
       - name: Build data
         run: pnpm build:data
         env:
           BDL_PROXY_BASE: https://bdlproxy.hicksrch.workers.dev/bdl
           ALLOW_INJURY_FAILURE: "true"
 
-      # Build static assets into public/assets/*
       - name: Build site
         run: pnpm build
 
-      # Optional: generate previews and validate before deploy
       - name: Generate previews
         run: pnpm gen:previews
 
@@ -54,13 +38,11 @@ jobs:
         run: pnpm validate:previews
 
       - name: Ensure site root exists
-        run: |
-          test -f public/index.html || { echo "public/index.html missing"; exit 1; }
+        run: test -f public/index.html
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
-      # Upload only the static site, not the repo root
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -76,4 +58,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -20,24 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: previews
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false   # pnpm version comes from package.json: packageManager
-
-      - name: Install deps
-        run: pnpm i --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm i --frozen-lockfile
 
       - name: Stamp date
         id: metadata
@@ -46,21 +33,16 @@ jobs:
       - name: Verify Ball Don't Lie API access
         env:
           BDL_PROXY_BASE: https://bdlproxy.hicksrch.workers.dev/bdl
-          VERIFY_ALLOW_5XX: "true"   # soft-pass a single upstream 5xx after one retry
+          VERIFY_ALLOW_5XX: "true"
         run: pnpm verify:bdl
 
-      # 'pnpm previews' already calls build:data + gen:previews + validate:previews
       - name: Build previews
         env:
           USE_NBA_STATS: "0"
           USE_BREF: "0"
           BDL_PROXY_BASE: https://bdlproxy.hicksrch.workers.dev/bdl
-          ALLOW_INJURY_FAILURE: "true"   # don't fail pipeline if /player_injuries keeps 500'ing
+          ALLOW_INJURY_FAILURE: "true"
         run: pnpm previews
-
-      # Optional: remove this if your 'previews' script already validates
-      # - name: Validate previews
-      #   run: pnpm validate:previews
 
       - name: Detect changes
         id: changes
@@ -84,8 +66,7 @@ jobs:
         with:
           commit-message: "chore(previews): refresh canonical data and regenerate previews for ${{ steps.metadata.outputs.date }}"
           title: "Auto refresh previews ${{ steps.metadata.outputs.date }}"
-          body: "Auto-generated previews. CI fails if stale names are detected."
+          body: "Auto-generated previews."
           branch: "chore/auto-previews-${{ github.run_id }}"
           base: "main"
           delete-branch: true
-


### PR DESCRIPTION
## Summary
- add a composite setup-pnpm action that installs pnpm 9.12.1 via Corepack
- update all workflows to use the composite action, install dependencies, and route data tasks through the Cloudflare proxy
- simplify workflows so pnpm commands always run after checkout and installation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc75c54ea083278422a936ba51f2a6