### PR TITLE
Fix games page date labels to ignore timezone offsets

### DIFF
--- a/public/scripts/games.js
+++ b/public/scripts/games.js
@@ -85,9 +85,16 @@ function formatDateLabel(value) {
   if (!isValidIsoDate(value)) {
     return value ?? '—';
   }
-  const [year, month, day] = value.split('-').map((part) => Number.parseInt(part, 10));
-  const date = new Date(Date.UTC(year, month - 1, day));
-  return date.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric' });
+  const date = parseDateOnly(value);
+  if (!date) {
+    return value;
+  }
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
 }
 
 function formatRangeLabel(range) {
@@ -112,11 +119,13 @@ function formatRangeLabel(range) {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
   const endLabel = endDate.toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    timeZone: 'UTC',
   });
   return `${startLabel} – ${endLabel}`;
 }


### PR DESCRIPTION
## Summary
- ensure game date labels are generated using UTC formatting to avoid timezone drift
- reuse the existing date parser and keep range labels aligned with the selected date

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df242007208327aa242486ba3e44d0