### PR TITLE
Add dynamic Ball Don't Lie game preview system

### DIFF
--- a/public/game-preview.html
+++ b/public/game-preview.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <base href="/NBA/" />
+    <title>Game preview | NBA Intelligence Hub</title>
+    <meta name="description" content="Procedural matchup previews powered by the Ball Don't Lie API." />
+    <link rel="icon" type="image/png" href="nba-logo-vector-01.png" />
+    <link rel="stylesheet" href="styles/hub.css" />
+    <link rel="stylesheet" href="styles/game-preview.css" />
+  </head>
+  <body>
+    <div class="site-frame preview-frame">
+      <header class="preview-hero" aria-live="polite">
+        <div class="preview-hero__meta">
+          <a class="preview-hero__back" href="games.html">← Back to games lab</a>
+          <div class="preview-hero__chips">
+            <span class="lab-chip" data-season-label>Season loading…</span>
+            <span class="lab-chip lab-chip--accent" data-status-label></span>
+          </div>
+        </div>
+        <h1 class="preview-hero__title" data-matchup>Loading matchup…</h1>
+        <p class="preview-hero__subtitle" data-tipoff></p>
+        <p class="preview-hero__subtitle" data-tipoff-countdown></p>
+        <p class="preview-hero__subtitle" data-location-note></p>
+      </header>
+
+      <main class="preview-main" data-preview-state>
+        <section class="preview-narrative">
+          <h2>Matchup storyline</h2>
+          <div class="preview-narrative__body" data-narrative>
+            <p>Generating matchup intel…</p>
+          </div>
+        </section>
+
+        <section class="preview-split" aria-label="Team capsules">
+          <article class="team-card" data-team-card="visitor">
+            <header class="team-card__header">
+              <div>
+                <span class="team-card__role">Road team</span>
+                <h2 class="team-card__title" data-team-name="visitor">Visitor</h2>
+              </div>
+              <div class="team-card__record" data-team-record="visitor">Record loading…</div>
+            </header>
+            <p class="team-card__note" data-team-note="visitor"></p>
+            <div class="team-card__grid">
+              <div>
+                <h3>Recent form</h3>
+                <ul class="team-card__list" data-team-last5="visitor"></ul>
+              </div>
+              <div>
+                <h3>Upcoming slate</h3>
+                <ul class="team-card__list" data-team-next5="visitor"></ul>
+              </div>
+            </div>
+            <div class="team-card__roster">
+              <h3>Active roster pulse</h3>
+              <ul class="team-card__roster-list" data-team-roster="visitor"></ul>
+            </div>
+          </article>
+
+          <article class="team-card" data-team-card="home">
+            <header class="team-card__header">
+              <div>
+                <span class="team-card__role">Home team</span>
+                <h2 class="team-card__title" data-team-name="home">Home</h2>
+              </div>
+              <div class="team-card__record" data-team-record="home">Record loading…</div>
+            </header>
+            <p class="team-card__note" data-team-note="home"></p>
+            <div class="team-card__grid">
+              <div>
+                <h3>Recent form</h3>
+                <ul class="team-card__list" data-team-last5="home"></ul>
+              </div>
+              <div>
+                <h3>Upcoming slate</h3>
+                <ul class="team-card__list" data-team-next5="home"></ul>
+              </div>
+            </div>
+            <div class="team-card__roster">
+              <h3>Active roster pulse</h3>
+              <ul class="team-card__roster-list" data-team-roster="home"></ul>
+            </div>
+          </article>
+        </section>
+
+        <section class="preview-footnotes">
+          <p class="preview-footnotes__status" data-preview-message>Pulling Ball Don't Lie data…</p>
+          <p class="preview-footnotes__meta">
+            Data source: Ball Don't Lie API via NBA Intelligence Hub proxy.
+            <br />
+            Last refreshed <span data-updated>—</span>.
+          </p>
+        </section>
+      </main>
+    </div>
+
+    <script type="module" src="scripts/game-preview.js"></script>
+  </body>
+</html>

