### PR TITLE
Add rolling current GOAT leaderboard and collapse Pantheon tiers

### DIFF
--- a/public/goat.html
+++ b/public/goat.html
@@ -86,6 +86,36 @@
           </div>
         </section>
 
+        <section id="goat-current" class="goat-leaderboard goat-leaderboard--current">
+          <div class="section-header">
+            <h2>Current leaderboard</h2>
+            <p class="section-header__meta" data-goat-recent-generated>Rolling window refresh warming up…</p>
+          </div>
+          <div class="goat-leaderboard__layout">
+            <div class="goat-table-wrapper">
+              <div class="goat-tree" data-goat-recent-tree aria-describedby="goat-recent-footnote">
+                <p class="goat-tree__placeholder">Scanning current window…</p>
+              </div>
+              <p id="goat-recent-footnote" class="goat-table-footnote">
+                Scores reflect the rolling three-year GOAT window used across the site.
+              </p>
+            </div>
+            <aside class="goat-detail" data-goat-recent-detail>
+              <header>
+                <h3 data-goat-recent-name>Select a player</h3>
+                <p class="goat-detail__meta" data-goat-recent-meta>
+                  Pick a name from the tier tree to study the current window resume.
+                </p>
+              </header>
+              <div class="goat-detail__summary">
+                <p class="goat-detail__resume" data-goat-recent-resume></p>
+                <dl class="goat-detail__list" data-goat-recent-components></dl>
+              </div>
+              <footer class="goat-detail__footer" data-goat-recent-footer></footer>
+            </aside>
+          </div>
+        </section>
+
         <section id="goat-method" class="goat-methodology">
           <div class="section-header">
             <h2>How the General Overall Attribute Total is built</h2>


### PR DESCRIPTION
## Summary
- collapse Pantheon leaderboard tiers by default while keeping selection state wired to the detail pane
- add a Current Leaderboard section that mirrors the Pantheon layout and surfaces the rolling three-year GOAT scores
- extend the GOAT page script to load recent data, share timestamp utilities, and drive the new detail panel

## Testing
- PYTHONPATH=. pytest tests/test_goat_recent.py


------
https://chatgpt.com/codex/tasks/task_e_68ddb7b2fbc08327bd8a83ec61c01227