### PR TITLE
Ensure Legends atlas uses latest GOAT metrics

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -3740,6 +3740,13 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   color: var(--navy);
 }
 
+.state-spotlight__metrics {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--navy);
+}
+
 .state-spotlight__headline {
   margin: 0;
   font-size: 0.95rem;


### PR DESCRIPTION
## Summary
- load the legends atlas from whichever GOAT snapshot has the newest generatedAt timestamp
- merge the live GOAT scores into the atlas entries while retaining curated headlines and team copy
- show each legend's GOAT score and global rank in the atlas spotlight with refreshed styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8a97e77883278071b931a79ec69b