### PR TITLE
Reposition GOAT roster averages grid on players page

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -115,16 +115,6 @@
                 Expand a team to scan its 2025-26 roster and jump straight to a player's scouting card.
               </p>
               <div class="player-atlas__teams-tree" data-player-team-tree></div>
-              <aside class="player-atlas__teams-goat" data-player-teams-goat hidden>
-                <h4 class="player-atlas__teams-goat-title">GOAT roster averages</h4>
-                <p class="player-atlas__teams-goat-copy">
-                  Ranking each franchise by average GOAT score per roster spot, normalized for current roster sizes.
-                </p>
-                <ol class="player-atlas__teams-goat-list" data-player-teams-goat-list></ol>
-                <p class="player-atlas__teams-goat-empty" data-player-teams-goat-empty hidden>
-                  Team GOAT averages are warming up.
-                </p>
-              </aside>
             </div>
             <article class="player-card" data-player-profile hidden aria-live="polite">
               <header class="player-card__header">
@@ -272,6 +262,19 @@
               </footer>
             </article>
           </div>
+        </section>
+
+        <section class="players-goat-averages" data-player-teams-goat hidden>
+          <header class="players-lab__section-header players-goat-averages__header">
+            <h2>GOAT roster averages</h2>
+            <p class="players-lab__lede players-goat-averages__lede">
+              Ranking each franchise by average GOAT score per roster spot, normalized for current roster sizes.
+            </p>
+          </header>
+          <ol class="player-atlas__teams-goat-list players-goat-averages__list" data-player-teams-goat-list></ol>
+          <p class="player-atlas__teams-goat-empty players-goat-averages__empty" data-player-teams-goat-empty hidden>
+            Team GOAT averages are warming up.
+          </p>
         </section>
 
         <section class="players-rankings">

--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -1747,9 +1747,12 @@ function initPlayerAtlas() {
   const statBlocksEl = atlas.querySelector('[data-player-stat-blocks]');
   const teamBrowser = atlas.querySelector('[data-player-teams]');
   const teamTree = atlas.querySelector('[data-player-team-tree]');
-  const teamGoatPanel = atlas.querySelector('[data-player-teams-goat]');
-  const teamGoatList = atlas.querySelector('[data-player-teams-goat-list]');
-  const teamGoatEmpty = atlas.querySelector('[data-player-teams-goat-empty]');
+  const teamGoatPanel =
+    atlas.querySelector('[data-player-teams-goat]') || document.querySelector('[data-player-teams-goat]');
+  const teamGoatList =
+    atlas.querySelector('[data-player-teams-goat-list]') || document.querySelector('[data-player-teams-goat-list]');
+  const teamGoatEmpty =
+    atlas.querySelector('[data-player-teams-goat-empty]') || document.querySelector('[data-player-teams-goat-empty]');
   const recentLeaderboard = document.querySelector('[data-recent-leaderboard]');
   const recentPlaceholder = document.querySelector('[data-recent-placeholder]');
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5132,35 +5132,39 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   font-size: 0.7rem;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
-.player-atlas__teams-goat {
-  margin-top: 0.4rem;
-  padding-top: 0.7rem;
-  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+.players-goat-averages {
+  margin: clamp(2.5rem, 6vw, 4rem) auto clamp(2.25rem, 5vw, 3.5rem);
+  padding: 0;
   display: grid;
-  gap: 0.6rem;
+  gap: clamp(1.2rem, 3vw, 1.8rem);
+  max-width: 1140px;
 }
-.player-atlas__teams-goat[hidden] {
+.players-goat-averages[hidden] {
   display: none;
 }
-.player-atlas__teams-goat-title {
-  margin: 0;
-  font-size: 0.75rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--text-subtle) 72%, var(--royal) 28%);
+.players-goat-averages__header {
+  justify-self: center;
+  text-align: center;
+  max-width: 760px;
 }
-.player-atlas__teams-goat-copy {
+.players-goat-averages__lede {
   margin: 0;
-  font-size: 0.76rem;
-  line-height: 1.45;
-  color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-atlas__teams-goat-list {
   margin: 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.35rem;
+  gap: clamp(0.6rem, 2vw, 0.9rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.players-goat-averages__list {
+  width: 100%;
+}
+@media (min-width: 1024px) {
+  .players-goat-averages__list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 .player-atlas__teams-goat-entry {
   display: flex;
@@ -5236,10 +5240,19 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   background: color-mix(in srgb, rgba(239, 61, 91, 0.2) 70%, rgba(255, 255, 255, 0.08) 30%);
   color: color-mix(in srgb, var(--coral) 68%, var(--navy) 32%);
 }
+.player-atlas__teams-goat-entry,
+.player-atlas__teams-goat-empty {
+  width: 100%;
+}
 .player-atlas__teams-goat-empty {
   margin: 0;
   font-size: 0.75rem;
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
+  text-align: center;
+}
+.players-goat-averages__empty {
+  justify-self: center;
+  max-width: 420px;
 }
 .player-card {
   grid-area: card;


### PR DESCRIPTION
## Summary
- relocate the GOAT roster averages module beneath the player scouting atlas and before the recent rankings feature
- refresh the layout so franchise averages render in a responsive three-column grid with centered copy
- update the player atlas script to find the moved GOAT averages elements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd446732dc8327b381c481d4aac416