--- a/public/scripts/game-preview.js
+++ b/public/scripts/game-preview.js
@@ -1,0 +1,600 @@
+import { bdl } from '../assets/js/bdl.js';
+
+const params = new URLSearchParams(window.location.search);
+const rawGameId = params.get('gameId') || params.get('id');
+
+const matchupTitle = document.querySelector('[data-matchup]');
+const seasonLabel = document.querySelector('[data-season-label]');
+const statusLabel = document.querySelector('[data-status-label]');
+const tipoffLabel = document.querySelector('[data-tipoff]');
+const countdownLabel = document.querySelector('[data-tipoff-countdown]');
+const locationLabel = document.querySelector('[data-location-note]');
+const narrativeContainer = document.querySelector('[data-narrative]');
+const previewMessage = document.querySelector('[data-preview-message]');
+const updatedLabel = document.querySelector('[data-updated]');
+
+const teamTargets = {
+  visitor: {
+    name: document.querySelector('[data-team-name="visitor"]'),
+    record: document.querySelector('[data-team-record="visitor"]'),
+    note: document.querySelector('[data-team-note="visitor"]'),
+    last5: document.querySelector('[data-team-last5="visitor"]'),
+    next5: document.querySelector('[data-team-next5="visitor"]'),
+    roster: document.querySelector('[data-team-roster="visitor"]'),
+  },
+  home: {
+    name: document.querySelector('[data-team-name="home"]'),
+    record: document.querySelector('[data-team-record="home"]'),
+    note: document.querySelector('[data-team-note="home"]'),
+    last5: document.querySelector('[data-team-last5="home"]'),
+    next5: document.querySelector('[data-team-next5="home"]'),
+    roster: document.querySelector('[data-team-roster="home"]'),
+  },
+};
+
+function setPreviewMessage(message, tone = 'default') {
+  if (!previewMessage) {
+    return;
+  }
+  previewMessage.textContent = message;
+  previewMessage.dataset.tone = tone;
+}
+
+function parseGameId(value) {
+  if (!value) {
+    return null;
+  }
+  const numeric = Number.parseInt(value, 10);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  return numeric;
+}
+
+function parseDateTime(value) {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+  const parsed = new Date(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+function parseDateOnly(value) {
+  if (!value || typeof value !== 'string') {
+    return null;
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed;
+}
+
+function formatSeasonLabel(season) {
+  if (!Number.isFinite(season)) {
+    return 'Season TBD';
+  }
+  const next = season + 1;
+  const suffix = String(next).slice(-2);
+  return `${season}-${suffix} season`;
+}
+
+function formatDateTime(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      dateStyle: 'full',
+      timeStyle: 'short',
+    }).format(date);
+  } catch (error) {
+    console.warn('Unable to format date', error);
+    return date.toISOString();
+  }
+}
+
+function formatShortDate(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+    }).format(date);
+  } catch (error) {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
+function formatTime(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(date);
+  } catch (error) {
+    return '';
+  }
+}
+
+function diffInHours(target) {
+  if (!(target instanceof Date) || Number.isNaN(target.getTime())) {
+    return null;
+  }
+  const now = new Date();
+  const deltaMs = target.getTime() - now.getTime();
+  return deltaMs / (1000 * 60 * 60);
+}
+
+function formatCountdown(target) {
+  const diffHours = diffInHours(target);
+  if (diffHours === null) {
+    return '';
+  }
+  if (diffHours > 48) {
+    const days = Math.round(diffHours / 24);
+    return `Tipoff in ${days} day${days === 1 ? '' : 's'}`;
+  }
+  if (diffHours > 1) {
+    const hours = Math.round(diffHours);
+    return `Tipoff in ${hours} hours`;
+  }
+  if (diffHours > 0) {
+    const minutes = Math.max(1, Math.round(diffHours * 60));
+    return `Tipoff in ${minutes} minutes`;
+  }
+  if (diffHours > -3) {
+    return 'Matchup underway';
+  }
+  return 'Matchup completed';
+}
+
+function normalizeTeam(team) {
+  if (!team) {
+    return {
+      id: null,
+      name: 'Team',
+      abbreviation: '',
+      city: '',
+    };
+  }
+  return {
+    id: Number.isFinite(team.id) ? team.id : null,
+    name: team.full_name || team.name || 'Team',
+    abbreviation: team.abbreviation || '',
+    city: team.city || '',
+  };
+}
+
+function normalizeGame(raw) {
+  if (!raw) {
+    return null;
+  }
+  const tipoff = parseDateTime(raw.datetime) || parseDateOnly(raw.date);
+  return {
+    id: Number.isFinite(raw.id) ? raw.id : null,
+    season: Number.isFinite(raw.season) ? raw.season : null,
+    status: typeof raw.status === 'string' ? raw.status : '',
+    period: Number.isFinite(raw.period) ? raw.period : 0,
+    time: typeof raw.time === 'string' ? raw.time.trim() : '',
+    date: typeof raw.date === 'string' ? raw.date : null,
+    tipoff,
+    postseason: Boolean(raw.postseason),
+    seasonType: typeof raw.season_type === 'string' ? raw.season_type : '',
+    home: normalizeTeam(raw.home_team),
+    visitor: normalizeTeam(raw.visitor_team),
+  };
+}
+
+async function loadGame(gameId) {
+  const payload = await bdl(`/v1/games/${gameId}`);
+  const raw = payload?.data ?? null;
+  return normalizeGame(raw);
+}
+
+async function fetchPaginated(path) {
+  const results = [];
+  let cursor;
+  do {
+    const url = cursor ? `${path}&cursor=${encodeURIComponent(cursor)}` : path;
+    // eslint-disable-next-line no-await-in-loop
+    const payload = await bdl(url);
+    const data = Array.isArray(payload?.data) ? payload.data : [];
+    results.push(...data);
+    cursor = payload?.meta?.next_cursor ?? null;
+  } while (cursor);
+  return results;
+}
+
+async function fetchRoster(teamId, season) {
+  if (!Number.isFinite(teamId)) {
+    return [];
+  }
+  const seasonParam = Number.isFinite(season) ? `&seasons[]=${season}` : '';
+  const path = `/v1/players?per_page=100&team_ids[]=${teamId}${seasonParam}`;
+  const players = await fetchPaginated(path);
+  const unique = new Map();
+  players.forEach((player) => {
+    if (!player) {
+      return;
+    }
+    const id = Number.isFinite(player.id) ? player.id : null;
+    if (!id) {
+      return;
+    }
+    if (!unique.has(id)) {
+      unique.set(id, player);
+    }
+  });
+  const entries = Array.from(unique.values());
+  entries.sort((a, b) => {
+    const nameA = `${(a?.last_name || '').toLowerCase()} ${(a?.first_name || '').toLowerCase()}`.trim();
+    const nameB = `${(b?.last_name || '').toLowerCase()} ${(b?.first_name || '').toLowerCase()}`.trim();
+    return nameA.localeCompare(nameB);
+  });
+  return entries.map((player) => {
+    const first = typeof player.first_name === 'string' ? player.first_name.trim() : '';
+    const last = typeof player.last_name === 'string' ? player.last_name.trim() : '';
+    const name = `${first} ${last}`.trim() || 'Player';
+    const position = typeof player.position === 'string' && player.position.trim() ? player.position.trim() : '—';
+    const jersey = typeof player.jersey_number === 'string' && player.jersey_number.trim() ? player.jersey_number.trim() : null;
+    return { id: player.id, name, position, jersey };
+  });
+}
+
+function normalizeTeamGame(raw, teamId) {
+  if (!raw) {
+    return null;
+  }
+  const tipoff = parseDateTime(raw.datetime) || parseDateOnly(raw.date);
+  const isHome = Number.isFinite(raw.home_team?.id) && raw.home_team.id === teamId;
+  const isVisitor = Number.isFinite(raw.visitor_team?.id) && raw.visitor_team.id === teamId;
+  if (!isHome && !isVisitor) {
+    return null;
+  }
+  const opponentRaw = isHome ? raw.visitor_team : raw.home_team;
+  const opponent = normalizeTeam(opponentRaw);
+  const pointsFor = isHome ? raw.home_team_score : raw.visitor_team_score;
+  const pointsAgainst = isHome ? raw.visitor_team_score : raw.home_team_score;
+  const status = typeof raw.status === 'string' ? raw.status.toLowerCase() : '';
+  const isFinal = status.includes('final');
+  const result = isFinal ? (pointsFor > pointsAgainst ? 'W' : pointsFor < pointsAgainst ? 'L' : 'T') : null;
+  return {
+    id: Number.isFinite(raw.id) ? raw.id : null,
+    tipoff,
+    date: typeof raw.date === 'string' ? raw.date : null,
+    season: Number.isFinite(raw.season) ? raw.season : null,
+    postseason: Boolean(raw.postseason),
+    status: typeof raw.status === 'string' ? raw.status : '',
+    opponent,
+    isHome,
+    pointsFor: Number.isFinite(pointsFor) ? pointsFor : 0,
+    pointsAgainst: Number.isFinite(pointsAgainst) ? pointsAgainst : 0,
+    result,
+    final: isFinal,
+  };
+}
+
+async function fetchTeamGames(teamId, season) {
+  if (!Number.isFinite(teamId)) {
+    return [];
+  }
+  const seasonParam = Number.isFinite(season) ? `&seasons[]=${season}` : '';
+  const path = `/v1/games?per_page=100&team_ids[]=${teamId}${seasonParam}`;
+  const games = await fetchPaginated(path);
+  return games
+    .map((game) => normalizeTeamGame(game, teamId))
+    .filter((entry) => entry !== null)
+    .sort((a, b) => {
+      const timeA = a.tipoff instanceof Date ? a.tipoff.getTime() : 0;
+      const timeB = b.tipoff instanceof Date ? b.tipoff.getTime() : 0;
+      return timeA - timeB;
+    });
+}
+
+function computeRecord(games, cutoff) {
+  if (!Array.isArray(games) || !games.length) {
+    return { wins: 0, losses: 0, total: 0, averageFor: null, averageAgainst: null, sample: [] };
+  }
+  const sample = games.filter((game) => game.final && (!cutoff || (game.tipoff instanceof Date && game.tipoff < cutoff)));
+  if (!sample.length) {
+    return { wins: 0, losses: 0, total: 0, averageFor: null, averageAgainst: null, sample: [] };
+  }
+  let wins = 0;
+  let losses = 0;
+  let totalFor = 0;
+  let totalAgainst = 0;
+  sample.forEach((game) => {
+    if (game.result === 'W') {
+      wins += 1;
+    } else if (game.result === 'L') {
+      losses += 1;
+    }
+    totalFor += game.pointsFor;
+    totalAgainst += game.pointsAgainst;
+  });
+  const averageFor = totalFor / sample.length;
+  const averageAgainst = totalAgainst / sample.length;
+  return { wins, losses, total: sample.length, averageFor, averageAgainst, sample };
+}
+
+function partitionUpcoming(games, cutoff) {
+  if (!Array.isArray(games) || !games.length) {
+    return [];
+  }
+  const upcoming = games.filter((game) => game.tipoff instanceof Date && (!cutoff || game.tipoff >= cutoff));
+  return upcoming;
+}
+
+function formatRecord(record) {
+  if (!record) {
+    return 'Record unavailable';
+  }
+  if (!record.total) {
+    return 'No games logged yet';
+  }
+  const winPct = record.total ? (record.wins / record.total) * 100 : 0;
+  return `${record.wins}-${record.losses} · ${winPct.toFixed(1)}%`; // Keep percent formatting consistent with other previews
+}
+
+function renderList(target, items, emptyMessage) {
+  if (!target) {
+    return;
+  }
+  target.innerHTML = '';
+  if (!items || !items.length) {
+    const li = document.createElement('li');
+    li.textContent = emptyMessage;
+    target.appendChild(li);
+    return;
+  }
+  items.forEach((entry) => {
+    const li = document.createElement('li');
+    li.textContent = entry;
+    target.appendChild(li);
+  });
+}
+
+function renderRoster(target, roster) {
+  if (!target) {
+    return;
+  }
+  target.innerHTML = '';
+  if (!roster || !roster.length) {
+    const li = document.createElement('li');
+    li.textContent = 'Roster will populate once Ball Don\'t Lie logs active players for this season.';
+    target.appendChild(li);
+    return;
+  }
+  roster.forEach((player) => {
+    const li = document.createElement('li');
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = player.name;
+    li.appendChild(nameSpan);
+    const detailSpan = document.createElement('span');
+    const parts = [];
+    if (player.jersey) {
+      parts.push(`#${player.jersey}`);
+    }
+    if (player.position && player.position !== '—') {
+      parts.push(player.position);
+    }
+    detailSpan.textContent = parts.join(' · ');
+    li.appendChild(detailSpan);
+    target.appendChild(li);
+  });
+}
+
+function renderTeamGames(target, games, options) {
+  if (!target) {
+    return;
+  }
+  const { upcoming } = options ?? {};
+  if (!games || !games.length) {
+    const li = document.createElement('li');
+    li.textContent = upcoming
+      ? 'No upcoming contests logged in the Ball Don\'t Lie window.'
+      : 'No completed contests logged yet.';
+    target.innerHTML = '';
+    target.appendChild(li);
+    return;
+  }
+  target.innerHTML = '';
+  games.forEach((game) => {
+    const li = document.createElement('li');
+    const dateLabel = formatShortDate(game.tipoff) || game.date || 'Date TBA';
+    const opponentLabel = game.opponent.abbreviation || game.opponent.name;
+    const locationPrefix = game.isHome ? 'vs' : '@';
+    if (upcoming) {
+      const timeLabel = formatTime(game.tipoff);
+      li.textContent = `${dateLabel} · ${locationPrefix} ${opponentLabel} · ${timeLabel || 'Time TBA'}`;
+    } else {
+      const scoreLine = `${game.pointsFor}-${game.pointsAgainst}`;
+      li.textContent = `${dateLabel} · ${locationPrefix} ${opponentLabel} · ${game.result || ''} ${scoreLine}`.trim();
+    }
+    target.appendChild(li);
+  });
+}
+
+function renderTeamSection(role, team, context, opponentName) {
+  const targets = teamTargets[role];
+  if (!targets) {
+    return;
+  }
+  if (targets.name) {
+    targets.name.textContent = team.name;
+  }
+  if (targets.record) {
+    targets.record.textContent = formatRecord(context.record);
+  }
+  if (targets.note) {
+    if (context.record.total) {
+      const avgFor = context.record.averageFor?.toFixed(1) ?? null;
+      const avgAgainst = context.record.averageAgainst?.toFixed(1) ?? null;
+      const differential =
+        context.record.averageFor !== null && context.record.averageAgainst !== null
+          ? (context.record.averageFor - context.record.averageAgainst).toFixed(1)
+          : null;
+      const offenseLine = avgFor ? `${avgFor} points for` : null;
+      const defenseLine = avgAgainst ? `${avgAgainst} points allowed` : null;
+      const pieces = [];
+      if (offenseLine) pieces.push(offenseLine);
+      if (defenseLine) pieces.push(defenseLine);
+      if (differential) pieces.push(`net ${differential}`);
+      targets.note.textContent = pieces.length
+        ? `${team.name} are averaging ${pieces.join(', ')} across ${context.record.total} contests.`
+        : `${team.name} have logged ${context.record.total} contests so far.`;
+    } else {
+      targets.note.textContent = `${team.name} are awaiting their first result of the ${opponentName} matchup build-up.`;
+    }
+  }
+  renderTeamGames(targets.last5, context.lastFive, { upcoming: false });
+  renderTeamGames(targets.next5, context.nextFive, { upcoming: true });
+  renderRoster(targets.roster, context.roster);
+}
+
+function buildNarrativeLines(game, visitorContext, homeContext) {
+  const lines = [];
+  const visitorRecord = visitorContext.record;
+  const homeRecord = homeContext.record;
+  if (visitorRecord.total || homeRecord.total) {
+    lines.push(
+      `${game.visitor.name} enter at ${formatRecord(visitorRecord)} while ${game.home.name} sit at ${formatRecord(homeRecord)}.`,
+    );
+  } else {
+    lines.push('Both teams are building toward their first logged contests in the Ball Don\'t Lie data feed.');
+  }
+  if (visitorRecord.averageFor !== null && homeRecord.averageFor !== null) {
+    lines.push(
+      `${game.visitor.name} are averaging ${visitorRecord.averageFor.toFixed(1)} points while ${game.home.name} are posting ${homeRecord.averageFor.toFixed(1)} per outing.`,
+    );
+  }
+  const visitorUpcoming = Array.isArray(visitorContext.nextFive) ? visitorContext.nextFive[0] : null;
+  const homeUpcoming = Array.isArray(homeContext.nextFive) ? homeContext.nextFive[0] : null;
+  if (visitorUpcoming) {
+    const locationDescriptor = visitorUpcoming.isHome ? 'home tilt' : 'road trip';
+    lines.push(
+      `${game.visitor.name} continue a ${locationDescriptor} on ${formatShortDate(visitorUpcoming.tipoff)} as part of their run-up.`,
+    );
+  }
+  if (homeUpcoming) {
+    const locationDescriptor = homeUpcoming.isHome ? 'home stand' : 'road swing';
+    lines.push(
+      `${game.home.name} transition into a ${locationDescriptor} on ${formatShortDate(homeUpcoming.tipoff)} immediately after this game.`,
+    );
+  }
+  return lines;
+}
+
+function renderNarrative(game, visitorContext, homeContext) {
+  if (!narrativeContainer) {
+    return;
+  }
+  const lines = buildNarrativeLines(game, visitorContext, homeContext);
+  narrativeContainer.innerHTML = '';
+  if (!lines.length) {
+    const paragraph = document.createElement('p');
+    paragraph.textContent = 'Awaiting more Ball Don\'t Lie data to build this storyline.';
+    narrativeContainer.appendChild(paragraph);
+    return;
+  }
+  const list = document.createElement('ul');
+  lines.forEach((line) => {
+    const li = document.createElement('li');
+    li.textContent = line;
+    list.appendChild(li);
+  });
+  narrativeContainer.appendChild(list);
+}
+
+function formatCountdownNote(tipoff) {
+  if (!(tipoff instanceof Date) || Number.isNaN(tipoff.getTime())) {
+    return '';
+  }
+  return formatCountdown(tipoff);
+}
+
+async function buildTeamContext(team, game) {
+  const [games, roster] = await Promise.all([fetchTeamGames(team.id, game.season), fetchRoster(team.id, game.season)]);
+  const record = computeRecord(games, game.tipoff);
+  const lastFive = record.sample.slice(-5);
+  const nextFive = partitionUpcoming(games, game.tipoff).slice(0, 5);
+  return {
+    roster,
+    record,
+    lastFive,
+    nextFive,
+  };
+}
+
+function updateDocumentTitle(game) {
+  const matchup = `${game.visitor.abbreviation || game.visitor.name} at ${game.home.abbreviation || game.home.name}`;
+  document.title = `${matchup} preview | NBA Intelligence Hub`;
+}
+
+async function initialize() {
+  const gameId = parseGameId(rawGameId);
+  if (!gameId) {
+    setPreviewMessage('Add a valid gameId query parameter to generate a preview.', 'error');
+    return;
+  }
+  setPreviewMessage('Loading matchup preview…');
+  try {
+    const game = await loadGame(gameId);
+    if (!game) {
+      setPreviewMessage('Unable to locate that matchup in the Ball Don\'t Lie dataset.', 'error');
+      return;
+    }
+    const tipoff = game.tipoff;
+    if (matchupTitle) {
+      const title = `${game.visitor.name} at ${game.home.name}`;
+      matchupTitle.textContent = title;
+    }
+    updateDocumentTitle(game);
+    if (seasonLabel) {
+      seasonLabel.textContent = formatSeasonLabel(game.season);
+    }
+    if (statusLabel) {
+      statusLabel.textContent = game.status || 'Scheduled';
+    }
+    if (tipoffLabel) {
+      tipoffLabel.textContent = tipoff ? `Local tip ${formatDateTime(tipoff)}` : '';
+    }
+    if (countdownLabel) {
+      countdownLabel.textContent = formatCountdownNote(tipoff);
+    }
+    if (locationLabel) {
+      locationLabel.textContent = game.postseason
+        ? 'Postseason contest (venue per league assignment).'
+        : '';
+    }
+
+    const [visitorContext, homeContext] = await Promise.all([
+      buildTeamContext(game.visitor, game),
+      buildTeamContext(game.home, game),
+    ]);
+
+    renderTeamSection('visitor', game.visitor, visitorContext, game.home.name);
+    renderTeamSection('home', game.home, homeContext, game.visitor.name);
+    renderNarrative(game, visitorContext, homeContext);
+
+    setPreviewMessage('Preview generated from live Ball Don\'t Lie data.');
+    if (updatedLabel) {
+      updatedLabel.textContent = formatDateTime(new Date());
+    }
+  } catch (error) {
+    console.error('Failed to build game preview', error);
+    setPreviewMessage('Unable to build the preview right now. Please retry in a moment.', 'error');
+  }
+}
+
+initialize();

