### PR TITLE
Refine roster height averages visualization

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -323,6 +323,21 @@
             </figure>
 
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
+              <header class="viz-card__title">Roster height stacks</header>
+              <div class="viz-canvas">
+                <canvas
+                  data-chart="team-height-averages"
+                  aria-describedby="team-height-averages-caption"
+                  data-chart-ratio="0.9"
+                ></canvas>
+              </div>
+              <figcaption id="team-height-averages-caption" class="viz-card__caption">
+                Horizontal bars rank every franchise from the shortest to tallest average listed
+                height using the current active roster snapshot.
+              </figcaption>
+            </figure>
+
+            <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Role orbit share</header>
               <div class="viz-canvas">
                 <canvas data-chart="position-orbits" aria-describedby="position-orbits-caption"></canvas>


### PR DESCRIPTION
## Summary
- add a new Morphology Lab card on the players page for roster height stacks
- polish the roster height stacks visualization with refined height formatting, axis bounds, and tooltip styling

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68dd689b259c8327a6f1ac42d1283500