### PR TITLE
Reduce spacing above history player archive

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -3215,7 +3215,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 
 .history-section--search {
-  margin-top: 2rem;
+  margin-top: clamp(0.5rem, 1.5vw, 1rem);
 }
 
 .history-archive {

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -3199,7 +3199,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 
 .history-section--search {
-  margin-top: 2rem;
+  margin-top: clamp(0.5rem, 1.5vw, 1rem);
 }
 
 .history-archive {


### PR DESCRIPTION
## Summary
- reduce the top margin on the history page's player archive explorer so it sits closer to the League Archive banner
- mirror the spacing adjustment in both the built and source style sheets

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd2a121e908327a6345ff803d8f117