### PR TITLE
Rework player atlas layout and stats

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -126,6 +126,26 @@
                     <dd data-player-archetype>—</dd>
                   </div>
                   <div class="player-card__fact">
+                    <dt>Team</dt>
+                    <dd data-player-team>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Position</dt>
+                    <dd data-player-position>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Jersey</dt>
+                    <dd data-player-jersey>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Height</dt>
+                    <dd data-player-height>—</dd>
+                  </div>
+                  <div class="player-card__fact">
+                    <dt>Weight</dt>
+                    <dd data-player-weight>—</dd>
+                  </div>
+                  <div class="player-card__fact">
                     <dt>Vitals</dt>
                     <dd data-player-vitals>—</dd>
                   </div>
@@ -139,6 +159,52 @@
                   </div>
                 </dl>
               </div>
+              <section
+                class="player-card__stats"
+                data-player-stats
+                aria-live="polite"
+                aria-busy="false"
+              >
+                <header class="player-card__stats-header">
+                  <h3>
+                    Season averages
+                    <span class="player-card__stats-season" data-player-stats-season>—</span>
+                  </h3>
+                  <p class="player-card__stats-meta" data-player-stats-meta></p>
+                </header>
+                <p class="player-card__stats-empty" data-player-stats-empty hidden>
+                  Season averages are not available right now.
+                </p>
+                <p class="player-card__stats-error" data-player-stats-error hidden>
+                  We couldn't load season averages right now.
+                </p>
+                <dl class="player-card__stats-grid">
+                  <div class="player-card__stat">
+                    <dt class="player-card__stat-label">Games</dt>
+                    <dd class="player-card__stat-value" data-player-stat-games>—</dd>
+                  </div>
+                  <div class="player-card__stat">
+                    <dt class="player-card__stat-label">Points</dt>
+                    <dd class="player-card__stat-value" data-player-stat-points>—</dd>
+                  </div>
+                  <div class="player-card__stat">
+                    <dt class="player-card__stat-label">Rebounds</dt>
+                    <dd class="player-card__stat-value" data-player-stat-rebounds>—</dd>
+                  </div>
+                  <div class="player-card__stat">
+                    <dt class="player-card__stat-label">Assists</dt>
+                    <dd class="player-card__stat-value" data-player-stat-assists>—</dd>
+                  </div>
+                  <div class="player-card__stat">
+                    <dt class="player-card__stat-label">Steals</dt>
+                    <dd class="player-card__stat-value" data-player-stat-steals>—</dd>
+                  </div>
+                  <div class="player-card__stat">
+                    <dt class="player-card__stat-label">Blocks</dt>
+                    <dd class="player-card__stat-value" data-player-stat-blocks>—</dd>
+                  </div>
+                </dl>
+              </section>
               <section
                 class="player-card__visuals-section"
                 aria-labelledby="player-card-visuals-title"

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -4611,9 +4611,20 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__layout {
   display: grid;
-  grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
-  gap: clamp(1.6rem, 3.2vw, 2.4rem);
+  grid-template-columns: minmax(0, clamp(13.5rem, 22vw, 17rem)) minmax(0, 1fr);
+  grid-template-areas:
+    'search search'
+    'tree card';
+  gap: clamp(1.2rem, 2.8vw, 2rem);
   align-items: start;
+  align-content: start;
+}
+
+.player-atlas__search {
+  grid-area: search;
+  align-self: stretch;
+  justify-self: stretch;
+  max-width: none;
 }
 .player-atlas__panel {
   display: grid;
@@ -4731,16 +4742,21 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__error { color: color-mix(in srgb, var(--red) 65%, var(--navy) 35%); }
 .player-atlas__teams {
+  grid-area: tree;
   display: grid;
-  gap: 0.65rem;
-  align-content: start;
-  padding: clamp(0.9rem, 2vw, 1.1rem);
+  grid-template-rows: auto auto 1fr;
+  gap: 0.45rem;
+  align-content: stretch;
+  align-self: stretch;
+  padding: clamp(0.65rem, 1.6vw, 0.9rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
   background:
     linear-gradient(160deg, rgba(17, 86, 214, 0.06), rgba(244, 181, 63, 0.04)),
     color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.88) 30%);
   box-shadow: var(--shadow-soft);
+  width: min(100%, clamp(13.5rem, 20vw, 16.5rem));
+  max-height: clamp(18rem, 70vh, 32rem);
 }
 .player-atlas__teams[hidden] { display: none; }
 .player-atlas__teams-title {
@@ -4757,10 +4773,12 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-atlas__teams-tree {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  max-height: clamp(12rem, 42vh, 18rem);
+  gap: 0.3rem;
+  min-height: 0;
   overflow-y: auto;
   padding-right: 0.2rem;
+  scrollbar-gutter: stable both-edges;
+  overscroll-behavior: contain;
 }
 
 .player-atlas__teams-tree > * {
@@ -4778,26 +4796,39 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.6rem;
-  padding: 0.6rem 0.75rem;
+  gap: 0.4rem;
+  padding: 0.4rem 0.55rem;
   cursor: pointer;
   font-weight: 600;
   color: var(--navy);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
 }
 .player-atlas__team-summary::-webkit-details-marker,
 .player-atlas__team-summary::marker {
   display: none;
 }
-.player-atlas__team-name { font-size: 0.88rem; }
+.player-atlas__team-identity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.player-atlas__team-name {
+  font-weight: 700;
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
+}
 .player-atlas__team-count {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 2ch;
-  padding: 0.08rem 0.45rem;
+  padding: 0.08rem 0.4rem;
   border-radius: 999px;
   background: color-mix(in srgb, rgba(17, 86, 214, 0.18) 60%, rgba(244, 181, 63, 0.18) 40%);
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 700;
   color: color-mix(in srgb, var(--royal) 68%, var(--navy) 32%);
 }
@@ -4806,10 +4837,10 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__team-roster {
   margin: 0;
-  padding: 0 0.35rem 0.45rem;
+  padding: 0 0.35rem 0.4rem 0.35rem;
   list-style: none;
   display: grid;
-  gap: 0.15rem;
+  gap: 0.12rem;
 }
 .player-atlas__team-entry { margin: 0; }
 .player-atlas__team-player {
@@ -4817,7 +4848,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   border: 0;
   background: transparent;
   text-align: left;
-  padding: 0.48rem 0.65rem 0.45rem;
+  padding: 0.35rem 0.5rem;
   display: grid;
   gap: 0.18rem;
   font: inherit;
@@ -4833,13 +4864,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   color: var(--navy);
 }
 .player-atlas__team-player:focus-visible { outline: none; }
-.player-atlas__team-player-name { font-weight: 600; font-size: 0.86rem; }
+.player-atlas__team-player-name { font-weight: 600; font-size: 0.82rem; }
 .player-atlas__team-player-meta {
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-card {
-  grid-column: 2;
+  grid-area: card;
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
@@ -5212,12 +5243,24 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 
 @media (max-width: 1080px) {
-  .player-atlas__layout { grid-template-columns: minmax(0, 1fr); }
-  .player-atlas__layout > * { grid-column: 1; }
-  .player-atlas__panel { max-width: none; }
+  .player-atlas__layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'search'
+      'card'
+      'tree';
+  }
+  .player-atlas__teams {
+    width: 100%;
+    max-width: 100%;
+    max-height: min(55vh, 28rem);
+  }
 }
 
 @media (max-width: 720px) {
+  .player-atlas__teams {
+    max-height: none;
+  }
   .player-card__header { flex-direction: column; align-items: flex-start; }
   .player-card__stats-grid { grid-template-columns: minmax(0, 1fr); }
 }
@@ -5784,51 +5827,90 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 
 .roster-teams {
   display: grid;
-  gap: 1.25rem;
+  gap: 0.35rem;
 }
 
 .roster-team {
-  background: var(--surface-muted);
-  border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
-  border-radius: var(--radius-md);
-  padding: 1.1rem 1.3rem;
-  backdrop-filter: blur(6px);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface-muted) 65%, transparent);
+  overflow: hidden;
 }
 
 .roster-team__header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.9rem;
