### PR TITLE
Remove outdated hero copy from games page

### DIFF
--- a/public/games.html
+++ b/public/games.html
@@ -53,11 +53,6 @@
           <div class="hero__intro">
             <span class="eyebrow">Games Observatory</span>
             <h1>Scoreboard lab</h1>
-            <p class="hero__lead">
-              Tracking the 2025-26 buildup through our live games feed while keeping the 2024-25 finish as our reference
-              point—the default slate spotlights the June 17, 2024 finale so every chart stays populated until the new campaign
-              tips off.
-            </p>
             <div class="games-toolbar">
               <label for="game-date-start">Game dates</label>
               <div class="games-toolbar__range">


### PR DESCRIPTION
## Summary
- remove the outdated hero lead paragraph from games.html to eliminate the preseason tracking blurb

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc59cd6248327996d266ff139a06f