### PR TITLE
Fix players lab visualization grid overflow

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -241,7 +241,7 @@
               logged to the shape of today's positionless rotations.
             </p>
           </header>
-          <div class="players-lab__grid viz-grid">
+          <div class="players-lab__grid viz-grid viz-grid--dense">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">League height distribution</header>
               <div class="viz-canvas">
@@ -285,7 +285,7 @@
               college programs producing the deepest alumni pools.
             </p>
           </header>
-          <div class="players-lab__grid viz-grid">
+          <div class="players-lab__grid viz-grid viz-grid--dense">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Global talent spectrum</header>
               <div class="viz-canvas">
@@ -329,7 +329,7 @@
               the lore of NBA players.
             </p>
           </header>
-          <div class="players-lab__grid viz-grid">
+          <div class="players-lab__grid viz-grid viz-grid--dense">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Scoring era waveform</header>
               <div class="viz-canvas">

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5489,7 +5489,31 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   line-height: 1.7;
   color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
 }
-.players-lab__grid { align-items: stretch; }
+.players-lab__grid {
+  display: grid;
+  gap: clamp(1.1rem, 2.5vw, 1.8rem);
+  align-items: stretch;
+}
+
+.viz-grid {
+  --viz-grid-min: clamp(260px, 30vw, 340px);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--viz-grid-min), 1fr));
+  grid-auto-rows: minmax(280px, auto);
+  grid-auto-flow: row dense;
+}
+
+.viz-grid--dense {
+  --viz-grid-min: clamp(220px, 26vw, 300px);
+}
+
+@media (max-width: 720px) {
+  .viz-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+    grid-auto-flow: row;
+  }
+}
 .viz-card {
   position: relative;
   display: grid;

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -5489,7 +5489,31 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   line-height: 1.7;
   color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
 }
-.players-lab__grid { align-items: stretch; }
+.players-lab__grid {
+  display: grid;
+  gap: clamp(1.1rem, 2.5vw, 1.8rem);
+  align-items: stretch;
+}
+
+.viz-grid {
+  --viz-grid-min: clamp(260px, 30vw, 340px);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(var(--viz-grid-min), 1fr));
+  grid-auto-rows: minmax(280px, auto);
+  grid-auto-flow: row dense;
+}
+
+.viz-grid--dense {
+  --viz-grid-min: clamp(220px, 26vw, 300px);
+}
+
+@media (max-width: 720px) {
+  .viz-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+    grid-auto-flow: row;
+  }
+}
 .viz-card {
   position: relative;
   display: grid;


### PR DESCRIPTION
## Summary
- allow the players lab visualization grid rows to expand so the post-morphology charts no longer overlap
- keep the responsive row flow consistent in the preview stylesheet so static renders match production

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd202d1ffc8327b79a4c151cba22a3