### PR TITLE
Fix player season averages query parameter

### DIFF
--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -1837,7 +1837,7 @@ function initPlayerAtlas() {
     try {
       const params = new URLSearchParams();
       params.set('season', String(LATEST_COMPLETED_SEASON));
-      params.append('player_ids[]', cacheKey);
+      params.set('player_id', cacheKey);
       const payload = await bdl(`/v1/season_averages?${params.toString()}`, { cache: 'no-store' });
       const record = Array.isArray(payload?.data) ? payload.data[0] : null;
       if (!record) {


### PR DESCRIPTION
## Summary
- use the Ball Don't Lie season_averages player_id parameter to load player card stats from the proxy

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd112f02c083278ee574f193f24bc2