+  gap: 0.5rem;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  line-height: 1.2;
+  cursor: pointer;
 }
 
-.roster-team__header h3 {
-  font-size: 1.5rem;
-  letter-spacing: 0.06em;
+.roster-team__header::-webkit-details-marker {
+  display: none;
 }
 
-.roster-team__header p {
-  font-size: 0.9rem;
+.roster-team__header::marker {
+  color: color-mix(in srgb, var(--sky) 75%, transparent);
+}
+
+.roster-team[open] .roster-team__header {
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--border) 82%, transparent);
+}
+
+.roster-team__identity {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.roster-team__abbr {
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+}
+
+.roster-team__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8rem;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(17, 86, 214, 0.12);
+  color: var(--royal);
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.roster-team__count--empty {
+  background: transparent;
   color: var(--text-subtle);
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
 .roster-list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0.35rem 0.55rem 0.6rem;
   display: grid;
-  gap: 0.65rem;
+  gap: 0.4rem;
 }
 
 .roster-player {
   display: grid;
-  gap: 0.25rem;
-  background: rgba(255, 255, 255, 0.78);
-  padding: 0.75rem 0.9rem;
+  gap: 0.2rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.55rem 0.65rem;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(17, 86, 214, 0.06);
+  border: 1px solid rgba(17, 86, 214, 0.08);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
   width: 100%;
   font: inherit;
@@ -5838,6 +5920,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   background-clip: padding-box;
   cursor: pointer;
   transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+  font-size: 0.9rem;
 }
 
 .roster-player:hover {
@@ -5928,7 +6011,6 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .roster-controls__filters { width: 100%; }
   .roster-controls__field { flex: 1 1 auto; min-width: unset; }
   .roster-controls__meta { width: 100%; justify-content: space-between; }
-  .roster-team__header { flex-direction: column; align-items: flex-start; }
 }
 
 @media (max-width: 620px) {


### PR DESCRIPTION
## Summary
- restructure the players atlas so the search input spans the top, the roster tree collapses into a compact sidebar, and the player card fills the main content column
- surface richer player card details including team, position, vitals, and an embedded season averages section fed by Ball Don't Lie data
- render the franchise browser with abbreviations and accessibility helpers so many teams fit inside the sidebar tree while staying navigable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc7cc6d71c83279b5f996889f92c4f