### PR TITLE
Display player atlas team browser as grid

### DIFF
--- a/public/scripts/players.js
+++ b/public/scripts/players.js
@@ -2355,7 +2355,10 @@ function initPlayerAtlas() {
       if (parentSection && !parentSection.open) {
         parentSection.open = true;
       }
-      activeButton.scrollIntoView({ block: 'nearest' });
+      const isTreeScrollable = teamTree.scrollHeight > teamTree.clientHeight;
+      if (isTreeScrollable) {
+        activeButton.scrollIntoView({ block: 'nearest' });
+      }
     }
   };
 

--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5023,7 +5023,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__layout {
   display: grid;
-  grid-template-columns: minmax(0, clamp(13.5rem, 22vw, 17rem)) minmax(0, 1fr);
+  grid-template-columns: minmax(0, clamp(30rem, 40vw, 36rem)) minmax(0, 1fr);
   grid-template-areas:
     'search search'
     'tree card';
@@ -5167,8 +5167,9 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
     linear-gradient(160deg, rgba(17, 86, 214, 0.06), rgba(244, 181, 63, 0.04)),
     color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.88) 30%);
   box-shadow: var(--shadow-soft);
-  width: min(100%, clamp(13.5rem, 20vw, 16.5rem));
-  max-height: clamp(18rem, 70vh, 32rem);
+  width: 100%;
+  max-width: 100%;
+  max-height: none;
 }
 .player-atlas__teams[hidden] { display: none; }
 .player-atlas__teams-title {
@@ -5183,18 +5184,15 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-atlas__teams-tree {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
   gap: 0.3rem;
   min-height: 0;
-  overflow-y: auto;
-  padding-right: 0.2rem;
-  scrollbar-gutter: stable both-edges;
-  overscroll-behavior: contain;
+  align-content: start;
 }
 
 .player-atlas__teams-tree > * {
-  flex: 0 0 auto;
+  min-width: 0;
 }
 .player-atlas__teams-tree:focus-visible { outline: none; }
 .player-atlas__team {
@@ -5787,7 +5785,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .player-atlas__teams {
     width: 100%;
     max-width: 100%;
-    max-height: min(55vh, 28rem);
+    max-height: none;
   }
 }
 

--- a/site/styles/hub.css
+++ b/site/styles/hub.css
@@ -4911,7 +4911,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__layout {
   display: grid;
-  grid-template-columns: minmax(0, clamp(13.5rem, 22vw, 17rem)) minmax(0, 1fr);
+  grid-template-columns: minmax(0, clamp(30rem, 40vw, 36rem)) minmax(0, 1fr);
   grid-template-areas:
     'search search'
     'tree card';
@@ -5055,8 +5055,9 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
     linear-gradient(160deg, rgba(17, 86, 214, 0.06), rgba(244, 181, 63, 0.04)),
     color-mix(in srgb, rgba(255, 255, 255, 0.92) 70%, rgba(242, 246, 255, 0.88) 30%);
   box-shadow: var(--shadow-soft);
-  width: min(100%, clamp(13.5rem, 20vw, 16.5rem));
-  max-height: clamp(18rem, 70vh, 32rem);
+  width: 100%;
+  max-width: 100%;
+  max-height: none;
 }
 .player-atlas__teams[hidden] { display: none; }
 .player-atlas__teams-title {
@@ -5071,18 +5072,15 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   color: color-mix(in srgb, var(--text-subtle) 78%, var(--navy) 22%);
 }
 .player-atlas__teams-tree {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(10, minmax(0, 1fr));
   gap: 0.3rem;
   min-height: 0;
-  overflow-y: auto;
-  padding-right: 0.2rem;
-  scrollbar-gutter: stable both-edges;
-  overscroll-behavior: contain;
+  align-content: start;
 }
 
 .player-atlas__teams-tree > * {
-  flex: 0 0 auto;
+  min-width: 0;
 }
 .player-atlas__teams-tree:focus-visible { outline: none; }
 .player-atlas__team {
@@ -5662,7 +5660,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
   .player-atlas__teams {
     width: 100%;
     max-width: 100%;
-    max-height: min(55vh, 28rem);
+    max-height: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- widen the player atlas franchise browser and switch the team list to a 10x3 grid layout
- remove the panel height cap so every franchise tile stays visible without scrolling
- guard the team highlight helper so it only scrolls when the browser is overflowed

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68ddc5f5fea88327bad6c4ebec3e7c99