### PR TITLE
Restore Insights Lab hero spacing without lead copy

### DIFF
--- a/public/insights.html
+++ b/public/insights.html
@@ -53,10 +53,7 @@
           <div class="hero__intro">
             <span class="eyebrow">Insights Lab Reset</span>
             <h1>The place where we test data insights</h1>
-            <p class="hero__lead">
-              Playful prototypes built to answer the NBA's strangest questions with numbers, storytelling, and just enough
-              skepticism to keep us honest.
-            </p>
+            <p class="hero__lead" aria-hidden="true">&nbsp;</p>
           </div>
           <dl class="hero-metrics hero-metrics--lab">
             <div class="hero-metrics__item">


### PR DESCRIPTION
## Summary
- reintroduce the hero lead element without copy to preserve the Insights Lab hero styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd377d4eac832781337619d01f4aed