### PR TITLE
Revamp player atlas search UX and GOAT leaderboard

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -64,12 +64,67 @@
             </p>
           </header>
           <div class="player-atlas__layout">
+            <section
+              class="player-atlas__search player-atlas__panel"
+              aria-labelledby="player-atlas-search-label"
+            >
+              <div class="player-atlas__searchbox">
+                <label class="player-atlas__label" id="player-atlas-search-label" for="player-atlas-search">
+                  Search the scouting atlas
+                </label>
+                <div class="player-atlas__field">
+                  <input
+                    id="player-atlas-search"
+                    class="player-atlas__input"
+                    type="search"
+                    inputmode="search"
+                    autocomplete="off"
+                    spellcheck="false"
+                    enterkeyhint="search"
+                    placeholder="Search by player, jersey, or franchise"
+                    data-player-search
+                    aria-autocomplete="list"
+                    aria-controls="player-atlas-search-results"
+                    aria-expanded="false"
+                  />
+                  <button type="button" class="player-atlas__clear" data-player-clear hidden>
+                    Clear
+                  </button>
+                </div>
+                <ul
+                  id="player-atlas-search-results"
+                  class="player-atlas__results"
+                  role="listbox"
+                  data-player-results
+                  hidden
+                ></ul>
+              </div>
+              <p class="player-atlas__hint" data-player-hint>
+                Start typing a player's name, jersey number, or franchise to surface his scouting capsule.
+              </p>
+              <p class="player-atlas__empty" data-player-empty hidden>
+                No matches found. Try another player, jersey number, or team.
+              </p>
+              <p class="player-atlas__error" data-player-error hidden>
+                We couldn't load the scouting atlas right now. Refresh to try again soon.
+              </p>
+            </section>
             <div class="player-atlas__teams" data-player-teams hidden>
               <h3 class="player-atlas__teams-title">Browse by franchise</h3>
               <p class="player-atlas__teams-copy">
                 Expand a team to scan its 2025-26 roster and jump straight to a player's scouting card.
               </p>
               <div class="player-atlas__teams-tree" data-player-team-tree></div>
+              <aside class="player-atlas__teams-goat" data-player-teams-goat hidden>
+                <h4 class="player-atlas__teams-goat-title">GOAT roster averages</h4>
+                <p class="player-atlas__teams-goat-copy">
+                  Ranking each franchise by average GOAT score per roster spot, normalized for current roster sizes.
+                </p>
+                <ol class="player-atlas__teams-goat-list" data-player-teams-goat-list></ol>
+                <p class="player-atlas__teams-goat-empty" data-player-teams-goat-empty hidden>
+                  Team GOAT averages are warming up.
+                </p>
+              </aside>
             </div>
             <article class="player-card" data-player-profile hidden aria-live="polite">
               <header class="player-card__header">

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -4777,7 +4777,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-atlas__teams {
   grid-area: tree;
   display: grid;
-  grid-template-rows: auto auto 1fr;
+  grid-template-rows: auto auto 1fr auto;
   gap: 0.45rem;
   align-content: stretch;
   align-self: stretch;
@@ -4900,6 +4900,115 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 .player-atlas__team-player-name { font-weight: 600; font-size: 0.82rem; }
 .player-atlas__team-player-meta {
   font-size: 0.7rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
+.player-atlas__teams-goat {
+  margin-top: 0.4rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  display: grid;
+  gap: 0.6rem;
+}
+.player-atlas__teams-goat[hidden] {
+  display: none;
+}
+.player-atlas__teams-goat-title {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-subtle) 72%, var(--royal) 28%);
+}
+.player-atlas__teams-goat-copy {
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
+.player-atlas__teams-goat-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+}
+.player-atlas__teams-goat-entry {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.55rem;
+  align-items: start;
+  padding: 0.55rem 0.65rem;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+  background: linear-gradient(140deg, rgba(17, 86, 214, 0.12), rgba(244, 181, 63, 0.1));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+.player-atlas__teams-goat-rank {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--surface);
+  background: linear-gradient(135deg, var(--royal), var(--sky));
+  box-shadow: 0 6px 12px rgba(17, 86, 214, 0.18);
+}
+.player-atlas__teams-goat-entry:nth-child(1) .player-atlas__teams-goat-rank {
+  background: linear-gradient(135deg, var(--gold), #ffdd77);
+  color: var(--navy);
+}
+.player-atlas__teams-goat-entry:nth-child(2) .player-atlas__teams-goat-rank,
+.player-atlas__teams-goat-entry:nth-child(3) .player-atlas__teams-goat-rank {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--royal) 55%, var(--sky) 45%),
+    var(--sky)
+  );
+}
+.player-atlas__teams-goat-body {
+  display: grid;
+  gap: 0.4rem;
+}
+.player-atlas__teams-goat-team {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem;
+}
+.player-atlas__teams-goat-name {
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--navy);
+}
+.player-atlas__teams-goat-roster {
+  font-size: 0.72rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
+.player-atlas__teams-goat-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem 0.85rem;
+  font-size: 0.78rem;
+  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+}
+.player-atlas__teams-goat-average {
+  font-weight: 700;
+  color: color-mix(in srgb, var(--royal) 68%, var(--navy) 32%);
+}
+.player-atlas__teams-goat-total {
+  font-weight: 700;
+  color: color-mix(in srgb, var(--gold) 70%, var(--navy) 30%);
+}
+.player-atlas__teams-goat-coverage {
+  font-weight: 600;
+}
+.player-atlas__teams-goat-empty {
+  margin: 0;
+  font-size: 0.75rem;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-card {
@@ -5293,6 +5402,17 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 @media (max-width: 720px) {
   .player-atlas__teams {
     max-height: none;
+  }
+  .player-atlas__teams-goat-entry {
+    grid-template-columns: auto 1fr;
+  }
+  .player-atlas__teams-goat-team {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+  .player-atlas__teams-goat-metrics {
+    gap: 0.35rem 0.65rem;
   }
   .player-card__header { flex-direction: column; align-items: flex-start; }
   .player-card__stats-grid { grid-template-columns: minmax(0, 1fr); }


### PR DESCRIPTION
## Summary
- add an inline search panel for the scouting atlas so the board loads empty and ready for input
- compute and display a team GOAT average leaderboard that normalizes for roster sizes within the franchise sidebar
- refresh supporting styles and client logic to remove the random showcase and focus the new search experience

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dd24d595888327879c976ac0cee586