### PR TITLE
Adjust franchise roster grid sizing

### DIFF
--- a/public/styles/hub.css
+++ b/public/styles/hub.css
@@ -5185,7 +5185,7 @@ section h2 { margin-top: 0; font-size: clamp(1.35rem, 3vw, 1.8rem); letter-spaci
 }
 .player-atlas__teams-tree {
   display: grid;
-  grid-template-columns: repeat(10, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(12.5rem, 1fr));
   gap: 0.3rem;
   min-height: 0;
   align-content: start;


### PR DESCRIPTION
## Summary
- widen the Browse by franchise grid so each team column can accommodate player text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddcb8bc1e083279ace339a2607a2a9