### PR TITLE
Restore scoreboard view toggle styling

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -109,6 +109,24 @@
               <div class="lab-module__meta">
                 <span class="lab-chip">Powered by the live games feed</span>
                 <span class="lab-chip lab-chip--accent" data-metric="scoreboard-summary">—</span>
+                <div class="team-mode-toggle scoreboard-view-toggle" role="group" aria-label="Scoreboard view">
+                  <button
+                    type="button"
+                    class="team-mode-toggle__button"
+                    data-scoreboard-view="all"
+                    aria-pressed="true"
+                  >
+                    All games
+                  </button>
+                  <button
+                    type="button"
+                    class="team-mode-toggle__button"
+                    data-scoreboard-view="upcoming"
+                    aria-pressed="false"
+                  >
+                    Upcoming only
+                  </button>
+                </div>
               </div>
             </header>
             <div class="scoreboard-grid" data-scoreboard aria-live="polite"></div>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -6025,6 +6025,11 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+
+.scoreboard-view-toggle {
+  margin-left: auto;
+}
+
 .scoreboard-state {
   margin: 0;
   padding: clamp(0.85rem, 2vw, 1rem);

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -6025,6 +6025,11 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+
+.scoreboard-view-toggle {
+  margin-left: auto;
+}
+
 .scoreboard-state {
   margin: 0;
   padding: clamp(0.85rem, 2vw, 1rem);


### PR DESCRIPTION
## Summary
- reuse the existing team-mode toggle component so the scoreboard view switch keeps the hub styling
- ensure the scoreboard toggle state is derived from aria-pressed attributes instead of bespoke classes
- mirror the minimal scoreboard view spacing tweak in both public and site stylesheets

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc7c0e1eb483279a7f87bbba5e64c1