### PR TITLE
Sort GOAT leaderboard by score before ranking

### DIFF
--- a/scripts/build_player_profiles.py
+++ b/scripts/build_player_profiles.py
@@ -1092,9 +1092,13 @@ def _build_recent_goat_leaderboard(
             entry["franchises"] = franchises
         if status:
             entry["status"] = status
+        entry["_sourceRank"] = entry["rank"]
         leaderboard.append(entry)
 
-    leaderboard.sort(key=lambda item: (item["rank"], -item["score"]))
+    leaderboard.sort(key=lambda item: (-item["score"], item["_sourceRank"], item["name"]))
+    for index, entry in enumerate(leaderboard, start=1):
+        entry["rank"] = index
+        entry.pop("_sourceRank", None)
     if limit > 0:
         return leaderboard[:limit]
     return leaderboard


### PR DESCRIPTION
## Summary
- sort the recent GOAT leaderboard entries by score before calculating ranks
- preserve the original rank for tie-breaking and emit sequential ranks after sorting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddda68c8648327b1b491a561ae2114