### PR TITLE
Expand skyline bubble chart to include all seven-footers

### DIFF
--- a/public/data/players_overview.json
+++ b/public/data/players_overview.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2025-09-30T19:49:16.563732+00:00",
+  "generatedAt": "2025-10-02T01:39:09.277499+00:00",
   "totals": {
     "players": 6533,
     "averageHeightInches": 78.03,
@@ -209,16 +209,6 @@
       ]
     },
     {
-      "personId": "76195",
-      "name": "Manute Bol",
-      "heightInches": 90.0,
-      "weightPounds": 200.0,
-      "country": "Sudan",
-      "positions": [
-        "C"
-      ]
-    },
-    {
       "personId": "2397",
       "name": "Yao Ming",
       "heightInches": 90.0,
@@ -239,31 +229,21 @@
       ]
     },
     {
+      "personId": "76195",
+      "name": "Manute Bol",
+      "heightInches": 90.0,
+      "weightPounds": 200.0,
+      "country": "Sudan",
+      "positions": [
+        "C"
+      ]
+    },
+    {
       "personId": "204021",
       "name": "Sim Bhullar",
       "heightInches": 89.0,
       "weightPounds": 360.0,
       "country": "Canada",
-      "positions": [
-        "C"
-      ]
-    },
-    {
-      "personId": "77707",
-      "name": "Chuck Nevitt",
-      "heightInches": 89.0,
-      "weightPounds": null,
-      "country": "USA",
-      "positions": [
-        "C"
-      ]
-    },
-    {
-      "personId": "2750",
-      "name": "Pavel Podkolzin",
-      "heightInches": 89.0,
-      "weightPounds": 260.0,
-      "country": "Russia",
       "positions": [
         "C"
       ]
@@ -279,9 +259,19 @@
       ]
     },
     {
-      "personId": "76631",
-      "name": "Mark Eaton",
-      "heightInches": 88.0,
+      "personId": "2750",
+      "name": "Pavel Podkolzin",
+      "heightInches": 89.0,
+      "weightPounds": 260.0,
+      "country": "Russia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77707",
+      "name": "Chuck Nevitt",
+      "heightInches": 89.0,
       "weightPounds": null,
       "country": "USA",
       "positions": [
@@ -299,11 +289,2522 @@
       ]
     },
     {
+      "personId": "1626246",
+      "name": "Boban Marjanovic",
+      "heightInches": 88.0,
+      "weightPounds": 290.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
       "personId": "22",
       "name": "Rik Smits",
       "heightInches": 88.0,
       "weightPounds": 265.0,
       "country": "Netherlands",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76631",
+      "name": "Mark Eaton",
+      "heightInches": 88.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78055",
+      "name": "Ralph Sampson",
+      "heightInches": 88.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "717",
+      "name": "Arvydas Sabonis",
+      "heightInches": 87.0,
+      "weightPounds": 292.0,
+      "country": "Lithuania",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2762",
+      "name": "Peter John Ramos",
+      "heightInches": 87.0,
+      "weightPounds": 275.0,
+      "country": "Puerto Rico",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "204002",
+      "name": "Edy Tavares",
+      "heightInches": 87.0,
+      "weightPounds": 265.0,
+      "country": "Cabo Verde",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201934",
+      "name": "Hasheem Thabeet",
+      "heightInches": 87.0,
+      "weightPounds": 263.0,
+      "country": "Tanzania",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "980",
+      "name": "Zydrunas Ilgauskas",
+      "heightInches": 87.0,
+      "weightPounds": 260.0,
+      "country": "Lithuania",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1893",
+      "name": "Aleksandar Radojevic",
+      "heightInches": 87.0,
+      "weightPounds": 250.0,
+      "country": "Bosnia and Herzegovina",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76247",
+      "name": "Randy Breuer",
+      "heightInches": 87.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1569",
+      "name": "Keith Closs",
+      "heightInches": 87.0,
+      "weightPounds": 212.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76919",
+      "name": "Harvey Halbrook",
+      "heightInches": 87.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2775",
+      "name": "Seung-Jin Ha",
+      "heightInches": 87.0,
+      "weightPounds": null,
+      "country": "South Korea",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202353",
+      "name": "Tibor Pleiss",
+      "heightInches": 87.0,
+      "weightPounds": null,
+      "country": "Germany",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "676",
+      "name": "Thomas Hamilton",
+      "heightInches": 86.0,
+      "weightPounds": 330.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2123",
+      "name": "Garth Joseph",
+      "heightInches": 86.0,
+      "weightPounds": 306.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2054",
+      "name": "Jake Tsakalidis",
+      "heightInches": 86.0,
+      "weightPounds": 290.0,
+      "country": "Greece",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "368",
+      "name": "Dwayne Schintzius",
+      "heightInches": 86.0,
+      "weightPounds": 285.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "731",
+      "name": "Greg Ostertag",
+      "heightInches": 86.0,
+      "weightPounds": 280.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76583",
+      "name": "James Donaldson",
+      "heightInches": 86.0,
+      "weightPounds": 275.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1007",
+      "name": "Luther Wright",
+      "heightInches": 86.0,
+      "weightPounds": 270.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201632",
+      "name": "Hamed Haddadi",
+      "heightInches": 86.0,
+      "weightPounds": 265.0,
+      "country": "Iran",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1743",
+      "name": "Bruno Sundov",
+      "heightInches": 86.0,
+      "weightPounds": 260.0,
+      "country": "Croatia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "87",
+      "name": "Dikembe Mutombo",
+      "heightInches": 86.0,
+      "weightPounds": 260.0,
+      "country": "Congo",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2254",
+      "name": "Loren Woods",
+      "heightInches": 86.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77704",
+      "name": "Martin Nessley",
+      "heightInches": 86.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "76901",
+      "name": "Petur Gudmundsson",
+      "heightInches": 86.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1101",
+      "name": "Rich King",
+      "heightInches": 86.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76604",
+      "name": "Ralph Drollinger",
+      "heightInches": 86.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201582",
+      "name": "Alexis Ajinca",
+      "heightInches": 86.0,
+      "weightPounds": 248.0,
+      "country": "France",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1629650",
+      "name": "Moses Brown",
+      "heightInches": 86.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1628",
+      "name": "Alan Ogg",
+      "heightInches": 86.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "600014",
+      "name": "Artis Gilmore",
+      "heightInches": 86.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2456",
+      "name": "Cezary Trybanski",
+      "heightInches": 86.0,
+      "weightPounds": 240.0,
+      "country": "Poland",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "200785",
+      "name": "Kosta Perovic",
+      "heightInches": 86.0,
+      "weightPounds": 240.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101149",
+      "name": "Martynas Andriuskevicius",
+      "heightInches": 86.0,
+      "weightPounds": 240.0,
+      "country": "Lithuania",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77823",
+      "name": "Tom Payne",
+      "heightInches": 86.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76003",
+      "name": "Kareem Abdul-Jabbar",
+      "heightInches": 86.0,
+      "weightPounds": 225.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76305",
+      "name": "Tom Burleson",
+      "heightInches": 86.0,
+      "weightPounds": 225.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201579",
+      "name": "Roy Hibbert",
+      "heightInches": 86.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1626257",
+      "name": "Salah Mejri",
+      "heightInches": 86.0,
+      "weightPounds": null,
+      "country": "Tunisia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1037",
+      "name": "Stojko Vrankovic",
+      "heightInches": 86.0,
+      "weightPounds": null,
+      "country": "Croatia",
+      "positions": []
+    },
+    {
+      "personId": "1937",
+      "name": "Tim Young",
+      "heightInches": 86.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "406",
+      "name": "Shaquille O'Neal",
+      "heightInches": 85.0,
+      "weightPounds": 325.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2053",
+      "name": "Dalibor Bagaric",
+      "heightInches": 85.0,
+      "weightPounds": 290.0,
+      "country": "Croatia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1917",
+      "name": "Wang Zhi-zhi",
+      "heightInches": 85.0,
+      "weightPounds": 284.0,
+      "country": "China",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2601",
+      "name": "Andreas Glyniadakis",
+      "heightInches": 85.0,
+      "weightPounds": 280.0,
+      "country": "Greece",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201178",
+      "name": "Kyrylo Fesenko",
+      "heightInches": 85.0,
+      "weightPounds": 280.0,
+      "country": "Ukraine",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202389",
+      "name": "Timofey Mozgov",
+      "heightInches": 85.0,
+      "weightPounds": 275.0,
+      "country": "Russia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2741",
+      "name": "Robert Swift",
+      "heightInches": 85.0,
+      "weightPounds": 270.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1068",
+      "name": "Greg Dreiling",
+      "heightInches": 85.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1630257",
+      "name": "Jon Teske",
+      "heightInches": 85.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2237",
+      "name": "Ratko Varda",
+      "heightInches": 85.0,
+      "weightPounds": 265.0,
+      "country": "Bosnia and Herzegovina",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2435",
+      "name": "Mario Kasun",
+      "heightInches": 85.0,
+      "weightPounds": 260.0,
+      "country": "Croatia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "687",
+      "name": "Rastko Cvetkovic",
+      "heightInches": 85.0,
+      "weightPounds": 260.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "124",
+      "name": "Vlade Divac",
+      "heightInches": 85.0,
+      "weightPounds": 260.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2091",
+      "name": "Daniel Santiago",
+      "heightInches": 85.0,
+      "weightPounds": 256.0,
+      "country": "Puerto Rico",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101148",
+      "name": "Mile Ilic",
+      "heightInches": 85.0,
+      "weightPounds": 255.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78407",
+      "name": "Nick Vanos",
+      "heightInches": 85.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2056",
+      "name": "Primoz Brezec",
+      "heightInches": 85.0,
+      "weightPounds": 255.0,
+      "country": "Slovenia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202374",
+      "name": "Solomon Alabi",
+      "heightInches": 85.0,
+      "weightPounds": 252.0,
+      "country": "Nigeria",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76172",
+      "name": "Uwe Blab",
+      "heightInches": 85.0,
+      "weightPounds": 252.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "764",
+      "name": "David Robinson",
+      "heightInches": 85.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78188",
+      "name": "Elmore Smith",
+      "heightInches": 85.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77370",
+      "name": "Gary Leonard",
+      "heightInches": 85.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78492",
+      "name": "Matt Wenstrom",
+      "heightInches": 85.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76375",
+      "name": "Wilt Chamberlain",
+      "heightInches": 85.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76362",
+      "name": "Bill Cartwright",
+      "heightInches": 85.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "200798",
+      "name": "Cheikh Samb",
+      "heightInches": 85.0,
+      "weightPounds": 245.0,
+      "country": "Senegal",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2038",
+      "name": "Joel Przybilla",
+      "heightInches": 85.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1572",
+      "name": "Nate Huffman",
+      "heightInches": 85.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201150",
+      "name": "Spencer Hawes",
+      "heightInches": 85.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "77057",
+      "name": "Tito Horford",
+      "heightInches": 85.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "305",
+      "name": "Robert Parish",
+      "heightInches": 85.0,
+      "weightPounds": 244.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1627834",
+      "name": "Georgios Papagiannis",
+      "heightInches": 85.0,
+      "weightPounds": 240.0,
+      "country": "Greece",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76715",
+      "name": "Greg Fillmore",
+      "heightInches": 85.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78647",
+      "name": "Jim Zoet",
+      "heightInches": 85.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76709",
+      "name": "Rolando Ferreira",
+      "heightInches": 85.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "77863",
+      "name": "Tom Piotrowski",
+      "heightInches": 85.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76217",
+      "name": "Sam Bowie",
+      "heightInches": 85.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78014",
+      "name": "Tree Rollins",
+      "heightInches": 85.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78148",
+      "name": "Ralph Siewert",
+      "heightInches": 85.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76370",
+      "name": "Ron Cavenall",
+      "heightInches": 85.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1628394",
+      "name": "Anzejs Pasecniks",
+      "heightInches": 85.0,
+      "weightPounds": 229.0,
+      "country": "Latvia",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "229",
+      "name": "James Edwards",
+      "heightInches": 85.0,
+      "weightPounds": 229.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77794",
+      "name": "Walter Palmer",
+      "heightInches": 85.0,
+      "weightPounds": 215.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1631096",
+      "name": "Chet Holmgren",
+      "heightInches": 85.0,
+      "weightPounds": 195.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1641726",
+      "name": "Dereck Lively II",
+      "heightInches": 85.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1744",
+      "name": "Jerome James",
+      "heightInches": 85.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101195",
+      "name": "Luke Schenscher",
+      "heightInches": 85.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78481",
+      "name": "Marvin Webster",
+      "heightInches": 85.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1735",
+      "name": "Vladimir Stepania",
+      "heightInches": 85.0,
+      "weightPounds": null,
+      "country": "Georgia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1627753",
+      "name": "Zhou Qi",
+      "heightInches": 85.0,
+      "weightPounds": null,
+      "country": "China",
+      "positions": []
+    },
+    {
+      "personId": "404",
+      "name": "Kevin Duckworth",
+      "heightInches": 84.0,
+      "weightPounds": 300.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2201",
+      "name": "Eddy Curry",
+      "heightInches": 84.0,
+      "weightPounds": 295.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "735",
+      "name": "Bryant Reeves",
+      "heightInches": 84.0,
+      "weightPounds": 290.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "280",
+      "name": "Felton Spencer",
+      "heightInches": 84.0,
+      "weightPounds": 290.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "914",
+      "name": "Stanley Roberts",
+      "heightInches": 84.0,
+      "weightPounds": 290.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101115",
+      "name": "Andrew Bynum",
+      "heightInches": 84.0,
+      "weightPounds": 285.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201577",
+      "name": "Robin Lopez",
+      "heightInches": 84.0,
+      "weightPounds": 281.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2758",
+      "name": "David Harrison",
+      "heightInches": 84.0,
+      "weightPounds": 280.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203954",
+      "name": "Joel Embiid",
+      "heightInches": 84.0,
+      "weightPounds": 280.0,
+      "country": "Cameroon",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1928",
+      "name": "Todd MacCulloch",
+      "heightInches": 84.0,
+      "weightPounds": 280.0,
+      "country": "Canada",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "922",
+      "name": "Elden Campbell",
+      "heightInches": 84.0,
+      "weightPounds": 279.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "201957",
+      "name": "Byron Mullens",
+      "heightInches": 84.0,
+      "weightPounds": 275.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2545",
+      "name": "Darko Milicic",
+      "heightInches": 84.0,
+      "weightPounds": 275.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2823",
+      "name": "John Edwards",
+      "heightInches": 84.0,
+      "weightPounds": 275.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1868",
+      "name": "Trevor Winter",
+      "heightInches": 84.0,
+      "weightPounds": 275.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201141",
+      "name": "Greg Oden",
+      "heightInches": 84.0,
+      "weightPounds": 273.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201189",
+      "name": "Aaron Gray",
+      "heightInches": 84.0,
+      "weightPounds": 270.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2082",
+      "name": "Dan McClintock",
+      "heightInches": 84.0,
+      "weightPounds": 270.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "771",
+      "name": "Elmore Spencer",
+      "heightInches": 84.0,
+      "weightPounds": 270.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "376",
+      "name": "Eric Montross",
+      "heightInches": 84.0,
+      "weightPounds": 270.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1709",
+      "name": "Michael Olowokandi",
+      "heightInches": 84.0,
+      "weightPounds": 270.0,
+      "country": "Nigeria",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203135",
+      "name": "Robert Sacre",
+      "heightInches": 84.0,
+      "weightPounds": 270.0,
+      "country": "Canada",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1127",
+      "name": "Charles Claxton",
+      "heightInches": 84.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2549",
+      "name": "Chris Kaman",
+      "heightInches": 84.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202355",
+      "name": "Hassan Whiteside",
+      "heightInches": 84.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202880",
+      "name": "Jeff Foote",
+      "heightInches": 84.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "212",
+      "name": "Yinka Dare",
+      "heightInches": 84.0,
+      "weightPounds": 265.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1442",
+      "name": "Zeljko Rebraca",
+      "heightInches": 84.0,
+      "weightPounds": 265.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2217",
+      "name": "Brendan Haywood",
+      "heightInches": 84.0,
+      "weightPounds": 263.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "903",
+      "name": "Geert Hammink",
+      "heightInches": 84.0,
+      "weightPounds": 262.0,
+      "country": "Netherlands",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1802",
+      "name": "Brad Miller",
+      "heightInches": 84.0,
+      "weightPounds": 261.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "101106",
+      "name": "Andrew Bogut",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "Australia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1629353",
+      "name": "Isaac Humphries",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "Australia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2044",
+      "name": "Jason Collier",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203086",
+      "name": "Meyers Leonard",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1627861",
+      "name": "Mike Tobey",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203136",
+      "name": "Ognjen Kuzmic",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77637",
+      "name": "Ron Moore",
+      "heightInches": 84.0,
+      "weightPounds": 260.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2257",
+      "name": "Ruben Boumtje-Boumtje",
+      "heightInches": 84.0,
+      "weightPounds": 257.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "440",
+      "name": "Zan Tabak",
+      "heightInches": 84.0,
+      "weightPounds": 257.0,
+      "country": "Croatia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101112",
+      "name": "Channing Frye",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "2788",
+      "name": "DJ Mbenga",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "Belgium",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1626177",
+      "name": "Dakari Johnson",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "190",
+      "name": "Duane Causwell",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203097",
+      "name": "Fab Melo",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "Brazil",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "165",
+      "name": "Hakeem Olajuwon",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "Nigeria",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2215",
+      "name": "Jason Collins",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203120",
+      "name": "Justin Hamilton",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2055",
+      "name": "Mamadou N'diaye",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "Senegal",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201600",
+      "name": "Omer Asik",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "Turkey",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1725",
+      "name": "Rasho Nesterovic",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "Slovenia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1629118",
+      "name": "Thomas Welsh",
+      "heightInches": 84.0,
+      "weightPounds": 255.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202366",
+      "name": "Jerome Jordan",
+      "heightInches": 84.0,
+      "weightPounds": 253.0,
+      "country": "Jamaica",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2740",
+      "name": "Andris Biedrins",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "Latvia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "104",
+      "name": "Benoit Benjamin",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77478",
+      "name": "Bob Martin",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1629028",
+      "name": "Deandre Ayton",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "Bahamas",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2853",
+      "name": "Earl Barron",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "678",
+      "name": "George Zidek",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1628392",
+      "name": "Isaiah Hartenstein",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "Germany",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "402",
+      "name": "Jon Koncak",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1548",
+      "name": "Mark Blount",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1627850",
+      "name": "Marshall Plumlee",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1091",
+      "name": "Mike Smrek",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203545",
+      "name": "Miroslav Raduljica",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "200753",
+      "name": "Patrick O'Bryant",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2200",
+      "name": "Pau Gasol",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "Spain",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "77623",
+      "name": "Paul Mokeski",
+      "heightInches": 84.0,
+      "weightPounds": 250.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1512",
+      "name": "Chris Anstey",
+      "heightInches": 84.0,
+      "weightPounds": 249.0,
+      "country": "Australia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1627733",
+      "name": "Dragan Bender",
+      "heightInches": 84.0,
+      "weightPounds": 249.0,
+      "country": "Croatia",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "76945",
+      "name": "Reggie Harding",
+      "heightInches": 84.0,
+      "weightPounds": 249.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101130",
+      "name": "Johan Petro",
+      "heightInches": 84.0,
+      "weightPounds": 247.0,
+      "country": "France",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203945",
+      "name": "Alex Kirk",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "175",
+      "name": "Alton Lister",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "82",
+      "name": "Bill Wennington",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "921",
+      "name": "Brad Daugherty",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1846",
+      "name": "Chris Welp",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1717",
+      "name": "Dirk Nowitzki",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "Germany",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "35",
+      "name": "Eric Riley",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "788",
+      "name": "Kevin Willis",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1514",
+      "name": "Paul Grant",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "984",
+      "name": "Steve Hamer",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76291",
+      "name": "Wallace Bryant",
+      "heightInches": 84.0,
+      "weightPounds": 245.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202686",
+      "name": "Jan Vesely",
+      "heightInches": 84.0,
+      "weightPounds": 242.0,
+      "country": "Czech Republic",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "77712",
+      "name": "Dave Newmark",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1626163",
+      "name": "Frank Kaminsky",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "76716",
+      "name": "Hank Finkel",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1630164",
+      "name": "James Wiseman",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201160",
+      "name": "Jason Smith",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "76079",
+      "name": "Milos Babic",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1629011",
+      "name": "Mitchell Robinson",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "2420",
+      "name": "Nenad Krstic",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "Serbia",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201623",
+      "name": "Semih Erden",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "Turkey",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1627757",
+      "name": "Stephen Zimmerman",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2212",
+      "name": "Steven Hunter",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1626161",
+      "name": "Willie Cauley-Stein",
+      "heightInches": 84.0,
+      "weightPounds": 240.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77129",
+      "name": "Les Jepsen",
+      "heightInches": 84.0,
+      "weightPounds": 237.0,
+      "country": "USA",
+      "positions": [
+        "G"
+      ]
+    },
+    {
+      "personId": "76812",
+      "name": "Ben Gillery",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202380",
+      "name": "Hamady Ndiaye",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "Senegal",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76844",
+      "name": "Jim Grandholm",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78603",
+      "name": "Luke Witte",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76260",
+      "name": "Mike Brittain",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77235",
+      "name": "Rich Kelley",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76469",
+      "name": "Ron Crevier",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76861",
+      "name": "Stuart Gray",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "969",
+      "name": "Travis Knight",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2199",
+      "name": "Tyson Chandler",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1629738",
+      "name": "Vincent Poirier",
+      "heightInches": 84.0,
+      "weightPounds": 235.0,
+      "country": "France",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1089",
+      "name": "Kevin Salvadori",
+      "heightInches": 84.0,
+      "weightPounds": 231.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1106",
+      "name": "Donald Hodge",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "203481",
+      "name": "Jeff Withey",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1886",
+      "name": "Jonathan Bender",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "77323",
+      "name": "Kevin Kunnert",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76458",
+      "name": "Mel Counts",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78293",
+      "name": "Roy Tarpley",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "76118",
+      "name": "Vic Bartolome",
+      "heightInches": 84.0,
+      "weightPounds": 230.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1630",
+      "name": "Mikki Moore",
+      "heightInches": 84.0,
+      "weightPounds": 225.0,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "2401",
+      "name": "Nikoloz Tskitishvili",
+      "heightInches": 84.0,
+      "weightPounds": 225.0,
+      "country": "Georgia",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "1627748",
+      "name": "Thon Maker",
+      "heightInches": 84.0,
+      "weightPounds": 221.0,
+      "country": "South Sudan",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "78207",
+      "name": "Bill Smith",
+      "heightInches": 84.0,
+      "weightPounds": 220.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78425",
+      "name": "Brett Vroman",
+      "heightInches": 84.0,
+      "weightPounds": 220.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "202700",
+      "name": "Donatas Motiejunas",
+      "heightInches": 84.0,
+      "weightPounds": 220.0,
+      "country": "Lithuania",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "1630250",
+      "name": "Marko Simonovic",
+      "heightInches": 84.0,
+      "weightPounds": 220.0,
+      "country": "Montenegro",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76611",
+      "name": "Walter Dukes",
+      "heightInches": 84.0,
+      "weightPounds": 220.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77757",
+      "name": "Jawann Oldham",
+      "heightInches": 84.0,
+      "weightPounds": 215.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1630197",
+      "name": "Aleksej Pokusevski",
+      "heightInches": 84.0,
+      "weightPounds": 210.0,
+      "country": "Serbia",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "78110",
+      "name": "Brad Sellers",
+      "heightInches": 84.0,
+      "weightPounds": 210.0,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "76084",
+      "name": "Carl Bailey",
+      "heightInches": 84.0,
+      "weightPounds": 210.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "77183",
+      "name": "Earl Jones",
+      "heightInches": 84.0,
+      "weightPounds": 210.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "101238",
+      "name": "Boniface Ndong",
+      "heightInches": 84.0,
+      "weightPounds": 205.0,
+      "country": "Senegal",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76980",
+      "name": "Steve Hayes",
+      "heightInches": 84.0,
+      "weightPounds": 205.0,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "121",
+      "name": "Patrick Ewing",
+      "heightInches": 84.0,
+      "weightPounds": 121.0,
+      "country": "Jamaica",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1627773",
+      "name": "AJ Hammons",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "200745",
+      "name": "Andrea Bargnani",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "Italy",
+      "positions": []
+    },
+    {
+      "personId": "2036",
+      "name": "Chris Mihm",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "78231",
+      "name": "Craig Spitzer",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2414",
+      "name": "Curtis Borchardt",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "2205",
+      "name": "DeSagana Diop",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "Senegal",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1055",
+      "name": "Ed Stokes",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": []
+    },
+    {
+      "personId": "2081",
+      "name": "Ernest Brown",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1922",
+      "name": "Francisco Elson",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "Netherlands",
+      "positions": []
+    },
+    {
+      "personId": "1630641",
+      "name": "Ibou Badji",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "Senegal",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "201580",
+      "name": "JaVale McGee",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "201146",
+      "name": "Jianlian Yi",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "China",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "76353",
+      "name": "Joe Barry Carroll",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1631219",
+      "name": "John Butler Jr.",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "F"
+      ]
+    },
+    {
+      "personId": "201585",
+      "name": "Kosta Koufos",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "1641857",
+      "name": "Liam Robbins",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "203512",
+      "name": "Lucas Nogueira",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "Brazil",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "200762",
+      "name": "Oleksiy Pecherov",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "Ukraine",
+      "positions": [
+        "F",
+        "C"
+      ]
+    },
+    {
+      "personId": "77716",
+      "name": "Rich Niemann",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "200797",
+      "name": "Ryan Hollins",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": []
+    },
+    {
+      "personId": "201631",
+      "name": "Steven Hill",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": []
+    },
+    {
+      "personId": "942",
+      "name": "Todd Mundt",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76192",
+      "name": "Tom Boerwinkle",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "781",
+      "name": "Will Perdue",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
+      "positions": [
+        "C"
+      ]
+    },
+    {
+      "personId": "76138",
+      "name": "William Bedford",
+      "heightInches": 84.0,
+      "weightPounds": null,
+      "country": "USA",
       "positions": [
         "C"
       ]

--- a/public/players.html
+++ b/public/players.html
@@ -317,8 +317,8 @@
                 <canvas data-chart="tallest-bubbles" aria-describedby="tallest-bubbles-caption"></canvas>
               </div>
               <figcaption id="tallest-bubbles-caption" class="viz-card__caption">
-                Bubble chart of the league's tallest players — bubble size mirrors listed weight to
-                show which giants carried the most mass.
+                Bubble chart of every 7-foot-plus player in league history — bubble size mirrors
+                listed weight to show which giants carried the most mass.
               </figcaption>
             </figure>
 


### PR DESCRIPTION
## Summary
- extend the insights snapshot builder to collect every seven-foot-and-taller player for the skyline dataset and regenerate the JSON
- update the skyline bubble visualization to accommodate the larger sample with formatted heights and dynamic axes
- refresh the players page copy to call out the all-time seven-foot club

## Testing
- python - <<'PY' ... build_players_overview()


------
https://chatgpt.com/codex/tasks/task_e_68ddd6e464b483278d7fe536d6f8fa94