### PR TITLE
Streamline games hero layout

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -744,7 +744,7 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .hero--lab {
-  padding: clamp(1.6rem, 3.8vw, 2.6rem) clamp(1.2rem, 3vw, 1.9rem);
+  padding: clamp(1.1rem, 3vw, 1.8rem) clamp(1rem, 2.6vw, 1.6rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
@@ -754,7 +754,7 @@ a:hover, a:focus { color: var(--sky); }
     color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
   box-shadow: 0 26px 48px rgba(11, 37, 69, 0.2);
   display: grid;
-  gap: clamp(0.9rem, 2.2vw, 1.5rem);
+  gap: clamp(0.6rem, 1.8vw, 1.1rem);
   position: relative;
   overflow: hidden;
 }
@@ -777,7 +777,9 @@ a:hover, a:focus { color: var(--sky); }
 .hero--lab .hero__intro {
   margin: 0;
   text-align: left;
-  gap: 0.5rem;
+  gap: 0.45rem;
+  max-width: none;
+  align-content: start;
 }
 
 .hero--lab h1 {
@@ -788,7 +790,12 @@ a:hover, a:focus { color: var(--sky); }
 
 .hero--lab .hero__lead {
   margin: 0;
-  max-width: 40ch;
+  max-width: none;
+  line-height: 1.45;
+}
+
+.hero--lab .games-toolbar {
+  margin-top: 0.7rem;
 }
 
 .hero--lab .hero-metrics {

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -744,7 +744,7 @@ a:hover, a:focus { color: var(--sky); }
 }
 
 .hero--lab {
-  padding: clamp(1.6rem, 3.8vw, 2.6rem) clamp(1.2rem, 3vw, 1.9rem);
+  padding: clamp(1.1rem, 3vw, 1.8rem) clamp(1rem, 2.6vw, 1.6rem);
   border-radius: var(--radius-lg);
   border: 1px solid color-mix(in srgb, var(--royal) 18%, transparent);
   background:
@@ -754,7 +754,7 @@ a:hover, a:focus { color: var(--sky); }
     color-mix(in srgb, rgba(255, 255, 255, 0.94) 70%, rgba(242, 246, 255, 0.92) 30%);
   box-shadow: 0 26px 48px rgba(11, 37, 69, 0.2);
   display: grid;
-  gap: clamp(0.9rem, 2.2vw, 1.5rem);
+  gap: clamp(0.6rem, 1.8vw, 1.1rem);
   position: relative;
   overflow: hidden;
 }
@@ -777,7 +777,9 @@ a:hover, a:focus { color: var(--sky); }
 .hero--lab .hero__intro {
   margin: 0;
   text-align: left;
-  gap: 0.5rem;
+  gap: 0.45rem;
+  max-width: none;
+  align-content: start;
 }
 
 .hero--lab h1 {
@@ -788,7 +790,12 @@ a:hover, a:focus { color: var(--sky); }
 
 .hero--lab .hero__lead {
   margin: 0;
-  max-width: 40ch;
+  max-width: none;
+  line-height: 1.45;
+}
+
+.hero--lab .games-toolbar {
+  margin-top: 0.7rem;
 }
 
 .hero--lab .hero-metrics {


### PR DESCRIPTION
## Summary
- tighten the games hero spacing so the copy and controls sit closer together and stretch across the card
- mirror the compact hero adjustments in the site preview stylesheet so local previews keep the full design treatment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2fef3d9083279902caf180569813