### PR TITLE
Fix preseason games fetching for scoreboard

### DIFF
--- a/scripts/smoke/bdl_preseason_test.mjs
+++ b/scripts/smoke/bdl_preseason_test.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import { bdl } from '../../public/assets/js/bdl.js';
+
+async function main() {
+  const params = new URLSearchParams();
+  params.append('dates[]', '2025-10-02');
+  params.set('per_page', '100');
+  params.set('postseason', 'false');
+
+  const payload = await bdl(`/v1/games?${params.toString()}`, { cache: 'no-store' });
+  const games = Array.isArray(payload?.data) ? payload.data : [];
+  console.log(`Fetched ${games.length} games for 2025-10-02`);
+
+  const matchupFound = games.some((game) => {
+    const home = game?.home_team?.full_name?.toLowerCase() ?? '';
+    const visitor = game?.visitor_team?.full_name?.toLowerCase() ?? '';
+    const hasKnicks = home.includes('knicks') || visitor.includes('knicks');
+    const hasSixers = home.includes('76ers') || visitor.includes('76ers');
+    return hasKnicks && hasSixers;
+  });
+
+  if (!matchupFound) {
+    console.error('Expected Knicks vs 76ers preseason game was not found.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('Knicks vs 76ers preseason game detected.');
+}
+
+main().catch((error) => {
+  console.error('Smoke test failed', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- fetch Ball Don't Lie data directly with an Authorization header and dev fallback key resolution
- rebuild the games query to include preseason NBA matchups, normalize statuses, and guard against non-NBA teams
- improve scoreboard empty state handling and add a preseason smoke test script for 2025-10-02

## Testing
- not run (Ball Don't Lie API key not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68df2d08fc248327b3c5d4066f78449b