### PR TITLE
Enhance Momentum & mythology layout after radar removal

### DIFF
--- a/public/players.html
+++ b/public/players.html
@@ -392,7 +392,7 @@
               the lore of NBA players.
             </p>
           </header>
-          <div class="players-lab__grid viz-grid viz-grid--dense">
+          <div class="players-lab__grid viz-grid viz-grid--dense" data-viz-grid="momentum">
             <figure class="viz-card viz-card--inline" data-chart-wrapper>
               <header class="viz-card__title">Scoring era waveform</header>
               <div class="viz-canvas">
@@ -426,16 +426,6 @@
               </figcaption>
             </figure>
 
-            <figure class="viz-card viz-card--inline" data-chart-wrapper>
-              <header class="viz-card__title">Pantheon production radar</header>
-              <div class="viz-canvas">
-                <canvas data-chart="career-constellation" aria-describedby="career-constellation-caption"></canvas>
-              </div>
-              <figcaption id="career-constellation-caption" class="viz-card__caption">
-                Radar comparison for the top career scorers — normalized blend of points, assists,
-                rebounds, and win percentage.
-              </figcaption>
-            </figure>
           </div>
         </section>
       </main>

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5987,7 +5987,22 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   --viz-grid-min: clamp(220px, 26vw, 300px);
 }
 
+.players-lab__grid[data-viz-grid="momentum"] {
+  --viz-grid-min: clamp(260px, 32vw, 360px);
+  grid-auto-rows: minmax(320px, auto);
+}
+
+@media (min-width: 960px) {
+  .players-lab__grid[data-viz-grid="momentum"] .viz-card:last-child {
+    grid-column: span 2;
+  }
+}
+
 @media (max-width: 720px) {
+  .players-lab__grid[data-viz-grid="momentum"] .viz-card:last-child {
+    grid-column: auto;
+  }
+
   .viz-grid {
     grid-template-columns: minmax(0, 1fr);
     grid-auto-rows: auto;

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -5894,7 +5894,22 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   --viz-grid-min: clamp(220px, 26vw, 300px);
 }
 
+.players-lab__grid[data-viz-grid="momentum"] {
+  --viz-grid-min: clamp(260px, 32vw, 360px);
+  grid-auto-rows: minmax(320px, auto);
+}
+
+@media (min-width: 960px) {
+  .players-lab__grid[data-viz-grid="momentum"] .viz-card:last-child {
+    grid-column: span 2;
+  }
+}
+
 @media (max-width: 720px) {
+  .players-lab__grid[data-viz-grid="momentum"] .viz-card:last-child {
+    grid-column: auto;
+  }
+
   .viz-grid {
     grid-template-columns: minmax(0, 1fr);
     grid-auto-rows: auto;


### PR DESCRIPTION
## Summary
- mark the Momentum & mythology visualization grid so it can receive layout-specific styling
- widen the Momentum grid cards and let the final visualization span two columns on large viewports
- mirror the styling updates in the static preview CSS bundle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddbaba47c48327b486f3eb321a8d32