### PR TITLE
Remove roster search overlay from players page

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -43,40 +43,6 @@
             </p>
           </header>
           <div class="player-atlas__layout">
-            <div class="player-atlas__search">
-              <label class="player-atlas__label" for="player-atlas-search">Find a player</label>
-              <div class="player-atlas__searchbox">
-                <div class="player-atlas__field">
-                  <input
-                    id="player-atlas-search"
-                    class="player-atlas__input"
-                    type="search"
-                    name="player-search"
-                    placeholder="Search by name, nickname, or era (e.g. &quot;Wemby&quot;, &quot;90s&quot;)"
-                    autocomplete="off"
-                    spellcheck="false"
-                    data-player-search
-                    aria-controls="player-atlas-results"
-                    aria-expanded="false"
-                  />
-                  <button type="button" class="player-atlas__clear" data-player-clear hidden>Clear</button>
-                </div>
-                <ul
-                  id="player-atlas-results"
-                  class="player-atlas__results"
-                  role="listbox"
-                  data-player-results
-                  hidden
-                ></ul>
-              </div>
-              <p class="player-atlas__hint" data-player-hint>Start typing to explore the atlas.</p>
-              <p class="player-atlas__empty" data-player-empty hidden>
-                No players found. Try a different era, nickname, or franchise.
-              </p>
-              <p class="player-atlas__error" data-player-error hidden>
-                We couldn't load the atlas right now. Refresh to try again.
-              </p>
-            </div>
             <div class="player-atlas__teams" data-player-teams hidden>
               <h3 class="player-atlas__teams-title">Browse by franchise</h3>
               <p class="player-atlas__teams-copy">


### PR DESCRIPTION
## Summary
- simplify the player atlas bootstrap so only the atlas UI renders, eliminating the roster search overlay
- keep roster data feeding the atlas team browser directly so player selection and highlighting continue to work without the removed widget

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc8e8d604c832787d6d56c8765ef7b