### PR TITLE
Keep history GOAT radar beside player results

### DIFF
--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -3159,7 +3159,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 @media (min-width: 1024px) {
   .history-archive {
-    grid-template-columns: minmax(260px, 340px) minmax(340px, 1fr);
+    grid-template-columns: minmax(260px, 340px) minmax(380px, 1fr) minmax(260px, 340px);
     align-items: start;
   }
 }


### PR DESCRIPTION
## Summary
- update the history archive desktop grid to allocate a dedicated column for the GOAT radar sidebar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc819851d48327a4de0ab903eef2ab