### PR TITLE
Adjust history archive layout for GOAT radar

### DIFF
--- a/public/history.html
+++ b/public/history.html
@@ -59,19 +59,19 @@
                 />
                 <ul class="history-search__results" data-history="player-results" aria-live="polite"></ul>
               </div>
+
+              <section class="history-visuals" data-history="player-visuals" aria-live="polite">
+                <header class="history-visuals__header">
+                  <h3>GOAT percentile radar</h3>
+                  <p>Percentiles derive from the latest internal GOAT index for 6,500+ players.</p>
+                </header>
+                <div class="history-visuals__grid" data-history="visuals-grid"></div>
+              </section>
             </div>
 
             <article class="history-player" data-history="player-card">
               <p class="history-player__placeholder">Select a player to pull their full career log.</p>
             </article>
-
-            <section class="history-visuals" data-history="player-visuals" aria-live="polite">
-              <header class="history-visuals__header">
-                <h3>GOAT percentile radar</h3>
-                <p>Percentiles derive from the latest internal GOAT index for 6,500+ players.</p>
-              </header>
-              <div class="history-visuals__grid" data-history="visuals-grid"></div>
-            </section>
           </div>
         </section>
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -3166,7 +3166,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 .history-search-panel {
   display: grid;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .history-key {


### PR DESCRIPTION
## Summary
- move the GOAT percentile radar section inside the history search panel so it sits directly below the search box
- tighten spacing in the history search column to keep the radar snug under the search results

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc7e34fbd08327acfe9826824efc9c