### PR TITLE
Fix GitHub Pages artifact upload path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: public
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- update the Pages workflow to upload only the built `public` directory so the deployment artifact has an index at its root

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc7a11bb588327959aebfa5b9b2f4c