### PR TITLE
Sort GOAT leaderboard by score

### DIFF
--- a/public/scripts/goat.js
+++ b/public/scripts/goat.js
@@ -640,16 +640,20 @@ function buildLeaderboard(
   }
 
   const sortedPlayers = playerList.slice().sort((a, b) => {
+    const scoreA = Number.isFinite(a?.goatScore) ? a.goatScore : null;
+    const scoreB = Number.isFinite(b?.goatScore) ? b.goatScore : null;
+    if (scoreA !== null || scoreB !== null) {
+      if (scoreA === null) return 1;
+      if (scoreB === null) return -1;
+      if (scoreA !== scoreB) {
+        return scoreB - scoreA;
+      }
+    }
+
     const rankA = Number.isFinite(a?.rank) ? a.rank : Infinity;
     const rankB = Number.isFinite(b?.rank) ? b.rank : Infinity;
     if (rankA !== rankB) {
       return rankA - rankB;
-    }
-
-    const scoreA = Number.isFinite(a?.goatScore) ? a.goatScore : -Infinity;
-    const scoreB = Number.isFinite(b?.goatScore) ? b.goatScore : -Infinity;
-    if (scoreA !== scoreB) {
-      return scoreB - scoreA;
     }
 
     const nameA = typeof a?.name === 'string' ? a.name.toLowerCase() : '';


### PR DESCRIPTION
## Summary
- sort the GOAT leaderboard by GOAT score before assigning sequential ranks so the top scorer appears first

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddccbf7f7c8327911d824830630996