### PR TITLE
Default scoreboard calendar to today

### DIFF
--- a/public/scripts/games.js
+++ b/public/scripts/games.js
@@ -42,17 +42,20 @@ function determineMaxSelectableDate() {
 
 function determineInitialDate() {
   const today = getTodayIso();
-  const maxSelectable = determineMaxSelectableDate();
-  if (today >= NEXT_SEASON_TIPOFF_DATE) {
-    if (maxSelectable && today > maxSelectable) {
-      return maxSelectable;
+  const bounds = getSelectableBounds();
+  const clampedToday = clampDate(today, bounds);
+  if (clampedToday) {
+    return clampedToday;
+  }
+  if (bounds) {
+    if (bounds.max) {
+      return bounds.max;
     }
-    return today;
+    if (bounds.min) {
+      return bounds.min;
+    }
   }
-  if (maxSelectable && LAST_COMPLETED_SEASON_FINALE > maxSelectable) {
-    return maxSelectable;
-  }
-  return LAST_COMPLETED_SEASON_FINALE;
+  return today;
 }
 
 function determineInitialRange() {


### PR DESCRIPTION
## Summary
- update the scoreboard initialization logic to clamp the default date range to today
- retain min/max fallbacks so the calendar stays within allowed bounds when today is outside the selectable window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc82d273ec83279ff47bde3fd27dba