--- a/public/scripts/games.js
+++ b/public/scripts/games.js
@@ -606,6 +606,19 @@ function createScoreboardCard(game) {
   if (footer.childNodes.length) {
     card.appendChild(footer);
   }
+  if (Number.isFinite(game?.id)) {
+    const actions = document.createElement('div');
+    actions.className = 'scoreboard-card__actions';
+    const link = document.createElement('a');
+    link.className = 'scoreboard-card__link';
+    link.href = `game-preview.html?gameId=${game.id}`;
+    const visitorLabel = game.visitor?.name || game.visitor?.abbreviation || 'Road team';
+    const homeLabel = game.home?.name || game.home?.abbreviation || 'Home team';
+    link.textContent = 'Matchup preview';
+    link.setAttribute('aria-label', `Open matchup preview for ${visitorLabel} at ${homeLabel}`);
+    actions.appendChild(link);
+    card.appendChild(actions);
+  }
   return card;
 }
 

--- a/public/styles/game-preview.css
+++ b/public/styles/game-preview.css
@@ -1,0 +1,252 @@
+:root {
+  color-scheme: light;
+}
+
+.preview-frame {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3.5rem;
+}
+
+.preview-hero {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.preview-hero__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.preview-hero__back {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--royal) 90%, var(--navy) 10%);
+  text-decoration: none;
+}
+
+.preview-hero__back:hover,
+.preview-hero__back:focus {
+  text-decoration: underline;
+}
+
+.preview-hero__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.preview-hero__title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  color: var(--navy);
+}
+
+.preview-hero__subtitle {
+  font-size: 1rem;
+  color: color-mix(in srgb, var(--text-subtle) 88%, var(--navy) 12%);
+  margin: 0;
+}
+
+.preview-main {
+  display: grid;
+  gap: 2.75rem;
+}
+
+.preview-narrative {
+  padding: 1.6rem 1.8rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background:
+    linear-gradient(145deg, rgba(15, 66, 178, 0.08), rgba(236, 242, 255, 0.9)),
+    rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.preview-narrative h2 {
+  margin-top: 0;
+  margin-bottom: 1.1rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--navy) 92%, var(--text-subtle) 8%);
+}
+
+.preview-narrative__body {
+  display: grid;
+  gap: 0.85rem;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: color-mix(in srgb, var(--navy) 88%, var(--text-subtle) 12%);
+}
+
+.preview-narrative__body ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.preview-split {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.team-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background:
+    linear-gradient(155deg, rgba(10, 46, 118, 0.08), rgba(255, 208, 128, 0.05)),
+    rgba(255, 255, 255, 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  padding: 1.6rem 1.75rem 1.85rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.team-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.team-card__role {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
+  margin-bottom: 0.35rem;
+}
+
+.team-card__title {
+  font-size: 1.65rem;
+  font-weight: 700;
+  color: var(--navy);
+  margin: 0;
+}
+
+.team-card__record {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--royal) 75%, var(--navy) 25%);
+}
+
+.team-card__note {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--navy) 80%, var(--text-subtle) 20%);
+}
+
+.team-card__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.team-card__grid h3 {
+  margin-top: 0;
+  margin-bottom: 0.65rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--navy) 88%, var(--text-subtle) 12%);
+}
+
+.team-card__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.45rem;
+  font-size: 0.92rem;
+  color: color-mix(in srgb, var(--navy) 78%, var(--text-subtle) 22%);
+}
+
+.team-card__list li {
+  padding: 0.55rem 0.65rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.team-card__roster h3 {
+  margin: 0 0 0.65rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--navy) 88%, var(--text-subtle) 12%);
+}
+
+.team-card__roster-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+  max-height: 380px;
+  overflow-y: auto;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--navy) 78%, var(--text-subtle) 22%);
+}
+
+.team-card__roster-list li {
+  padding: 0.45rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  background: rgba(255, 255, 255, 0.65);
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.team-card__roster-list li span {
+  white-space: nowrap;
+}
+
+.preview-footnotes {
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-top: 1.5rem;
+  font-size: 0.9rem;
+  color: color-mix(in srgb, var(--text-subtle) 85%, var(--navy) 15%);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.preview-footnotes__status {
+  margin: 0;
+  font-weight: 600;
+}
+
+.preview-footnotes__status[data-tone='error'] {
+  color: rgba(239, 61, 91, 0.88);
+}
+
+.preview-footnotes__status[data-tone='default'] {
+  color: color-mix(in srgb, var(--text-subtle) 88%, var(--navy) 12%);
+}
+
+.preview-footnotes__meta {
+  margin: 0;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .preview-frame {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .preview-hero__meta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -6820,6 +6820,24 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   margin: 0;
 }
 
+.scoreboard-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.scoreboard-card__link {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--royal) 80%, var(--navy) 20%);
+  text-decoration: none;
+}
+
+.scoreboard-card__link:hover,
+.scoreboard-card__link:focus {
+  color: color-mix(in srgb, var(--royal) 92%, var(--navy) 8%);
+  text-decoration: underline;
+}
+
 .games-caption-meta {
   display: inline-block;
   margin-left: 0.75rem;


### PR DESCRIPTION
## Summary
- add a reusable game-preview page that pulls Ball Don't Lie data for matchup details, team form, and rosters
- wire Scoreboard pulse cards to the new previews and add styling hooks for the call-to-action link
- style the dynamic preview shell so the narrative, team capsules, and data freshness state are easy to scan

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ddc22c2f688327958454eb2285ecb7