### PR TITLE
Refine Insights Lab hero layout

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -744,7 +744,7 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .hero--lab {
-  padding: clamp(2rem, 4.2vw, 2.8rem) clamp(1.4rem, 3.4vw, 2.1rem);
+  padding: clamp(1.6rem, 3.8vw, 2.6rem) clamp(1.2rem, 3vw, 1.9rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
@@ -754,7 +754,7 @@ a:hover, a:focus { color: var(--sky); }
     color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
   box-shadow: 0 26px 48px rgba(11, 37, 69, 0.2);
   display: grid;
-  gap: clamp(1.1rem, 2.5vw, 1.9rem);
+  gap: clamp(0.9rem, 2.2vw, 1.5rem);
   position: relative;
   overflow: hidden;
 }
@@ -777,11 +777,53 @@ a:hover, a:focus { color: var(--sky); }
 .hero--lab .hero__intro {
   margin: 0;
   text-align: left;
-  gap: 0.6rem;
+  gap: 0.5rem;
 }
 
 .hero--lab h1 {
   margin: 0;
+  font-size: clamp(1.9rem, 3.8vw, 2.6rem);
+  line-height: 1.05;
+}
+
+.hero--lab .hero__lead {
+  margin: 0;
+  max-width: 40ch;
+}
+
+.hero--lab .hero-metrics {
+  margin: clamp(0.4rem, 1.2vw, 0.8rem) 0 0;
+  max-width: none;
+  width: 100%;
+}
+
+.hero--lab .hero-metrics--lab {
+  padding: clamp(1rem, 2.2vw, 1.4rem);
+  gap: clamp(0.8rem, 1.8vw, 1.2rem);
+}
+
+@media (min-width: 880px) {
+  .hero--lab {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 1fr);
+    align-items: start;
+  }
+
+  .hero--lab h1 {
+    white-space: nowrap;
+  }
+
+  .hero--lab .hero__lead {
+    max-width: 34ch;
+  }
+
+  .hero--lab .hero-metrics {
+    margin-top: 0;
+    align-self: start;
+  }
+
+  .hero--lab .hero-metrics--lab {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .power-board {

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -744,7 +744,7 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .hero--lab {
-  padding: clamp(2rem, 4.2vw, 2.8rem) clamp(1.4rem, 3.4vw, 2.1rem);
+  padding: clamp(1.6rem, 3.8vw, 2.6rem) clamp(1.2rem, 3vw, 1.9rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
@@ -754,7 +754,7 @@ a:hover, a:focus { color: var(--sky); }
     color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
   box-shadow: 0 26px 48px rgba(11, 37, 69, 0.2);
   display: grid;
-  gap: clamp(1.1rem, 2.5vw, 1.9rem);
+  gap: clamp(0.9rem, 2.2vw, 1.5rem);
   position: relative;
   overflow: hidden;
 }
@@ -777,11 +777,53 @@ a:hover, a:focus { color: var(--sky); }
 .hero--lab .hero__intro {
   margin: 0;
   text-align: left;
-  gap: 0.6rem;
+  gap: 0.5rem;
 }
 
 .hero--lab h1 {
   margin: 0;
+  font-size: clamp(1.9rem, 3.8vw, 2.6rem);
+  line-height: 1.05;
+}
+
+.hero--lab .hero__lead {
+  margin: 0;
+  max-width: 40ch;
+}
+
+.hero--lab .hero-metrics {
+  margin: clamp(0.4rem, 1.2vw, 0.8rem) 0 0;
+  max-width: none;
+  width: 100%;
+}
+
+.hero--lab .hero-metrics--lab {
+  padding: clamp(1rem, 2.2vw, 1.4rem);
+  gap: clamp(0.8rem, 1.8vw, 1.2rem);
+}
+
+@media (min-width: 880px) {
+  .hero--lab {
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 1fr);
+    align-items: start;
+  }
+
+  .hero--lab h1 {
+    white-space: nowrap;
+  }
+
+  .hero--lab .hero__lead {
+    max-width: 34ch;
+  }
+
+  .hero--lab .hero-metrics {
+    margin-top: 0;
+    align-self: start;
+  }
+
+  .hero--lab .hero-metrics--lab {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .power-board {


### PR DESCRIPTION
## Summary
- restore the Insights Lab hero to the standard modifier and keep styling consistent
- tighten hero spacing and typography while shifting to a two-column layout on wide screens to shorten the section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd267ff7688327a8a3a805488382e9